### PR TITLE
Run lint on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ services:
 
 matrix:
   fast_finish: true
+  include:
+    - env: TEST=lint
+    - env: TEST=build
 
 install:
 - pip install --upgrade pip
@@ -44,13 +47,7 @@ before_script:
 - psql -U temba postgres -c "CREATE DATABASE temba;"
 - ln -s $TRAVIS_BUILD_DIR/temba/settings.py.dev $TRAVIS_BUILD_DIR/temba/settings.py
 
-script:
-- flake8
-- python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
-- python manage.py collectstatic --noinput
-- (! python manage.py compress --extension=".haml" --settings=temba.settings_travis | grep 'Error') || exit 1
-- node_modules/karma/bin/karma start karma.conf.coffee --single-run --browsers PhantomJS
-- coverage run manage.py test --noinput --verbosity=2
+script: ./travis.sh
 
 after_success:
 - coveralls --rcfile .coveragerc_failcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,20 @@ language: python
 
 python: 
   - "2.7.11"
+  - "3.6"
 
 services:
 - redis-server
 
+env:
+  - TEST=lint
+  - TEST=build
+
 matrix:
   fast_finish: true
-  include:
-    - env: TEST=lint
-    - env: TEST=build
+  allow_failures:
+    - python: "3.6"
+      env: TEST=build
 
 install:
 - pip install --upgrade pip

--- a/temba/channels/courier.py
+++ b/temba/channels/courier.py
@@ -39,7 +39,7 @@ def msg_as_task(msg):
     Used to serialize msgs as tasks to courier
     """
     msg_json = dict(id=msg.id,
-                    uuid=unicode(msg.uuid) if msg.uuid else "",
+                    uuid=str(msg.uuid) if msg.uuid else "",
                     org_id=msg.org_id,
                     channel_id=msg.channel_id,
                     channel_uuid=msg.channel.uuid,

--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -2364,7 +2364,7 @@ class JioChatHandler(BaseChannelHandler):
         create_time = body.get('CreateTime', None)
         msg_date = None
         if create_time:
-            msg_date = datetime.utcfromtimestamp(float(unicode(create_time)[:10])).replace(tzinfo=pytz.utc)
+            msg_date = datetime.utcfromtimestamp(float(six.text_type(create_time)[:10])).replace(tzinfo=pytz.utc)
         msg_type = body.get('MsgType')
         external_id = body.get('MsgId', None)
 

--- a/temba/channels/types/junebug/type.py
+++ b/temba/channels/types/junebug/type.py
@@ -4,6 +4,7 @@ import json
 import time
 
 from datetime import timedelta
+from six import text_type
 
 import requests
 from django.conf import settings
@@ -93,7 +94,7 @@ class JunebugType(ChannelType):
             event.response_body = response.text
 
         except Exception as e:
-            raise SendException(unicode(e), event=event, start=start)
+            raise SendException(text_type(e), event=event, start=start)
 
         if not (200 <= response.status_code < 300):
             raise SendException("Received a non 200 response %d from Junebug" % response.status_code,
@@ -107,7 +108,7 @@ class JunebugType(ChannelType):
         try:
             message_id = data['result']['message_id']
             Channel.success(channel, msg, WIRED, start, event=event, external_id=message_id)
-        except KeyError, e:
+        except KeyError as e:
             raise SendException("Unable to read external message_id: %r" % (e,),
                                 event=HttpEvent('POST', log_url,
                                                 request_body=json.dumps(json.dumps(payload)),

--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -27,6 +27,7 @@ from django.utils.translation import ugettext_lazy as _, ungettext_lazy as _n
 from django.utils.html import escape
 from django_redis import get_redis_connection
 from enum import Enum
+from six.moves import range
 from smartmin.models import SmartModel
 from temba.airtime.models import AirtimeTransfer
 from temba.assets.models import register_asset_store
@@ -97,13 +98,13 @@ def edit_distance(s1, s2):  # pragma: no cover
     lenstr1 = len(s1)
     lenstr2 = len(s2)
 
-    for i in xrange(-1, lenstr1 + 1):
+    for i in range(-1, lenstr1 + 1):
         d[(i, -1)] = i + 1
-    for j in xrange(-1, lenstr2 + 1):
+    for j in range(-1, lenstr2 + 1):
         d[(-1, j)] = j + 1
 
-    for i in xrange(0, lenstr1):
-        for j in xrange(0, lenstr2):
+    for i in range(0, lenstr1):
+        for j in range(0, lenstr2):
             if s1[i] == s2[j]:
                 cost = 0
             else:

--- a/temba/msgs/migrations/0079_populate_msg_session.py
+++ b/temba/msgs/migrations/0079_populate_msg_session.py
@@ -29,7 +29,7 @@ def do_populate(ChannelSession, Msg):
                                   created_on__lte=session.ended_on)
         updated += msgs.filter(Q(msg_type='V') | Q(channel__channel_type='VMU')).update(session=session)
         if idx % 1000 == 0:
-            print ("Populated %d of %d sessions (%d msgs)" % (idx, count, updated))
+            print("Populated %d of %d sessions (%d msgs)" % (idx, count, updated))
             updated = 0
 
 

--- a/temba/msgs/migrations/0096_populate_attachments.py
+++ b/temba/msgs/migrations/0096_populate_attachments.py
@@ -20,7 +20,7 @@ def populate_attachments(Msg):
             msg.save(update_fields=('attachments',))
 
         num_updated += len(id_batch)
-        print (" > Updated %d of %d messages with media" % (num_updated, len(id_batch)))
+        print(" > Updated %d of %d messages with media" % (num_updated, len(id_batch)))
 
 
 def apply_as_migration(apps, schema_editor):

--- a/temba/utils/email.py
+++ b/temba/utils/email.py
@@ -78,7 +78,7 @@ def send_custom_smtp_email(recipients, subject, body, from_email, smtp_host, smt
     :param smtp_password: SMTP password
     :param use_tls: Whether to use TLS
     """
-    recipient_list = [recipients] if isinstance(recipients, basestring) else recipients
+    recipient_list = [recipients] if isinstance(recipients, six.string_types) else recipients
 
     if smtp_port is not None:
         smtp_port = int(smtp_port)

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e # Exit whenever a command fails
+set -x # Output commands run to see them in the Travis interface
+
+if [ "$TEST" == "lint" ]; then
+    flake8
+elif [ "$TEST" == "build" ]; then
+    python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
+    python manage.py collectstatic --noinput
+    (! python manage.py compress --extension=".haml" --settings=temba.settings_travis | grep 'Error') || exit 1
+    node_modules/karma/bin/karma start karma.conf.coffee --single-run --browsers PhantomJS
+    coverage run manage.py test --noinput --verbosity=2
+else
+    echo "The environment variable TEST was not set correctly"
+    exit 1
+fi


### PR DESCRIPTION
This pull request involves splitting the Travis build into multiple parts so that it's possible to run just the lint on Python 3.

It may be possible to split the build step further into more steps but I'm not familiar enough with the project yet to know.

This will keep the codebase Python 3-friendly and allow fixing the tests gradually over time.

## Example Travis output

![screenshot from 2017-10-12 17-36-47](https://user-images.githubusercontent.com/121219/31507822-f136ae36-af73-11e7-9cc2-4ec6156bbd92.png)