### PR TITLE
Do not specify to & from when using reply_to in Junebug channel

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1416,7 +1416,6 @@ class Channel(TembaModel):
 
         # build our payload
         payload = dict()
-        payload['from'] = channel.address
         payload['event_url'] = event_url
         payload['content'] = text
 
@@ -1428,6 +1427,7 @@ class Channel(TembaModel):
                 'continue_session': session_status not in ChannelSession.DONE,
             }
         else:
+            payload['from'] = channel.address
             payload['to'] = msg.urn_path
 
         log_url = channel.config[Channel.CONFIG_SEND_URL]

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8765,6 +8765,8 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
                 [call] = mock.call_args_list
                 (args, kwargs) = call
                 payload = kwargs['json']
+                self.assertFalse('from' in payload.keys())
+                self.assertFalse('to' in payload.keys())
                 self.assertEquals(payload['reply_to'], 'vumi-message-id')
                 self.assertEquals(payload['channel_data'], {
                     'continue_session': True
@@ -8805,6 +8807,8 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
                 [call] = mock.call_args_list
                 (args, kwargs) = call
                 payload = kwargs['json']
+                self.assertFalse('from' in payload.keys())
+                self.assertFalse('to' in payload.keys())
                 self.assertEquals(payload['reply_to'], 'vumi-message-id')
                 self.assertEquals(payload['channel_data'], {
                     'continue_session': False


### PR DESCRIPTION
Junebug doesn't want the `from` nor `to` values specified when a message id is given as a `reply_to`