### PR TITLE
Show the create login form on page load if there are form errors. Fixes #193.

### DIFF
--- a/templates/orgs/org_create_login.haml
+++ b/templates/orgs/org_create_login.haml
@@ -101,6 +101,9 @@
         $(".create_login-part").removeClass("expanded");
       }
     });
+  -if form.errors
+    :javascript
+      $('.create_login-part').click();
 
 
 -block extra-style


### PR DESCRIPTION
The javascript on this page was always hiding the create_login form,
even when errors were rendered. Now we show the create_login form if there are errors.