### PR TITLE
link to lessc and coffee, both required to run the app

### DIFF
--- a/_docs/development.md
+++ b/_docs/development.md
@@ -19,6 +19,8 @@ You'll need the following to get started:
    to help get this working.
  * [Redis](https://redis.io) 2.8 or later installed and listening on localhost.
    By default the development server uses database 15.
+ * [lessc](http://lesscss.org), the Less compiler.
+ * [coffee](http://coffeescript.org), the Coffee script compiler.
 
 ## Create temba user for PostgreSQL
 


### PR DESCRIPTION
Great app & first run experience. I found out `lessc` & `coffee` to both be required before `python manage.py runserver` would be happy, I'm guessing because of `django-compressor`?

This PR just adds the two to the list of prerequisites. 
