### PR TITLE
Handle 4XX errors for flow management

### DIFF
--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -311,19 +311,20 @@ class WebHookEvent(SmartModel):
                 body = 'Skipped actual send'
                 status_code = 200
 
-            if (200 <= status_code < 300) or (400 <= status_code < 500):
-                try:
-                    response_json = json.loads(body, object_pairs_hook=OrderedDict)
+            # process the webhook response
+            try:
+                response_json = json.loads(body, object_pairs_hook=OrderedDict)
 
-                    # only update if we got a valid JSON dictionary or list
-                    if not isinstance(response_json, dict) and not isinstance(response_json, list):
-                        raise ValueError("Response must be a JSON dictionary or list, ignoring response.")
+                # only update if we got a valid JSON dictionary or list
+                if not isinstance(response_json, dict) and not isinstance(response_json, list):
+                    raise ValueError("Response must be a JSON dictionary or list, ignoring response.")
 
-                    run.update_fields(response_json)
-                    message = "Webhook called successfully."
-                except ValueError:
-                    message = "Response must be a JSON dictionary, ignoring response."
+                run.update_fields(response_json)
+                message = "Webhook called successfully."
+            except ValueError:
+                message = "Response must be a JSON dictionary, ignoring response."
 
+            if 200 <= status_code < 300:
                 webhook_event.status = cls.STATUS_COMPLETE
             else:
                 webhook_event.status = cls.STATUS_FAILED

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -311,7 +311,7 @@ class WebHookEvent(SmartModel):
                 body = 'Skipped actual send'
                 status_code = 200
 
-            if 200 <= status_code < 300:
+            if (200 <= status_code < 300) or (400 <= status_code < 500):
                 try:
                     response_json = json.loads(body, object_pairs_hook=OrderedDict)
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4181,18 +4181,18 @@ class WebhookTest(TembaTest):
             self.assertEquals("1001", incoming.text)
 
         with patch('requests.post') as mock:
-            mock.return_value = MockResponse(400, '{ "error": "400", "message": "Missing field in request" }')
+            mock.return_value = MockResponse(400, '{ "text": "Valid", "error": "400", "message": "Missing field in request" }')
             rule_step.run.fields = None
             rule_step.run.save()
 
             (match, value) = webhook.find_matching_rule(webhook_step, run, incoming)
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
-            self.assertIsNone(valid_uuid, match.uuid)
+            self.assertEquals(valid_uuid, match.uuid)
             self.assertEquals("Valid", value)
-            self.assertEquals(dict(error="400", message="Missing field in request"), run.field_dict())
+            self.assertEquals(dict(text="Valid", error="400", message="Missing field in request"), run.field_dict())
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
-            self.assertEquals(dict(error="400", message="Missing field in request"), message_context['extra'])
+            self.assertEquals(dict(text="Valid", error="400", message="Missing field in request"), message_context['extra'])
 
     def test_resthook(self):
         self.contact = self.create_contact("Macklemore", "+12067799294")

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4180,6 +4180,20 @@ class WebhookTest(TembaTest):
             self.assertIsNone(value)
             self.assertEquals("1001", incoming.text)
 
+        with patch('requests.post') as mock:
+            mock.return_value = MockResponse(400, '{ "error": "400", "message": "Missing field in request" }')
+            rule_step.run.fields = None
+            rule_step.run.save()
+
+            (match, value) = webhook.find_matching_rule(webhook_step, run, incoming)
+            (match, value) = rules.find_matching_rule(rule_step, run, incoming)
+            self.assertIsNone(valid_uuid, match.uuid)
+            self.assertEquals("Valid", value)
+            self.assertEquals(dict(error="400", message="Missing field in request"), run.field_dict())
+
+            message_context = self.flow.build_expressions_context(self.contact, incoming)
+            self.assertEquals(dict(error="400", message="Missing field in request"), message_context['extra'])
+
     def test_resthook(self):
         self.contact = self.create_contact("Macklemore", "+12067799294")
         webhook_flow = self.get_flow('resthooks')


### PR DESCRIPTION
We have a problem with returning _failures_ that can be acted on.  4XX class errors could potentially be managed and resolved.  Right now we have to return a 200 that provides a failure code as part of the body so we're all to check it.

I'm not entirely this is the right way to do this, but it's a start.

fixes #616
