### PR TITLE
fix running karma tests with Chrome browser and debugging

### DIFF
--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -924,9 +924,10 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
 
         # update our auto completion options
         $http.get('/flow/completion/?flow=' + flowId).success (data) ->
-          Flow.completions = data.message_completions
-          Flow.function_completions = data.function_completions
-          Flow.variables_and_functions = [Flow.completions...,Flow.function_completions...]
+          if data.function_completions and data.message_completions
+            Flow.completions = data.message_completions
+            Flow.function_completions = data.function_completions
+            Flow.variables_and_functions = [Flow.completions...,Flow.function_completions...]
 
         $http.get('/contactfield/json/').success (fields) ->
           Flow.contactFields = fields


### PR DESCRIPTION
Flow service "flow completion" fetch should not iterate through null variables.
It resulted in "Array.prototype.slice called on null or undefined" with Chrome launcher thus some tests failed.
This fix will ensure both PhantomJS and Chrome browsers to have same results.