### PR TITLE
fix migration dependencies/ordering

### DIFF
--- a/temba/flows/migrations/0060_flowrun_timeout_on.py
+++ b/temba/flows/migrations/0060_flowrun_timeout_on.py
@@ -11,7 +11,7 @@ ON flows_flowrun (timeout_on) WHERE is_active = TRUE AND timeout_on IS NOT NULL;
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('flows', '0060_exit_flowruns'),
+        ('flows', '0059_auto_20160721_1654'),
     ]
 
     operations = [

--- a/temba/flows/migrations/0061_exit_flowruns.py
+++ b/temba/flows/migrations/0061_exit_flowruns.py
@@ -55,7 +55,7 @@ def migration_exit_active_flowruns(apps, schema):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('flows', '0059_auto_20160721_1654'),
+        ('flows', '0060_flowrun_timeout_on'),
         ('contacts', '0041_indexes_update'),
     ]
 

--- a/temba/flows/migrations/0062_flowlabel_uuid.py
+++ b/temba/flows/migrations/0062_flowlabel_uuid.py
@@ -15,7 +15,7 @@ def populate_flowlabel_uuid(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('flows', '0061_flowrun_timeout_on'),
+        ('flows', '0061_exit_flowruns'),
     ]
 
     operations = [


### PR DESCRIPTION
Running migration flows.60 throws this:
"django.db.utils.ProgrammingError: column flows_flowrun.timeout_on does not exist"
That column was only added in 61, so I fixed the order of dependencies