### PR TITLE
libmagic needs to be installed to get set up.

### DIFF
--- a/_docs/development.md
+++ b/_docs/development.md
@@ -22,6 +22,7 @@ You'll need the following to get started:
  * [lessc](http://lesscss.org), the Less compiler.
  * [coffee](http://coffeescript.org), the Coffee script compiler.
  * [bower](http://bower.io), package manager for javascript libraries.
+ * [libmagic](http://brewformulas.org/Libmagic) or [libmagic-dev](https://packages.ubuntu.com/search?keywords=libmagic-dev) depending on your development platform. Required by https://github.com/dveselov/python-libmagic.
 
 ## Create temba user for PostgreSQL
 


### PR DESCRIPTION
Django startup fails with an obscure warnings about settings not being available if libmagic isn't installed.