### PR TITLE
expose flow and run expirations via api

### DIFF
--- a/temba/api/serializers.py
+++ b/temba/api/serializers.py
@@ -300,7 +300,7 @@ class LabelWriteSerializer(WriteSerializer):
 
 
 class ContactGroupReadSerializer(serializers.ModelSerializer):
-    group = serializers.Field(source='id')  # deprecated, use uuid 
+    group = serializers.Field(source='id')  # deprecated, use uuid
     uuid = serializers.Field(source='uuid')
     name = serializers.Field(source='name')
     size = serializers.SerializerMethodField('get_size')
@@ -926,6 +926,7 @@ class CampaignWriteSerializer(WriteSerializer):
 class FlowReadSerializer(serializers.ModelSerializer):
     uuid = serializers.Field(source='uuid')
     archived = serializers.Field(source='is_archived')
+    expires = serializers.Field(source='expires_after_minutes')
     labels = serializers.SerializerMethodField('get_labels')
     rulesets = serializers.SerializerMethodField('get_rulesets')
     runs = serializers.SerializerMethodField('get_runs')
@@ -957,7 +958,7 @@ class FlowReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Flow
-        fields = ('uuid', 'archived', 'name', 'labels', 'participants', 'runs', 'completed_runs', 'rulesets',
+        fields = ('uuid', 'archived', 'expires', 'name', 'labels', 'participants', 'runs', 'completed_runs', 'rulesets',
                   'created_on', 'flow')
 
 
@@ -1168,6 +1169,8 @@ class FlowRunReadSerializer(serializers.ModelSerializer):
     steps = serializers.SerializerMethodField('get_steps')
     contact = serializers.SerializerMethodField('get_contact_uuid')
     completed = serializers.SerializerMethodField('is_completed')
+    expires_on = serializers.Field(source='expires_on')
+    expired_on = serializers.Field(source='expired_on')
     flow = serializers.SerializerMethodField('get_flow')  # deprecated, use flow_uuid
 
     def get_flow(self, obj):
@@ -1203,7 +1206,8 @@ class FlowRunReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = FlowRun
-        fields = ('flow_uuid', 'flow', 'run', 'contact', 'completed', 'values', 'steps', 'created_on')
+        fields = ('flow_uuid', 'flow', 'run', 'contact', 'completed', 'values',
+                  'steps', 'created_on', 'expires_on', 'expired_on')
 
 
 class BroadcastReadSerializer(serializers.ModelSerializer):

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -304,6 +304,7 @@ class APITest(TembaTest):
                                                                           label='color')],
                                                            participants=0,
                                                            created_on=datetime_to_json_date(flow.created_on),
+                                                           expires=flow.expires_after_minutes,
                                                            archived=False))
 
         # try fetching as XML
@@ -579,6 +580,8 @@ class APITest(TembaTest):
         self.assertEqual(response.json['results'][0]['flow_uuid'], flow.uuid)
         self.assertEqual(response.json['results'][0]['contact'], self.joe.uuid)
         self.assertEqual(response.json['results'][0]['completed'], False)
+        self.assertEqual(response.json['results'][0]['expires_on'], datetime_to_json_date(run.expires_on))
+        self.assertEqual(response.json['results'][0]['expired_on'], None)
 
         # filter by flow id (deprecated)
         response = self.fetchJSON(url, "flow=%d" % flow.pk)

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -1930,11 +1930,14 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
     By making a ```GET``` request you can list all the flow runs for your organization, filtering them as needed.  Each
     run has the following attributes:
 
-    * **run** - the id of the run (long) (filterable: ```run``` repeatable)
+    * **uuid** - the UUID of the run (string) (filterable: ```uuid``` repeatable)
     * **flow_uuid** - the UUID of the flow (string) (filterable: ```flow_uuid``` repeatable)
     * **contact** - the UUID of the contact this run applies to (string) filterable: ```contact``` repeatable)
     * **group_uuids** - the UUIDs of any groups this contact is part of (string array, optional) (filterable: ```group_uuids``` repeatable)
     * **created_on** - the datetime when this run was started (datetime) (filterable: ```before``` and ```after```)
