### PR TITLE
Fix Django upgrade breaking Ansible provisioning

### DIFF
--- a/ansible/roles/rapidpro/tasks/python.yml
+++ b/ansible/roles/rapidpro/tasks/python.yml
@@ -16,5 +16,5 @@
 - name: Django | Syncdb
   become: no
   command: |
-    {{ project_path }}/.venv/bin/python manage.py syncdb
+    {{ project_path }}/.venv/bin/python manage.py migrate
     chdir={{ project_path }}


### PR DESCRIPTION
Simple fix changes Ansible script to run `python manage.py migrate` rather than `python manage.py syncdb`.

Associated documentation upgrade: #438 