### PR TITLE
Display links to channel logs for USSD channels.

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -859,11 +859,17 @@ class Channel(TembaModel):
     def get_caller(self):
         return self.get_delegate(Channel.ROLE_CALL)
 
+    def get_ussd_delegate(self):
+        return self.get_delegate(Channel.ROLE_USSD)
+
     def is_delegate_sender(self):
         return self.parent and Channel.ROLE_SEND in self.role
 
     def is_delegate_caller(self):
         return self.parent and Channel.ROLE_CALL in self.role
+
+    def is_delegate_ussd(self):
+        return self.parent and Channel.ROLE_USSD in self.role
 
     def generate_ivr_response(self):
         if self.channel_type in Channel.TWIML_CHANNELS:

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -868,9 +868,6 @@ class Channel(TembaModel):
     def is_delegate_caller(self):
         return self.parent and Channel.ROLE_CALL in self.role
 
-    def is_delegate_ussd(self):
-        return self.parent and Channel.ROLE_USSD in self.role
-
     def generate_ivr_response(self):
         if self.channel_type in Channel.TWIML_CHANNELS:
             return twiml.Response()

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -36,9 +36,6 @@
           -if channel.is_delegate_caller
             -trans "Voice calls enabled"
 
-          - if channel.is_delegate_ussd
-            -trans "USSD enabled"
-
       -if channel.has_configuration_page
         <a class="btn btn-tiny" href="{% url 'channels.channel_configuration' channel.id %}">{%trans "Settings"%}</a>
 
@@ -167,9 +164,6 @@
 
       -if channel.is_delegate_caller
         -trans "Voice calls enabled"
-
-      -if channel.is_delegate_ussd
-        -trans "USSD enabled"
 
 -block post-fields
   -block charts-zone

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -36,19 +36,24 @@
           -if channel.is_delegate_caller
             -trans "Voice calls enabled"
 
+          - if channel.is_delegate_ussd
+            -trans "USSD enabled"
+
       -if channel.has_configuration_page
         <a class="btn btn-tiny" href="{% url 'channels.channel_configuration' channel.id %}">{%trans "Settings"%}</a>
 
 
       -if channel.has_channel_log
         -if not user_org.is_anon or perms.contacts.contact_break_anon
-          -with channel.get_sender as sender and channel.get_caller as caller
+          -with channel.get_sender as sender and channel.get_caller as caller and channel.get_ussd_delegate as ussd
             -if sender and not caller
               <a class="btn btn-tiny" href="{% url 'channels.channellog_list' %}?channel={{ sender.id }}">{%trans "Sending Log"%}</a>
             -if sender and sender == caller
               <a class="btn btn-tiny" href="{% url 'channels.channellog_list' %}?channel={{ sender.id }}">{%trans "Channel Log"%}</a>
             - if caller and caller != sender
               <a class="btn btn-tiny" href="{% url 'channels.channellog_list' %}?channel={{ caller.id }}&sessions=1">{%trans "Call Log"%}</a>
+            - if ussd
+              <a class="btn btn-tiny" href="{% url 'channels.channellog_list' %}?channel={{ ussd.id }}">{%trans "USSD Log"%}</a>
       .notice
         -if delayed_sync_event or unsent_msgs_count
           .icon.icon-warning.errored
@@ -162,6 +167,9 @@
 
       -if channel.is_delegate_caller
         -trans "Voice calls enabled"
+
+      -if channel.is_delegate_ussd
+        -trans "USSD enabled"
 
 -block post-fields
   -block charts-zone


### PR DESCRIPTION
Currently they're only accessible by manually constructing the URL and providing the correct primary key for the `?channel=` parameter.