### PR TITLE
Add Token Authentication to the Junebug handler

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -2004,6 +2004,13 @@ class JunebugHandler(BaseChannelHandler):
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
+        authorization = request.META.get('AUTHORIZATION', '').split(' ')
+
+        if channel.secret is not None and (
+                len(authorization) != 2 or authorization[0] != 'Token' or
+                authorization[1] != channel.secret):
+            return JsonResponse(dict(error="Incorrect authentication token"), status=401)
+
         # Junebug is sending an event
         if action == 'event':
             expected_keys = ["event_type", "message_id", "timestamp"]

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -2004,7 +2004,7 @@ class JunebugHandler(BaseChannelHandler):
         if not channel:
             return HttpResponse("Channel not found for id: %s" % request_uuid, status=400)
 
-        authorization = request.META.get('AUTHORIZATION', '').split(' ')
+        authorization = request.META.get('HTTP_AUTHORIZATION', '').split(' ')
 
         if channel.secret is not None and (
                 len(authorization) != 2 or authorization[0] != 'Token' or

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1427,7 +1427,7 @@ class Channel(TembaModel):
         payload['content'] = text
 
         if channel.secret is not None:
-            payload['event_auth'] = {"Authorization": "Token %s" % channel.secret}
+            payload['event_auth_token'] = channel.secret
 
         if is_ussd:
             session = USSDSession.objects.get_session_with_status_only(msg.session_id)

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1426,6 +1426,9 @@ class Channel(TembaModel):
         payload['event_url'] = event_url
         payload['content'] = text
 
+        if channel.secret is not None:
+            payload['event_auth'] = {"Authorization": "Token %s" % channel.secret}
+
         if is_ussd:
             session = USSDSession.objects.get_session_with_status_only(msg.session_id)
             external_id = Msg.objects.values_list('external_id', flat=True).filter(pk=msg.response_to_id).first()

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8866,7 +8866,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
         data = self.mk_event()
         joe = self.create_contact("Joe Biden", "+254788383383")
-        msg = joe.send("Hey Joe, it's Obama, pick up!", self.admin)
+        msg = joe.send("Hey Joe, it's Obama, pick up!", self.admin)[0]
         msg.external_id = data['message_id']
         msg.save(update_fields=('external_id',))
 
@@ -9074,7 +9074,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
         self.channel.save()
 
         joe = self.create_contact("Joe", "+250788383383")
-        msg = joe.send("événement", self.admin, trigger_send=False)
+        msg = joe.send("événement", self.admin, trigger_send=False)[0]
 
         settings.SEND_MESSAGES = True
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -2872,6 +2872,44 @@ class ChannelClaimTest(TembaTest):
 
         self.assertContains(response, reverse('handlers.junebug_handler', args=['inbound', channel.uuid]))
 
+    def test_claim_junebug_with_secret(self):
+        Channel.objects.all().delete()
+        self.login(self.admin)
+
+        response = self.client.get(reverse('channels.channel_claim_junebug'))
+        self.assertEquals(200, response.status_code)
+
+        post_data = {
+            "channel_type": Channel.TYPE_JUNEBUG,
+            "country": "ZA",
+            "number": "+273454325324",
+            "url": "http://example.com/messages.json",
+            "username": "foo",
+            "password": "bar",
+            "secret": "UjOq8ATo2PDS6L08t6vlqSoK"
+        }
+
+        response = self.client.post(reverse('channels.channel_claim_junebug'), post_data)
+
+        channel = Channel.objects.get()
+
+        self.assertEquals(channel.country, post_data['country'])
+        self.assertEquals(channel.address, post_data['number'])
+        self.assertEquals(channel.secret, post_data['secret'])
+        self.assertEquals(channel.config_json()['send_url'], post_data['url'])
+        self.assertEquals(channel.config_json()['username'], post_data['username'])
+        self.assertEquals(channel.config_json()['password'], post_data['password'])
+        self.assertEquals(channel.channel_type, Channel.TYPE_JUNEBUG)
+        self.assertEquals(channel.role, Channel.DEFAULT_ROLE)
+
+        config_url = reverse('channels.channel_configuration', args=[channel.pk])
+        self.assertRedirect(response, config_url)
+
+        response = self.client.get(config_url)
+        self.assertEquals(200, response.status_code)
+
+        self.assertContains(response, reverse('handlers.junebug_handler', args=['inbound', channel.uuid]))
+
     def test_claim_junebug_ussd(self):
         Channel.objects.all().delete()
         self.login(self.admin)
@@ -8822,6 +8860,47 @@ class JunebugTest(JunebugTestMixin, TembaTest):
             "Message with external id of '%s' not found" % (
                 data['message_id'],))
 
