### PR TITLE
Don't include REST framework's default.js on customized API pages

### DIFF
--- a/templates/api/v1/api_root.html
+++ b/templates/api/v1/api_root.html
@@ -78,7 +78,6 @@
 {% block extra-script %}
     {{ block.super }}
     <script src="{{ STATIC_URL }}rest_framework/js/prettify-min.js"></script>
-    <script src="{% static "rest_framework/js/default.js" %}"></script>
 
     <script>
         $(function(){

--- a/templates/api/v2/api_root.html
+++ b/templates/api/v2/api_root.html
@@ -78,7 +78,6 @@
 {% block extra-script %}
     {{ block.super }}
     <script src="{{ STATIC_URL }}rest_framework/js/prettify-min.js"></script>
-    <script src="{% static "rest_framework/js/default.js" %}"></script>
 
     <script>
         $(function(){


### PR DESCRIPTION
It assumes you're using the default doc pages which have tabs so it throws an error and breaks other Javascript on the page leading to things like the dropdown menu not working https://github.com/rapidpro/rapidpro/issues/409