### PR TITLE
Wait for transaction commit before pushing tasks

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -738,6 +738,8 @@ class Msg(models.Model):
         task_priority = None
         last_contact = None
 
+        tasks_to_push = []
+
         # we send in chunks of 1,000 to help with contention
         for msg_chunk in chunk_list(all_msgs, 1000):
             # create a temporary list of our chunk so we can iterate more than once
@@ -768,7 +770,7 @@ class Msg(models.Model):
                             if task_priority is None:  # pragma: needs cover
                                 task_priority = DEFAULT_PRIORITY
 
-                            push_task(task_msgs[0]['org'], MSG_QUEUE, SEND_MSG_TASK, task_msgs, priority=task_priority)
+                            tasks_to_push.append((task_msgs, task_priority))
                             task_msgs = []
                             task_priority = None
 
@@ -789,7 +791,15 @@ class Msg(models.Model):
         if task_msgs:
             if task_priority is None:
                 task_priority = DEFAULT_PRIORITY
-            push_task(task_msgs[0]['org'], MSG_QUEUE, SEND_MSG_TASK, task_msgs, priority=task_priority)
+
+            tasks_to_push.append((task_msgs, task_priority))
+
+        on_transaction_commit(lambda: cls.push_tasks(tasks_to_push))
+
+    @classmethod
+    def push_tasks(cls, tasks):
+        for msg_task in tasks:
+            push_task(msg_task[0][0]['org'], MSG_QUEUE, SEND_MSG_TASK, msg_task[0], priority=msg_task[1])
 
     @classmethod
     def process_message(cls, msg):

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2131,7 +2131,7 @@ class CeleryTaskTest(TembaTest):
         AdminBoundary.objects.all().delete()
         Org.objects.all().delete()
         Contact.objects.all().delete()
-        User.objects.all().delete()
+        User.objects.all().exclude(username=settings.ANONYMOUS_USER_NAME).delete()
 
     @classmethod
     def _enter_atomics(cls):

--- a/temba/settings.py.dev
+++ b/temba/settings.py.dev
@@ -51,6 +51,18 @@ DATABASES = {
         'CONN_MAX_AGE': 60,
         'OPTIONS': {
         }
+    },
+    'default2': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': 'temba',
+        'USER': 'temba',
+        'PASSWORD': 'temba',
+        'HOST': 'localhost',
+        'PORT': '',
+        'ATOMIC_REQUESTS': True,
+        'CONN_MAX_AGE': 60,
+        'OPTIONS': {
+        }
     }
 }
 


### PR DESCRIPTION
We were experiencing issues with our USSD service, our sentry was showing these errors:

```
IntegrityError: insert or update on table "channels_channellog" violates foreign key constraint "channels_channellog_msg_id_e40e6612_fk_msgs_msg_id"
DETAIL:  Key (msg_id)=(260040) is not present in table "msgs_msg".
```

After investigating I found the message object would always exist in the DB, but the queue started processing the message before the original transaction was committed. It will now wait for the transaction to commit before placing things on the queue.

We have this fix running in one of our Production environments and the error has disappeared.
