### PR TITLE
Sometimes the `id` is not available from Junebug, log when that happens

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1455,8 +1455,15 @@ class Channel(TembaModel):
                                 event=event, start=start)
 
         data = response.json()
-        message_id = data['result']['id']
-        Channel.success(channel, msg, WIRED, start, event=event, external_id=message_id)
+        try:
+            message_id = data['result']['id']
+            Channel.success(channel, msg, WIRED, start, event=event, external_id=message_id)
+        except KeyError, e:
+            raise SendException("Unable to read external message_id: %r" % (e,),
+                                event=HttpEvent('POST', log_url,
+                                                request_body=json.dumps(json.dumps(payload)),
+                                                response_body=json.dumps(data)),
+                                start=start)
 
     @classmethod
     def send_facebook_message(cls, channel, msg, text):

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1456,7 +1456,7 @@ class Channel(TembaModel):
 
         data = response.json()
         try:
-            message_id = data['result']['id']
+            message_id = data['result']['message_id']
             Channel.success(channel, msg, WIRED, start, event=event, external_id=message_id)
         except KeyError, e:
             raise SendException("Unable to read external message_id: %r" % (e,),

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8584,7 +8584,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(200, json.dumps({
                 'result': {
-                    'id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
+                    'message_id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
                 }
             }))
 
@@ -8611,7 +8611,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(200, json.dumps({
                 'result': {
-                    'id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
+                    'message_id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
                 }
             }))
 
@@ -8740,7 +8740,7 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
             with patch('requests.post') as mock:
                 mock.return_value = MockResponse(200, json.dumps({
                     'result': {
-                        'id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
+                        'message_id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
                     }
                 }))
 
@@ -8797,7 +8797,7 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
             with patch('requests.post') as mock:
                 mock.return_value = MockResponse(200, json.dumps({
                     'result': {
-                        'id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
+                        'message_id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
                     }
                 }))
 


### PR DESCRIPTION
Currently it just crashes and logs an `id` in the channel log which is not all that useful.
![channel_event](https://cloud.githubusercontent.com/assets/1065/24498717/ab0bfef8-153f-11e7-9ff9-1bb88cc26ad9.png)
