### PR TITLE
Enable searching in groups and blocked/stopped contacts

### DIFF
--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -15,7 +15,7 @@
 
 -block above-bar
   -block top-form
-    %form{'method':'get', 'action': "{% url 'contacts.contact_list' %}" }
+    %form{method:'get'}
       %input.input-medium.search-query{'type':'text', 'placeholder':'{% trans "Search" %}', 'name':"search", 'value':"{{search}}"}
 
 -block content


### PR DESCRIPTION
Currently the search box is shown at the top of any contact listing page, but using it always takes the user back to the 'All Contacts' list page and does a search on that group.