### PR TITLE
The first Msg created for USSD Pull sessions has no direction set.

### DIFF
--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8792,7 +8792,7 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
         self.assertEquals(data["from"], outbound_msg.contact.get_urn(TEL_SCHEME).path)
         self.assertEquals(outbound_msg.response_to, inbound_msg)
         self.assertEquals(outbound_msg.session.status, USSDSession.TRIGGERED)
-        self.assertEquals(inbound_msg.direction, USSDSession.USSD_PULL)
+        self.assertEquals(inbound_msg.direction, INCOMING)
 
     def test_receive_ussd_no_sesion(self):
         from temba.channels.handlers import JunebugHandler

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8792,6 +8792,7 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
         self.assertEquals(data["from"], outbound_msg.contact.get_urn(TEL_SCHEME).path)
         self.assertEquals(outbound_msg.response_to, inbound_msg)
         self.assertEquals(outbound_msg.session.status, USSDSession.TRIGGERED)
+        self.assertEquals(inbound_msg.direction, USSDSession.USSD_PULL)
 
     def test_receive_ussd_no_sesion(self):
         from temba.channels.handlers import JunebugHandler

--- a/temba/ussd/models.py
+++ b/temba/ussd/models.py
@@ -38,7 +38,7 @@ class USSDSession(ChannelSession):
             channel=self.channel, contact=self.contact, contact_urn=self.contact_urn,
             sent_on=date, session=self, msg_type=USSD, external_id=message_id,
             created_on=timezone.now(), modified_on=timezone.now(), org=self.channel.org,
-            direction=self.USSD_PULL)
+            direction=self.INCOMING)
         flow.start([], [self.contact], start_msg=message, restart_participants=True, session=self)
 
     def handle_session_async(self, urn, content, date, message_id):

--- a/temba/ussd/models.py
+++ b/temba/ussd/models.py
@@ -37,7 +37,8 @@ class USSDSession(ChannelSession):
         message = Msg.objects.create(
             channel=self.channel, contact=self.contact, contact_urn=self.contact_urn,
             sent_on=date, session=self, msg_type=USSD, external_id=message_id,
-            created_on=timezone.now(), modified_on=timezone.now(), org=self.channel.org)
+            created_on=timezone.now(), modified_on=timezone.now(), org=self.channel.org,
+            direction=self.USSD_PULL)
         flow.start([], [self.contact], start_msg=message, restart_participants=True, session=self)
 
     def handle_session_async(self, urn, content, date, message_id):


### PR DESCRIPTION
This causes template rendering problems because the `msg.direction` should always be truth-y.