### PR TITLE
Fix USSD event handling for Junebug

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -1937,15 +1937,13 @@ class JunebugHandler(BaseChannelHandler):
         data = json.load(request)
         is_ussd = self.is_ussd_message(data)
         channel_data = data.get('channel_data', {})
-        channel_type = (Channel.TYPE_JUNEBUG_USSD
-                        if is_ussd
-                        else Channel.TYPE_JUNEBUG)
+        channel_types = (Channel.TYPE_JUNEBUG_USSD, Channel.TYPE_JUNEBUG)
 
         # look up the channel
         channel = Channel.objects.filter(
             uuid=request_uuid,
             is_active=True,
-            channel_type=channel_type).exclude(org=None).first()
+            channel_type__in=channel_types).exclude(org=None).first()
 
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8689,6 +8689,30 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
         super(JunebugUSSDTest, self).tearDown()
         settings.SEND_MESSAGES = False
 
+    def test_status(self):
+        joe = self.create_contact("Joe Biden", "+254788383383")
+        msg = joe.send("Hey Joe, it's Obama, pick up!", self.admin, msg_type=USSD)
+
+        data = self.mk_event()
+        msg.external_id = data['message_id']
+        msg.save(update_fields=('external_id',))
+
+        def assertStatus(sms, event_type, assert_status):
+            data['event_type'] = event_type
+            response = self.client.post(
+                reverse('handlers.junebug_handler',
+                        args=['event', self.channel.uuid]),
+                data=json.dumps(data),
+                content_type='application/json')
+            self.assertEquals(200, response.status_code)
+            sms = Msg.objects.get(pk=sms.id)
+            self.assertEquals(assert_status, sms.status)
+
+        assertStatus(msg, 'submitted', SENT)
+        assertStatus(msg, 'delivery_succeeded', DELIVERED)
+        assertStatus(msg, 'delivery_failed', FAILED)
+        assertStatus(msg, 'rejected', FAILED)
+
     def test_receive_ussd(self):
         from temba.ussd.models import USSDSession
         from temba.channels.handlers import JunebugHandler


### PR DESCRIPTION
An event in isolation does not give us enough to determine whether or not the original message was a USSD message or not.

This change makes sure the channel is one of the two known Junebug channel types and then handles the event.