### PR TITLE
Fix simulator background when using Whitenoise to serve statics.

### DIFF
--- a/templates/flows/simulator.haml
+++ b/templates/flows/simulator.haml
@@ -31,7 +31,7 @@
 
 :css
   .simulator-content {
-    background: url('{{STATIC_URL}}/images/simulator_bg.png') top center no-repeat;
+    background: url('{{STATIC_URL}}images/simulator_bg.png') top center no-repeat;
   }
 
   .media-button {
@@ -42,4 +42,3 @@
     padding: 2px 12px;
     margin-top: 3px;
   }
-


### PR DESCRIPTION
Whitenoise does not appreciate the extra forward slash.

before:
![rapidpro_-_visually_build_interactive_sms_applications](https://cloud.githubusercontent.com/assets/1065/24913054/40cce79c-1ed0-11e7-82a4-ca5bc6f2ebd2.png)

after:
![rapidpro_-_visually_build_interactive_sms_applications](https://cloud.githubusercontent.com/assets/1065/24913094/589378dc-1ed0-11e7-930c-81e26324e2d7.png)
