### PR TITLE
Show Junebug config for USSD channel and use Radio buttons for selecting channel type.

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1733,6 +1733,7 @@ class ChannelCRUDL(SmartCRUDL):
         class JunebugForm(forms.Form):
             channel_type = forms.ChoiceField(choices=((Channel.TYPE_JUNEBUG, 'SMS'),
                                                       (Channel.TYPE_JUNEBUG_USSD, 'USSD')),
+                                             widget=forms.RadioSelect,
                                              label=_('Channel Type'),
                                              help_text=_('The type of channel you are wanting to connect.'))
             country = forms.ChoiceField(choices=ALL_COUNTRIES, label=_("Country"),

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -855,28 +855,6 @@ class UpdateChannelForm(forms.ModelForm):
         helps = {'address': _('The number or address of this channel')}
 
 
-class UpdateJunebugForm(UpdateChannelForm):
-    send_url = forms.URLField(label=_("URL"),
-                              help_text=_("The URL for the Junebug channel. ex: https://junebug.praekelt.org/jb/channels/3853bb51-d38a-4bca-b332-8a57c00f2a48/messages.json"))
-    username = forms.CharField(label=_("Username"),
-                               help_text=_("The username to be used to authenticate to Junebug"),
-                               required=False)
-    password = forms.CharField(label=_("Password"),
-                               help_text=_("The password to be used to authenticate to Junebug"),
-                               required=False)
-
-    def add_config_fields(self):
-        config = json.loads(self.object.config)
-        self.fields['send_url'].initial = config.get('send_url')
-        self.fields['username'].initial = config.get('username')
-        self.fields['password'].initial = config.get('password')
-
-    class Meta(UpdateChannelForm.Meta):
-        fields = ('name', 'alert_email', 'address', 'country', 'send_url', 'username', 'password')
-        readonly = []
-        config_fields = ('username', 'password', 'send_url')
-
-
 class UpdateNexmoForm(UpdateChannelForm):
     class Meta(UpdateChannelForm.Meta):
         readonly = ('country',)
@@ -1219,8 +1197,6 @@ class ChannelCRUDL(SmartCRUDL):
                 return UpdateAndroidForm
             elif channel_type == Channel.TYPE_NEXMO:
                 return UpdateNexmoForm
-            elif channel_type in (Channel.TYPE_JUNEBUG, Channel.TYPE_JUNEBUG_USSD):
-                return UpdateJunebugForm
             elif scheme == TWITTER_SCHEME:
                 return UpdateTwitterForm
             else:
@@ -1235,7 +1211,7 @@ class ChannelCRUDL(SmartCRUDL):
             if obj.config:
                 config = json.loads(obj.config)
                 for field in self.form.Meta.config_fields:  # pragma: needs cover
-                    config[field] = self.form.cleaned_data[field]
+                    config[field] = bool(self.form.cleaned_data[field])
                 obj.config = json.dumps(config)
             return obj
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -855,6 +855,28 @@ class UpdateChannelForm(forms.ModelForm):
         helps = {'address': _('The number or address of this channel')}
 
 
+class UpdateJunebugForm(UpdateChannelForm):
+    send_url = forms.URLField(label=_("URL"),
+                              help_text=_("The URL for the Junebug channel. ex: https://junebug.praekelt.org/jb/channels/3853bb51-d38a-4bca-b332-8a57c00f2a48/messages.json"))
+    username = forms.CharField(label=_("Username"),
+                               help_text=_("The username to be used to authenticate to Junebug"),
+                               required=False)
+    password = forms.CharField(label=_("Password"),
+                               help_text=_("The password to be used to authenticate to Junebug"),
+                               required=False)
+
+    def add_config_fields(self):
+        config = json.loads(self.object.config)
+        self.fields['send_url'].initial = config.get('send_url')
+        self.fields['username'].initial = config.get('username')
+        self.fields['password'].initial = config.get('password')
+
+    class Meta(UpdateChannelForm.Meta):
+        fields = ('name', 'alert_email', 'address', 'country', 'send_url', 'username', 'password')
+        readonly = []
+        config_fields = ('username', 'password', 'send_url')
+
+
 class UpdateNexmoForm(UpdateChannelForm):
     class Meta(UpdateChannelForm.Meta):
         readonly = ('country',)
@@ -1197,6 +1219,8 @@ class ChannelCRUDL(SmartCRUDL):
                 return UpdateAndroidForm
             elif channel_type == Channel.TYPE_NEXMO:
                 return UpdateNexmoForm
+            elif channel_type in (Channel.TYPE_JUNEBUG, Channel.TYPE_JUNEBUG_USSD):
+                return UpdateJunebugForm
             elif scheme == TWITTER_SCHEME:
                 return UpdateTwitterForm
             else:
@@ -1211,7 +1235,7 @@ class ChannelCRUDL(SmartCRUDL):
             if obj.config:
                 config = json.loads(obj.config)
                 for field in self.form.Meta.config_fields:  # pragma: needs cover
-                    config[field] = bool(self.form.cleaned_data[field])
+                    config[field] = self.form.cleaned_data[field]
                 obj.config = json.dumps(config)
             return obj
 

--- a/templates/channels/channel_configuration.haml
+++ b/templates/channels/channel_configuration.haml
@@ -648,7 +648,7 @@
     %code
       https://{{ domain }}{% url 'handlers.jasmin_handler' 'receive' object.uuid %}
 
-  -elif object.channel_type == 'JN'
+  -elif object.channel_type == 'JN' or object.channel_type == 'JNU'
     %h4
       -blocktrans
         As a last step you'll need to configure Junebug to call the following URL for MO (incoming) messages.


### PR DESCRIPTION
This makes use of an `add_config_fields` hook which doesn't seem to be used anywhere else.
Also it addresses (what seems to be) a bug in the `pre_save()` function where every field value was turned into a bool. 