### PR TITLE
Plivo release calls requests.delete, not requests.post. 

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -7398,7 +7398,7 @@ class PlivoTest(TembaTest):
         self.joe = self.create_contact("Joe", "+250788383383")
 
     def test_release(self):
-        with patch('requests.post') as mock:
+        with patch('requests.delete') as mock:
             mock.return_value = MockResponse(200, "Success", method='POST')
             self.channel.release()
             self.channel.refresh_from_db()


### PR DESCRIPTION
The test case is is hitting api.plivo.com. Came across this while running tests offline and spotted the TCP error. 