### PR TITLE
Create a first message for when starting a USSD Flow

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8703,9 +8703,10 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
         self.assertEqual(response.json()['status'], JunebugHandler.ACK)
 
         # load our message
-        msg = Msg.objects.get()
-        self.assertEquals(data["from"], msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(msg.session.status, USSDSession.TRIGGERED)
+        inbound_msg, outbound_msg = Msg.objects.all().order_by('pk')
+        self.assertEquals(data["from"], outbound_msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEquals(outbound_msg.response_to, inbound_msg)
+        self.assertEquals(outbound_msg.session.status, USSDSession.TRIGGERED)
 
     def test_receive_ussd_no_sesion(self):
         from temba.channels.handlers import JunebugHandler

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1545,7 +1545,6 @@ class Flow(TembaModel):
                     for msg in step_msgs:
                         msgs.append(msg)
 
-            # no start msgs in ussd flows but we want the variable there
             run.start_msgs = [start_msg]
 
             runs.append(run)

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1539,16 +1539,14 @@ class Flow(TembaModel):
 
                 step = self.add_step(run, entry_rule, is_start=True, arrived_on=timezone.now())
                 if entry_rule.is_ussd():
-                    # create an empty placeholder message
-                    msg = Msg(org=self.org, contact_id=contact_id, text='', id=0)
-                    handled, step_msgs = Flow.handle_destination(entry_rule, step, run, msg, trigger_send=False)
+                    handled, step_msgs = Flow.handle_destination(entry_rule, step, run, start_msg, trigger_send=False)
 
                     # add these messages as ones that are ready to send
                     for msg in step_msgs:
                         msgs.append(msg)
 
             # no start msgs in ussd flows but we want the variable there
-            run.start_msgs = []
+            run.start_msgs = [start_msg]
 
             runs.append(run)
 

--- a/temba/ussd/models.py
+++ b/temba/ussd/models.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import six
 
 from django.db import models
+from django.utils import timezone
 from temba.channels.models import ChannelSession
 from temba.contacts.models import Contact, URN
 from temba.triggers.models import Trigger
@@ -33,9 +34,10 @@ class USSDSession(ChannelSession):
 
     def start_session_async(self, flow, urn, content, date, message_id):
         from temba.msgs.models import Msg, USSD
-        message = Msg.create_incoming(
-            channel=self.channel, urn=urn, text=content or '', date=date, session=self,
-            msg_type=USSD, external_id=message_id)
+        message = Msg.objects.create(
+            channel=self.channel, contact=self.contact, contact_urn=self.contact_urn,
+            sent_on=date, session=self, msg_type=USSD, external_id=message_id,
+            created_on=timezone.now(), modified_on=timezone.now(), org=self.channel.org)
         flow.start([], [self.contact], start_msg=message, restart_participants=True, session=self)
 
     def handle_session_async(self, urn, content, date, message_id):


### PR DESCRIPTION
When starting a USSD session, the first message isn't saved and used in the Flow as the `start_msg`. This means that the first reply the Flow sends back has no `response_to` set. When USSD channels (Like Vumi and Junebug) try to send a reply they often need to refer back to the `external_id` of the `response_to` object to allow the integrations to link back to an actively running USSD session.

This PR should address that.