+    def test_status_with_auth(self):
+        self.channel.secret = "UjOq8ATo2PDS6L08t6vlqSoK"
+        self.channel.save()
+
+        data = self.mk_event()
+        joe = self.create_contact("Joe Biden", "+254788383383")
+        msg = joe.send("Hey Joe, it's Obama, pick up!", self.admin)
+        msg.external_id = data['message_id']
+        msg.save(update_fields=('external_id',))
+
+        def assertStatus(sms, event_type, assert_status):
+            data['event_type'] = event_type
+            response = self.client.post(
+                reverse('handlers.junebug_handler',
+                        args=['event', self.channel.uuid]),
+                data=json.dumps(data),
+                content_type='application/json',
+                AUTHORIZATION="Token UjOq8ATo2PDS6L08t6vlqSoK")
+            self.assertEquals(200, response.status_code)
+            sms = Msg.objects.get(pk=sms.id)
+            self.assertEquals(assert_status, sms.status)
+
+        assertStatus(msg, 'submitted', SENT)
+        assertStatus(msg, 'delivery_succeeded', DELIVERED)
+        assertStatus(msg, 'delivery_failed', FAILED)
+        assertStatus(msg, 'rejected', FAILED)
+
+    def test_status_incorrect_auth(self):
+        self.channel.secret = "UjOq8ATo2PDS6L08t6vlqSoK"
+        self.channel.save()
+
+        # ok, what happens with an invalid uuid?
+        data = self.mk_event()
+        response = self.client.post(
+            reverse('handlers.junebug_handler',
+                    args=['event', self.channel.uuid]),
+            data=json.dumps(data),
+            content_type='application/json',
+            AUTHORIZATION="Token Not_token")
+        self.assertEquals(401, response.status_code)
+
     def test_receive_with_invalid_message(self):
         callback_url = reverse('handlers.junebug_handler',
                                args=['inbound', self.channel.uuid])
@@ -8847,6 +8926,41 @@ class JunebugTest(JunebugTestMixin, TembaTest):
         self.assertEquals(self.org, msg.org)
         self.assertEquals(self.channel, msg.channel)
         self.assertEquals("événement", msg.text)
