### PR TITLE
Upgrade to Alpine linux friendly version of python-magic

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -89,7 +89,7 @@ PyJWT==1.4.2
 pyparsing==2.1.10
 python-dateutil==2.2
 python-gcm==0.1.5
-python-magic==0.4.12
+python-magic==0.4.13
 python-telegram-bot==3.3b1
 pytz==2016.4
 PyYAML==3.11


### PR DESCRIPTION
pip-freeze.txt wants 4.0.12 which breaks on Alpine Linux, 4.0.13 fixes that. 
Alpine is used for the rapidpro docker images and so the docker builds are broken because of the 4.0.12 dependency.