### PR TITLE
history_class template tag crashes when given a Msg object.

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -519,6 +519,7 @@ class Contact(TembaModel):
 
         msgs = Msg.objects.filter(contact=self, created_on__gte=after, created_on__lt=before)
         msgs = msgs.exclude(visibility=Msg.VISIBILITY_DELETED).select_related('channel').prefetch_related('channel_logs')
+        msgs = msgs.prefetch_related('broadcast')
 
         # we also include in the timeline purged broadcasts with a best guess at the translation used
         recipients = BroadcastRecipient.objects.filter(contact=self)

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -199,7 +199,7 @@ def history_class(item):
     if isinstance(item, Msg):
         if item.media and item.media[:6] == 'video:':
             css = '%s %s' % (css, 'video')
-        if item.direction or item.recipient_count:
+        if item.direction or (item.broadcast and item.broadcast.recipient_count > 1):
             css = '%s %s' % (css, 'msg')
         if item.status in (ERRORED, FAILED):
             css = '%s %s' % (css, 'warning')

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1578,6 +1578,7 @@ class ContactTest(TembaTest):
         from temba.contacts.templatetags.contacts import activity_icon, history_class
 
         self.assertEquals('non-msg', history_class(call))
+        self.assertEquals('msg', history_class(msg))
 
         call.status = IVRCall.FAILED
         self.assertEquals('non-msg warning', history_class(call))


### PR DESCRIPTION
It looks for an attribute called `recipient_count` which is on the `broadcast`, not the `Msg` itself.