### PR TITLE
Management command to download OSM extracts for relation ids

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -100,7 +100,7 @@ redis==2.10.1
 regex==2014.6.28
 requests==2.9.1
 requests-oauthlib==0.4.0
-responses-0.5.1
+responses==0.5.1
 rsa==3.4.2
 selenium==2.31.0
 simplejson==3.4.1

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -100,6 +100,7 @@ redis==2.10.1
 regex==2014.6.28
 requests==2.9.1
 requests-oauthlib==0.4.0
+responses-0.5.1
 rsa==3.4.2
 selenium==2.31.0
 simplejson==3.4.1

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -62,3 +62,4 @@ openpyxl
 django-excel
 pyexcel-xls
 pyexcel-xlsx
+responses

--- a/temba/locations/management/commands/download_geojson.py
+++ b/temba/locations/management/commands/download_geojson.py
@@ -1,0 +1,62 @@
+import os
+import requests
+import re
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Download geojson files for OSM relation ids.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('relation_ids', nargs='+')
+        parser.add_argument('--oauth-token',
+                            dest='oauth_token',
+                            default=None,
+                            help='The OAuth token to use when authenticating '
+                                 'to GitHub. Unauthenticated requests are '
+                                 'rate limited to 60 per hour. Defaults to '
+                                 'None')
+        parser.add_argument('--repo',
+                            dest='repo',
+                            default='nyaruka/posm-extracts',
+                            help="The GitHub posm-extracts repo to use. "
+                                 "Defaults to nyaruka/posm-extracts")
+        parser.add_argument('--dir',
+                            dest='dir',
+                            default='geojson',
+                            help='The directory to write the geojson files '
+                                 'to. Defaults to `geojson`')
+
+    def handle(self, *args, **options):
+
+        destination_dir = options['dir']
+        relation_ids = options['relation_ids']
+        repo = options['repo']
+
+        data = requests.get(
+            "https://api.github.com/repos/%s/git/trees/master" % (
+                repo,)).json()
+        [geojson] = filter(lambda obj: obj['path'] == "geojson", data['tree'])
+        geojson_sha = geojson['sha']
+
+        files = requests.get(
+            'https://api.github.com/repos/%s/git/trees/%s' % (
+                repo, geojson_sha,)).json()
+
+        if not os.path.exists(destination_dir):
+            os.makedirs(destination_dir)
+
+        for relation_id in relation_ids:
+            relation_files = filter(
+                lambda obj: re.match(r'R%s.*_simplified.json' % (relation_id,),
+                                     obj['path']), files['tree'])
+            for relation_file in relation_files:
+                destination = os.path.join(
+                    destination_dir, relation_file['path'])
+                with open(destination, 'w') as fp:
+                    response = requests.get(
+                        'https://raw.githubusercontent.com/%s/'
+                        'master/geojson/%s' % (
+                            repo, relation_file['path']))
+                    fp.write(response.content)

--- a/temba/locations/management/commands/download_geojson.py
+++ b/temba/locations/management/commands/download_geojson.py
@@ -1,6 +1,8 @@
+from __future__ import print_function, unicode_literals
+
 import os
 import requests
-import re
+import regex
 
 from django.core.management.base import BaseCommand
 
@@ -10,23 +12,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('relation_ids', nargs='+')
-        parser.add_argument('--oauth-token',
-                            dest='oauth_token',
-                            default=None,
-                            help='The OAuth token to use when authenticating '
-                                 'to GitHub. Unauthenticated requests are '
-                                 'rate limited to 60 per hour. Defaults to '
-                                 'None')
-        parser.add_argument('--repo',
-                            dest='repo',
-                            default='nyaruka/posm-extracts',
-                            help="The GitHub posm-extracts repo to use. "
-                                 "Defaults to nyaruka/posm-extracts")
-        parser.add_argument('--dir',
-                            dest='dir',
-                            default='geojson',
-                            help='The directory to write the geojson files '
-                                 'to. Defaults to `geojson`')
+        parser.add_argument('--oauth-token', dest='oauth_token', default=None,
+                            help='The OAuth token to use when authenticating to GitHub. Unauthenticated requests are '
+                                 'rate limited to 60 per hour. Defaults to None')
+        parser.add_argument('--repo', dest='repo', default='nyaruka/posm-extracts',
+                            help="The GitHub posm-extracts repo to use. Defaults to nyaruka/posm-extracts")
+        parser.add_argument('--dir', dest='dir', default='geojson',
+                            help='The directory to write the geojson files to. Defaults to `geojson`')
 
     def handle(self, *args, **options):
 
