### PR TITLE
add missing temba template tag library to templates/includes/nav.haml

### DIFF
--- a/templates/includes/nav.haml
+++ b/templates/includes/nav.haml
@@ -1,4 +1,4 @@
--load smartmin i18n
+-load smartmin i18n temba
 
 %ul#top-menu
 


### PR DESCRIPTION
Fixes issue #358 