### PR TITLE
Ensure caching is used for contact fetching over the API

### DIFF
--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -1604,7 +1604,10 @@ class Contacts(generics.ListAPIView):
 
         # initialize caches of all contact fields and URNs
         org = self.request.user.get_org()
-        Contact.bulk_cache_initialize(org, object_list)
+
+        # convert to list before cache initialization so that these will be the contact objects which get serialized
+        page.object_list = list(page.object_list)
+        Contact.bulk_cache_initialize(org, page.object_list)
 
         return packed
 


### PR DESCRIPTION
Problem here was that we initialize cached values as dynamic attributes for contacts in the paged queryset, but when the serializer is serializing the `object_list` field of the page object, it calls `all()` to extract the contact items... and of course that generates a new queryset with different contact objects. Converting `page.object_list` to a list avoids this.