### PR TITLE
Vagrant developer environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,8 @@ docs/_build/
 # PyBuilder
 target/
 textit
+
+# Vagrant/Ansible
+.vagrant/
+ansible/vendor/
+ansible/site.retry

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,73 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/home/vagrant/rapidpro"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "2048"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  config.ssh.forward_agent = true
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "ansible/site.yml"
+    ansible.verbose = 'v'
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ansible/vendor/roles

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = vendor/roles

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,4 @@
+---
+
+- name: supervisor
+  src: Stouts.supervisor

--- a/ansible/roles/rapidpro/defaults/main.yml
+++ b/ansible/roles/rapidpro/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+project_user: vagrant
+project_path: /home/{{ project_user }}/rapidpro
+pip_requirements_file: pip-freeze.txt

--- a/ansible/roles/rapidpro/meta/main.yml
+++ b/ansible/roles/rapidpro/meta/main.yml
@@ -1,0 +1,12 @@
+---
+
+galaxy_info:
+  author: javaguirre
+  description: Rapidpro role
+  min_ansible_version: 2.0
+  platforms:
+    - name: Ubuntu
+  versions:
+    - all
+  categories:
+    - web

--- a/ansible/roles/rapidpro/tasks/main.yml
+++ b/ansible/roles/rapidpro/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+
+- name: OS | Install dependencies
+  become: yes
+  apt: name={{ item }} update_cache=yes
+  with_items:
+    - git
+    - redis-server
+    - postgresql
+    - postgresql-contrib
+    - postgis
+    - postgresql-9.3-postgis-2.1
+    - libpq-dev
+    - python-dev
+    - python-virtualenv
+    - python-psycopg2
+    - npm
+    # Pillow
+    - libjpeg8-dev
+    - zlib1g-dev
+    # Other dependencies for python packages
+    - lib32ncurses5-dev
+
+- include: postgres.yml
+
+- include: python.yml
+
+- include: npm.yml

--- a/ansible/roles/rapidpro/tasks/npm.yml
+++ b/ansible/roles/rapidpro/tasks/npm.yml
@@ -1,0 +1,15 @@
+---
+
+- name: NPM | Node symlink
+  become: yes
+  file: |
+    src=/usr/bin/nodejs
+    dest=/usr/bin/node
+    state=link
+
+- name: NPM | Ensure nodejs packages are present
+  become: yes
+  npm: name={{ item }} global=yes
+  with_items:
+    - less
+    - coffee-script

--- a/ansible/roles/rapidpro/tasks/postgres.yml
+++ b/ansible/roles/rapidpro/tasks/postgres.yml
@@ -1,0 +1,31 @@
+---
+
+- name: Postgresql | Create db
+  become: yes
+  become_user: postgres
+  postgresql_db: |
+    name=temba
+
+- name: Postgresql | Create db test
+  become: yes
+  become_user: postgres
+  postgresql_db: |
+    name=test
+
+- name: Postgresql | Create User
+  become: yes
+  become_user: postgres
+  postgresql_user: |
+    db=temba
+    name=temba
+    password=temba
+    role_attr_flags=SUPERUSER
+
+- name: Postgresql | Add extensions
+  become: yes
+  become_user: postgres
+  postgresql_ext: name={{ item }} db=temba
+  with_items:
+    - postgis
+    - postgis_topology
+    - hstore

--- a/ansible/roles/rapidpro/tasks/python.yml
+++ b/ansible/roles/rapidpro/tasks/python.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Pip | Install via PIP and virtualenv
+  become: no
+  pip: |
+    chdir={{ project_path }}
+    virtualenv={{ project_path }}/.venv
+    requirements={{ pip_requirements_file }}
+
+- name: Django | Settings symlink
+  file: |
+    state=link
+    src={{ project_path }}/temba/settings.py.dev
+    dest={{ project_path }}/temba/settings.py
+
+- name: Django | Syncdb
+  become: no
+  command: |
+    {{ project_path }}/.venv/bin/python manage.py syncdb
+    chdir={{ project_path }}

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Rapidpro
+  hosts: all
+  remote_user: vagrant
+  become: no
+
+  vars_files:
+    - vars.yml
+
+  roles:
+    - rapidpro
+    - { role: supervisor, become: yes }

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -1,0 +1,13 @@
+---
+
+supervisor_enabled: yes
+
+supervisor_tasks:
+  - name: rapidpro_celery
+    directory: "{{ project_path }}"
+    command: "{{ project_path }}/.venv/bin/python manage.py celery worker --beat -l debug -Q flows,msgs,handler,celery -c 2"
+    user: "{{ ansible_ssh_user }}"
+    stdout_logfile: /var/log/supervisor/rapidpro.log
+    stderr_logfile: /var/log/supervisor/rapidpro.error.log
+    autostart: true
+    autorestart: true


### PR DESCRIPTION
Vagrant developer environment. #145 

Only two dependencies, Vagrant and Ansible.

I use Ansible to configure and manage the developer environment because the configuration is cleaner and often self-explanatory. :-)

The developer environment would work as follows.

```bash
cd rapidpro/ansible
ansible-galaxy install -r requirements.yml
cd ..
vagrant up --provision
```

When It finishes:

```bash
vagrant ssh
cd rapidpro
source .venv/bin/activate
python manage.py runserver 0.0.0.0:8000
```

Then if you go in your browser to `http://localhost:8000` you're good to go!

I'll update the development gh-page configuration if you're ok with this PR.