### PR TITLE
Update TransferTo API URL

### DIFF
--- a/temba/airtime/models.py
+++ b/temba/airtime/models.py
@@ -16,7 +16,7 @@ from temba.utils import get_country_code_by_name
 
 
 class AirtimeTransfer(SmartModel):
-    TRANSFERTO_AIRTIME_API_URL = 'https://fm.transfer-to.com/cgi-bin/shop/topup'
+    TRANSFERTO_AIRTIME_API_URL = 'https://airtime.transferto.com/cgi-bin/shop/topup'
     LOG_DIVIDER = "\n\n%s\n\n" % ('=' * 20)
 
     PENDING = 'P'

--- a/temba/airtime/tests.py
+++ b/temba/airtime/tests.py
@@ -46,7 +46,7 @@ class AirtimeEventTest(TembaTest):
             self.assertEqual(response.content, "foo=allo\r\nbar=1,2,3\r\n")
 
             self.assertEqual(mock_post.call_count, 1)
-            self.assertEqual('https://fm.transfer-to.com/cgi-bin/shop/topup', mock_post.call_args_list[0][0][0])
+            self.assertEqual('https://airtime.transferto.com/cgi-bin/shop/topup', mock_post.call_args_list[0][0][0])
             mock_args = mock_post.call_args_list[0][0][1]
             self.assertTrue('action' in mock_args.keys())
             self.assertTrue('login' in mock_args.keys())
@@ -67,7 +67,7 @@ class AirtimeEventTest(TembaTest):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, "foo=allo\r\nbar=1,2,3\r\n")
             self.assertEqual(mock_post.call_count, 1)
-            self.assertEqual('https://fm.transfer-to.com/cgi-bin/shop/topup', mock_post.call_args_list[0][0][0])
+            self.assertEqual('https://airtime.transferto.com/cgi-bin/shop/topup', mock_post.call_args_list[0][0][0])
             mock_args = mock_post.call_args_list[0][0][1]
             self.assertTrue('action' in mock_args.keys())
             self.assertTrue('login' in mock_args.keys())


### PR DESCRIPTION
Reobone received this email from TransferTo:

> We just upgraded our highly available infrastructure and setup a new Airtime
> API endpoint that provides better performance and security with the support
> of TLS 1.2.
>
> Please update your applications now to call this new endpoint (new Domain name
> & IP) https://airtime.transferto.com/cgi-bin/shop/topup
> (instead of https://fm.transfer-to.com/cgi-bin/shop/topup).
>
> The current endpoint will remain available over the next few weeks to give you
> time to test and perform the migration safely, you can already access it using
> your existing credentials. No other changes are expected in your configuration.