### PR TITLE
Save incoming Twilio MMS URLs as messages

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -148,7 +148,22 @@ class TwilioHandler(View):
                 # raise an exception that things weren't properly signed
                 raise ValidationError("Invalid request signature")
 
-            Msg.create_incoming(channel, (TEL_SCHEME, request.POST['From']), request.POST['Body'])
+            body = request.POST['Body']
+
+            # process any attached media, we will append these to our body
+            media = list()
+            for i in range(int(request.POST.get('NumMedia', 0))):
+                media.append(request.POST['MediaUrl%d' % i])
+
+            if media:
+                # add a newline if there is a text message as well
+                if body:
+                    body += '\n'
+
+                # Add each media URL, with newlines separating them
+                body += '\n'.join(media)
+
+            Msg.create_incoming(channel, (TEL_SCHEME, request.POST['From']), body)
 
             return HttpResponse("", status=201)
 


### PR DESCRIPTION
Right now when an MMS message is sent to a Twilio number we manage, we just create an empty incoming message. This instead puts the URLs of the media that was sent in the message.

Not amazing, but satisfies the "better than before" rule and is an easy win with one our customers.