### PR TITLE
django asset compression failing when compressing offline

### DIFF
--- a/temba/utils/templatetags/temba.py
+++ b/temba/utils/templatetags/temba.py
@@ -83,8 +83,13 @@ class LessBlockNode(template.Node):
 
     def render(self, context):
         output = self.nodelist.render(context)
+
+        # When compressing offline the brand isn't set by the middleware
+        # and so we have to fallback to the default brand
+        brand = context.get('brand', settings.BRANDING[settings.DEFAULT_BRAND])
+
         includes = '@import (reference) "variables.less";\n'
-        includes += '@import (reference, optional) "../brands/%s/less/variables.less";\n' % context['brand']['slug']
+        includes += '@import (reference, optional) "../brands/%s/less/variables.less";\n' % brand['slug']
         includes += '@import (reference) "mixins.less";\n'
         style_output = '<style type="text/less" media="all">\n%s\n%s</style>' % (includes, output)
         return style_output


### PR DESCRIPTION
1e8ae2fa984287f0e712e58dbd889c9bd81d8e00 introduces a change which assumes `context` has a `brand` key.

```bash
$ ./manage.py compress --extension=".haml" --force
```

Results in the following error:
```
Compressing... Traceback (most recent call last):
  File "./manage.py", line 9, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
    utility.execute()
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/django/core/management/__init__.py", line 359, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/django/core/management/base.py", line 294, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 291, in handle
    self.compress(sys.stdout, **options)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 237, in compress
    rendered = parser.render_nodelist(template, context, node)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/compressor/offline/django.py", line 114, in render_nodelist
    return node.nodelist.render(context)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/django/template/base.py", line 994, in render
    bit = node.render_annotated(context)
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/django/template/base.py", line 961, in render_annotated
    return self.render(context)
  File "/Users/sdehaan/Documents/Repositories/rapidpro/temba/utils/templatetags/temba.py", line 87, in render
    includes += '@import (reference, optional) "../brands/%s/less/variables.less";\n' % context['brand']['slug']
  File "/Users/sdehaan/.virtualenvs/rapidpro/lib/python2.7/site-packages/django/template/context.py", line 75, in __getitem__
    raise KeyError(key)
KeyError: 'brand'
```

This is causing build failures on the rapidpro/rapidpro-docker images.

It looks like the branding is added to the request by the `BrandingMiddleware` and to the template context by the branding context processor. I suspect the problem here is that these aren't called when compress is called offline to generate all the assets.

Are you lazy compressing assets or generating them offline? If they're generated lazily as part of the first request then I'm happy to update the docker builds to reflect that. 