@@ -43,28 +35,22 @@ class Command(BaseCommand):
             headers = {}
 
         data = requests.get(
-            "https://api.github.com/repos/%s/git/trees/master" % (
-                repo,), headers=headers).json()
+            "https://api.github.com/repos/%s/git/trees/master" % (repo,), headers=headers).json()
         [geojson] = filter(lambda obj: obj['path'] == "geojson", data['tree'])
         geojson_sha = geojson['sha']
 
-        files = requests.get(
-            'https://api.github.com/repos/%s/git/trees/%s' % (
-                repo, geojson_sha,), headers=headers).json()
+        files = requests.get('https://api.github.com/repos/%s/git/trees/%s' % (repo, geojson_sha,),
+                             headers=headers).json()
 
         if not os.path.exists(destination_dir):
             os.makedirs(destination_dir)
 
         for relation_id in relation_ids:
             relation_files = filter(
-                lambda obj: re.match(r'R%s.*_simplified.json' % (relation_id,),
-                                     obj['path']), files['tree'])
+                lambda obj: regex.match(r'R%s.*_simplified.json' % (relation_id,), obj['path']), files['tree'])
             for relation_file in relation_files:
-                destination = os.path.join(
-                    destination_dir, relation_file['path'])
+                destination = os.path.join(destination_dir, relation_file['path'])
                 with open(destination, 'w') as fp:
-                    response = requests.get(
-                        'https://raw.githubusercontent.com/%s/'
-                        'master/geojson/%s' % (
-                            repo, relation_file['path']), headers=headers)
+                    response = requests.get('https://raw.githubusercontent.com/%s/master/geojson/%s' % (
+                                            repo, relation_file['path']), headers=headers)
                     fp.write(response.content)

--- a/temba/locations/management/commands/download_geojson.py
+++ b/temba/locations/management/commands/download_geojson.py
@@ -33,16 +33,24 @@ class Command(BaseCommand):
         destination_dir = options['dir']
         relation_ids = options['relation_ids']
         repo = options['repo']
+        oauth_token = options['oauth_token']
+
+        if oauth_token:
+            headers = {
+                'Authorization': 'token %s' % (oauth_token,)
+            }
+        else:
+            headers = {}
 
         data = requests.get(
             "https://api.github.com/repos/%s/git/trees/master" % (
-                repo,)).json()
+                repo,), headers=headers).json()
         [geojson] = filter(lambda obj: obj['path'] == "geojson", data['tree'])
         geojson_sha = geojson['sha']
 
         files = requests.get(
             'https://api.github.com/repos/%s/git/trees/%s' % (
-                repo, geojson_sha,)).json()
+                repo, geojson_sha,), headers=headers).json()
 
         if not os.path.exists(destination_dir):
             os.makedirs(destination_dir)
@@ -58,5 +66,5 @@ class Command(BaseCommand):
                     response = requests.get(
                         'https://raw.githubusercontent.com/%s/'
                         'master/geojson/%s' % (
-                            repo, relation_file['path']))
+                            repo, relation_file['path']), headers=headers)
                     fp.write(response.content)


### PR DESCRIPTION
This accompanies the `import_geojson` management command. It takes OSM relation ids as positional arguments and then downloads the relevant files from a GitHub repository. It defaults to `nyaruka/posm-extracts`.