+
+    def test_receive_with_auth(self):
+        self.channel.secret = "UjOq8ATo2PDS6L08t6vlqSoK"
+        self.channel.save()
+
+        data = self.mk_msg(content="événement")
+        callback_url = reverse('handlers.junebug_handler',
+                               args=['inbound', self.channel.uuid])
+        response = self.client.post(callback_url, json.dumps(data),
+                                    content_type='application/json',
+                                    AUTHORIZATION="Token UjOq8ATo2PDS6L08t6vlqSoK")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'ack')
+
+        # load our message
+        msg = Msg.objects.get()
+        self.assertEquals(data["from"], msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEquals(INCOMING, msg.direction)
+        self.assertEquals(self.org, msg.org)
+        self.assertEquals(self.channel, msg.channel)
+        self.assertEquals("événement", msg.text)
+
+    def test_receive_with_incorrect_auth(self):
+        self.channel.secret = "UjOq8ATo2PDS6L08t6vlqSoK"
+        self.channel.save()
+
+        data = self.mk_msg(content="événement")
+        callback_url = reverse('handlers.junebug_handler',
+                               args=['inbound', self.channel.uuid])
+        response = self.client.post(callback_url, json.dumps(data),
+                                    content_type='application/json',
+                                    AUTHORIZATION="Token Not_token")
+
+        self.assertEqual(response.status_code, 401)
 
     def test_send_wired(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -8954,6 +9068,27 @@ class JunebugTest(JunebugTestMixin, TembaTest):
             # manually send it off
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
             self.assertTrue(ChannelLog.objects.filter(description__icontains="Unable to read external message_id"))
+
+    def test_send_adds_auth(self):
+        self.channel.secret = "UjOq8ATo2PDS6L08t6vlqSoK"
+        self.channel.save()
+
+        joe = self.create_contact("Joe", "+250788383383")
+        msg = joe.send("événement", self.admin, trigger_send=False)
+
+        settings.SEND_MESSAGES = True
+
+        with patch('requests.post') as mock:
+            mock.return_value = MockResponse(200, json.dumps({
+                'result': {
+                    'message_id': '07033084-5cfd-4812-90a4-e4d24ffb6e3d',
+                }
+            }))
+
+            # manually send it off
+            self.channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
+            self.assertEqual(mock.call_args[1]['json']['event_auth'],
+                             {"Authorization": "Token UjOq8ATo2PDS6L08t6vlqSoK"})
 
 
 class MbloxTest(TembaTest):

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -8877,7 +8877,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                         args=['event', self.channel.uuid]),
                 data=json.dumps(data),
                 content_type='application/json',
-                AUTHORIZATION="Token UjOq8ATo2PDS6L08t6vlqSoK")
+                HTTP_AUTHORIZATION="Token UjOq8ATo2PDS6L08t6vlqSoK")
             self.assertEquals(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
             self.assertEquals(assert_status, sms.status)
@@ -8898,7 +8898,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                     args=['event', self.channel.uuid]),
             data=json.dumps(data),
             content_type='application/json',
-            AUTHORIZATION="Token Not_token")
+            HTTP_AUTHORIZATION="Token Not_token")
         self.assertEquals(401, response.status_code)
 
     def test_receive_with_invalid_message(self):
@@ -8936,7 +8936,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                                args=['inbound', self.channel.uuid])
         response = self.client.post(callback_url, json.dumps(data),
                                     content_type='application/json',
-                                    AUTHORIZATION="Token UjOq8ATo2PDS6L08t6vlqSoK")
+                                    HTTP_AUTHORIZATION="Token UjOq8ATo2PDS6L08t6vlqSoK")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['status'], 'ack')
@@ -8958,7 +8958,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                                args=['inbound', self.channel.uuid])
         response = self.client.post(callback_url, json.dumps(data),
                                     content_type='application/json',
-                                    AUTHORIZATION="Token Not_token")
+                                    HTTP_AUTHORIZATION="Token Not_token")
 
         self.assertEqual(response.status_code, 401)
 

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -9087,8 +9087,8 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
             # manually send it off
             self.channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
-            self.assertEqual(mock.call_args[1]['json']['event_auth'],
-                             {"Authorization": "Token UjOq8ATo2PDS6L08t6vlqSoK"})
+            self.assertEqual(mock.call_args[1]['json']['event_auth_token'],
+                             "UjOq8ATo2PDS6L08t6vlqSoK")
 
 
 class MbloxTest(TembaTest):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1635,10 +1635,13 @@ class ChannelCRUDL(SmartCRUDL):
             password = forms.CharField(label=_("Password"),
                                        help_text=_("The password to be used to authenticate to Junebug"),
                                        required=False)
+            secret = forms.CharField(label=_("Secret"),
+                                     help_text=_("The token Junebug should use to authenticate"),
+                                     required=False)
 
         title = _("Connect Junebug")
         form_class = JunebugForm
-        fields = ('channel_type', 'country', 'number', 'url', 'username', 'password')
+        fields = ('channel_type', 'country', 'number', 'url', 'username', 'password', 'secret')
 
         def form_valid(self, form):
             org = self.request.user.get_org()
@@ -1655,6 +1658,9 @@ class ChannelCRUDL(SmartCRUDL):
                                                                      data['password'], data['channel_type'],
                                                                      data.get('url'),
                                                                      role=role)
+            if data['secret']:
+                self.object.secret = data['secret']
+                self.object.save()
 
             return super(ChannelCRUDL.ClaimAuthenticatedExternal, self).form_valid(form)
 


### PR DESCRIPTION
This allows messages and events from Junebug to be authenticated if the channel has a token specified.