+    * **completed** - boolean indicating whether this run has completed the flow (boolean)
+    * **expires_on** - the datetime when this run will expire (datetime) (filterable: ```before``` and ```after```)
+    * **expired_on** - the datetime when this run expired or null if it has not yet expired (datetime or null)
     * **steps** - steps visited by the contact on the flow (array of dictionaries)
     * **values** - values collected during the flow run (array of dictionaries)
 
@@ -1954,6 +1957,8 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
                 "flow_uuid": "f5901b62-ba76-4003-9c62-72fdacc1b7b7",
                 "contact": "09d23a05-47fe-11e4-bfe9-b8f6b119e9ab",
                 "created_on": "2013-03-02T17:28:12",
+                "expires_on": "2015-07-08T01:10:43.111Z",
+                "expired_on": null
                 "steps": [
                     {
                         "node": "22bd934e-953b-460d-aaf5-42a84ec8f8af",
@@ -2575,7 +2580,11 @@ class FlowEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
       * **archived** - whether this flow is archived (boolean) (filterable: ```archived```)
       * **labels** - the labels for this flow (string array) (filterable: ```label``` repeatable)
       * **created_on** - the datetime when this flow was created (datetime) (filterable: ```before``` and ```after```)
-      * **rulesets** - the rulesets on this flow, including their node UUID and label
+      * **expires** - the time (in minutes) when this flow's inactive contacts will exipire (integer)
+      * **participants** - the number of contacts who have participated in this flow (integer)
+      * **runs** - the total number of runs for this flow (integer)
+      * **completed_runs** - the number of completed runs for this flow (integer)
+      * **rulesets** - the rulesets on this flow, including their node UUID, response type, and label
 
     Example:
 
@@ -2591,17 +2600,23 @@ class FlowEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
             {
                 "uuid": "cf85cb74-a4e4-455b-9544-99e5d9125cfd",
                 "archived": false,
+                "expires": 720,
                 "name": "Thrift Shop Status",
                 "labels": [ "Polls" ],
+                "participants": 1,
+                "runs": 3,
+                "completed_runs": 0,
                 "rulesets": [
                    {
                     "id": 17122,
                     "node": "fe594710-68fc-4cb5-bd85-c0c77e4caa45",
+                    "response_type": "N",
                     "label": "Age"
                    },
                    {
                     "id": 17128,
                     "node": "fe594710-68fc-4cb5-bd85-c0c77e4caa45",
+                    "response_type": "C",
                     "label": "Gender"
                    }
                 ]

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -1936,7 +1936,7 @@ class FlowRunEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
     * **group_uuids** - the UUIDs of any groups this contact is part of (string array, optional) (filterable: ```group_uuids``` repeatable)
     * **created_on** - the datetime when this run was started (datetime) (filterable: ```before``` and ```after```)
     * **completed** - boolean indicating whether this run has completed the flow (boolean)
-    * **expires_on** - the datetime when this run will expire (datetime) (filterable: ```before``` and ```after```)
+    * **expires_on** - the datetime when this run will expire (datetime)
     * **expired_on** - the datetime when this run expired or null if it has not yet expired (datetime or null)
     * **steps** - steps visited by the contact on the flow (array of dictionaries)
     * **values** - values collected during the flow run (array of dictionaries)

--- a/temba/api/views.py
+++ b/temba/api/views.py
@@ -2580,7 +2580,7 @@ class FlowEndpoint(ListAPIMixin, CreateAPIMixin, BaseAPIView):
       * **archived** - whether this flow is archived (boolean) (filterable: ```archived```)
       * **labels** - the labels for this flow (string array) (filterable: ```label``` repeatable)
       * **created_on** - the datetime when this flow was created (datetime) (filterable: ```before``` and ```after```)
-      * **expires** - the time (in minutes) when this flow's inactive contacts will exipire (integer)
+      * **expires** - the time (in minutes) when this flow's inactive contacts will expire (integer)
       * **participants** - the number of contacts who have participated in this flow (integer)
       * **runs** - the total number of runs for this flow (integer)
       * **completed_runs** - the number of completed runs for this flow (integer)


### PR DESCRIPTION
adds `expires` (in minutes) to the Flow read API endpoint (https://rapidpro.io/api/v1/flows)

adds `expires_on` and `expired_on` to the FlowRun read API endpoint (https://rapidpro.io/api/v1/runs)

see also https://github.com/rapidpro/rapidpro/issues/179