### PR TITLE
Enforce modern assertEqual() syntax

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -17,7 +17,6 @@ certifi==2017.4.17        # via python-telegram-bot, requests
 cffi==1.10.0              # via cryptography
 chardet==3.0.4            # via requests
 colorama==0.3.9
-configparser==3.5.0       # via flake8
 contextlib2==0.5.5        # via raven
 cookies==2.2.1            # via responses
 coverage==4.4.1
@@ -42,11 +41,10 @@ djangorestframework==3.5.1
 docutils==0.13.1          # via botocore
 enum34==1.1.6
 et-xmlfile==1.0.1         # via openpyxl
+flake8-deprecated==1.2.1
 flake8-print==2.0.2
 flake8==3.3.0
-funcsigs==1.0.2           # via mock
 future==0.16.0            # via django-hamlpy, python-telegram-bot, uservoice
-futures==3.1.1            # via s3transfer
 geojson==1.3.5
 google==1.9.3
 gunicorn==19.7.1
@@ -88,6 +86,7 @@ pyexcel==0.5.0            # via pyexcel-webio
 pyfcm==1.3.1
 pyflakes==1.5.0           # via flake8
 pyjwt==1.5.0              # via nexmo
+pysocks==1.6.7            # via twilio
 python-dateutil==2.2
 python-gcm==0.4
 python-magic==0.4.13

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -68,6 +68,7 @@ unidecode
 ########################## testing ##########################
 coverage
 flake8
+flake8-deprecated
 flake8-print
 mock
 responses

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -141,30 +141,30 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_call_event(call)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('C', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('C', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
             self.assertIn("Event delivered successfully", result.message)
             self.assertIn("not JSON", result.message)
-            self.assertEquals(200, result.status_code)
-            self.assertEquals("Hello World", result.body)
+            self.assertEqual(200, result.status_code)
+            self.assertEqual("Hello World", result.body)
 
             self.assertTrue(mock.called)
             args = mock.call_args_list[0][0]
             prepared_request = args[0]
-            self.assertEquals(self.channel.org.get_webhook_url(), prepared_request.url)
+            self.assertEqual(self.channel.org.get_webhook_url(), prepared_request.url)
 
             data = parse_qs(prepared_request.body)
-            self.assertEquals('+250788123123', data['phone'][0])
-            self.assertEquals(six.text_type(self.joe.get_urn(TEL_SCHEME)), data['urn'][0])
-            self.assertEquals(self.joe.uuid, data['contact'][0])
-            self.assertEquals(self.joe.name, data['contact_name'][0])
-            self.assertEquals(call.pk, int(data['call'][0]))
-            self.assertEquals(call.event_type, data['event'][0])
+            self.assertEqual('+250788123123', data['phone'][0])
+            self.assertEqual(six.text_type(self.joe.get_urn(TEL_SCHEME)), data['urn'][0])
+            self.assertEqual(self.joe.uuid, data['contact'][0])
+            self.assertEqual(self.joe.name, data['contact_name'][0])
+            self.assertEqual(call.pk, int(data['call'][0]))
+            self.assertEqual(call.event_type, data['event'][0])
             self.assertTrue('occurred_on' in data)
-            self.assertEquals(self.channel.pk, int(data['channel'][0]))
+            self.assertEqual(self.channel.pk, int(data['channel'][0]))
 
     def test_alarm_deliveries(self):
         sync_event = SyncEvent.objects.create(channel=self.channel,
@@ -200,28 +200,28 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_channel_alarm(sync_event)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('C', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('C', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
             self.assertIn("Event delivered successfully", result.message)
-            self.assertEquals(200, result.status_code)
-            self.assertEquals("", result.body)
+            self.assertEqual(200, result.status_code)
+            self.assertEqual("", result.body)
 
             self.assertTrue(mock.called)
             args = mock.call_args_list[0][0]
             prepared_request = args[0]
-            self.assertEquals(self.channel.org.get_webhook_url(), prepared_request.url)
+            self.assertEqual(self.channel.org.get_webhook_url(), prepared_request.url)
 
             data = parse_qs(prepared_request.body)
-            self.assertEquals(self.channel.pk, int(data['channel'][0]))
-            self.assertEquals(85, int(data['power_level'][0]))
-            self.assertEquals('AC', data['power_source'][0])
-            self.assertEquals('CHARGING', data['power_status'][0])
-            self.assertEquals('WIFI', data['network_type'][0])
-            self.assertEquals(5, int(data['pending_message_count'][0]))
-            self.assertEquals(4, int(data['retry_message_count'][0]))
+            self.assertEqual(self.channel.pk, int(data['channel'][0]))
+            self.assertEqual(85, int(data['power_level'][0]))
+            self.assertEqual('AC', data['power_source'][0])
+            self.assertEqual('CHARGING', data['power_status'][0])
+            self.assertEqual('WIFI', data['network_type'][0])
+            self.assertEqual(5, int(data['pending_message_count'][0]))
+            self.assertEqual(4, int(data['retry_message_count'][0]))
 
     @patch('requests.Session.send')
     def test_flow_event(self, mock_send):
@@ -250,13 +250,13 @@ class WebHookTest(TembaTest):
         # should have one event created
         event = WebHookEvent.objects.get()
 
-        self.assertEquals('C', event.status)
-        self.assertEquals(1, event.try_count)
+        self.assertEqual('C', event.status)
+        self.assertEqual(1, event.try_count)
         self.assertFalse(event.next_attempt)
 
         result = WebHookResult.objects.get()
         self.assertIn("successfully", result.message)
-        self.assertEquals(200, result.status_code)
+        self.assertEqual(200, result.status_code)
         self.assertEqual(self.joe, result.contact)
 
         self.assertTrue(mock_send.called)
@@ -280,9 +280,9 @@ class WebHookTest(TembaTest):
 
         values = json.loads(data['values'][0])
 
-        self.assertEquals('Other', values[0]['category']['base'])
-        self.assertEquals('color', values[0]['label'])
-        self.assertEquals('Mauve', values[0]['text'])
+        self.assertEqual('Other', values[0]['category']['base'])
+        self.assertEqual('color', values[0]['label'])
+        self.assertEqual('Mauve', values[0]['text'])
         self.assertTrue(values[0]['time'])
         self.assertTrue(data['time'])
 
@@ -301,14 +301,14 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, sms, now)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('C', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('C', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
             self.assertIn("Event delivered successfully", result.message)
             self.assertIn("not JSON", result.message)
-            self.assertEquals(200, result.status_code)
+            self.assertEqual(200, result.status_code)
             self.assertEqual(result.request_time, 5000)
 
             self.assertTrue(mock_time.called)
@@ -407,13 +407,13 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, sms, now)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('F', event.status)
-            self.assertEquals(0, event.try_count)
+            self.assertEqual('F', event.status)
+            self.assertEqual(0, event.try_count)
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
             self.assertIn("No active user", result.message)
-            self.assertEquals(0, result.status_code)
+            self.assertEqual(0, result.status_code)
 
             self.assertFalse(mock.called)
 
@@ -432,14 +432,14 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, sms, now)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('C', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('C', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
             self.assertIn("Event delivered successfully", result.message)
             self.assertIn("not JSON", result.message)
-            self.assertEquals(200, result.status_code)
+            self.assertEqual(200, result.status_code)
 
             self.assertTrue(mock.called)
 
@@ -453,8 +453,8 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, sms, now)
             event = WebHookEvent.objects.all().first()
 
-            self.assertEquals('E', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('E', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertTrue(event.next_attempt)
 
             mock.return_value = MockResponse(200, "Hello World")
@@ -466,7 +466,7 @@ class WebHookTest(TembaTest):
             event.deliver()
 
             self.assertTrue(mock.called)
-            self.assertEquals(mock.call_count, 2)
+            self.assertEqual(mock.call_count, 2)
 
             WebHookEvent.objects.all().delete()
             WebHookResult.objects.all().delete()
@@ -479,8 +479,8 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, sms, now)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('C', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('C', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertFalse(event.next_attempt)
 
             self.assertTrue(mock.called)
@@ -488,8 +488,8 @@ class WebHookTest(TembaTest):
             result = WebHookResult.objects.get()
             self.assertIn("Event delivered successfully", result.message)
             self.assertIn("ignoring", result.message)
-            self.assertEquals(200, result.status_code)
-            self.assertEquals(bad_json, result.body)
+            self.assertEqual(200, result.status_code)
+            self.assertEqual(bad_json, result.body)
 
             WebHookEvent.objects.all().delete()
             WebHookResult.objects.all().delete()
@@ -500,12 +500,12 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, sms, now)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('C', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('C', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
-            self.assertEquals(200, result.status_code)
+            self.assertEqual(200, result.status_code)
 
             self.assertTrue(mock.called)
 
@@ -517,17 +517,17 @@ class WebHookTest(TembaTest):
             self.assertTrue(mock.called)
             args = mock.call_args_list[0][0]
             prepared_request = args[0]
-            self.assertEquals(self.org.get_webhook_url(), prepared_request.url)
+            self.assertEqual(self.org.get_webhook_url(), prepared_request.url)
 
             data = parse_qs(prepared_request.body)
-            self.assertEquals(self.joe.get_urn(TEL_SCHEME).path, data['phone'][0])
-            self.assertEquals(six.text_type(self.joe.get_urn(TEL_SCHEME)), data['urn'][0])
-            self.assertEquals(self.joe.uuid, data['contact'][0])
-            self.assertEquals(self.joe.name, data['contact_name'][0])
-            self.assertEquals(sms.pk, int(data['sms'][0]))
-            self.assertEquals(self.channel.pk, int(data['channel'][0]))
-            self.assertEquals(WebHookEvent.TYPE_SMS_RECEIVED, data['event'][0])
-            self.assertEquals("I'm gonna pop some tags", data['text'][0])
+            self.assertEqual(self.joe.get_urn(TEL_SCHEME).path, data['phone'][0])
+            self.assertEqual(six.text_type(self.joe.get_urn(TEL_SCHEME)), data['urn'][0])
+            self.assertEqual(self.joe.uuid, data['contact'][0])
+            self.assertEqual(self.joe.name, data['contact_name'][0])
+            self.assertEqual(sms.pk, int(data['sms'][0]))
+            self.assertEqual(self.channel.pk, int(data['channel'][0]))
+            self.assertEqual(WebHookEvent.TYPE_SMS_RECEIVED, data['event'][0])
+            self.assertEqual("I'm gonna pop some tags", data['text'][0])
             self.assertTrue('time' in data)
 
             WebHookEvent.objects.all().delete()
@@ -542,15 +542,15 @@ class WebHookTest(TembaTest):
             WebHookEvent.trigger_sms_event(WebHookEvent.TYPE_SMS_RECEIVED, sms, now)
             event = WebHookEvent.objects.get()
 
-            self.assertEquals('E', event.status)
-            self.assertEquals(1, event.try_count)
+            self.assertEqual('E', event.status)
+            self.assertEqual(1, event.try_count)
             self.assertTrue(event.next_attempt)
             self.assertTrue(next_attempt_earliest < event.next_attempt and next_attempt_latest > event.next_attempt)
 
             result = WebHookResult.objects.get()
             self.assertIn("Error", result.message)
-            self.assertEquals(500, result.status_code)
-            self.assertEquals("I am error", result.body)
+            self.assertEqual(500, result.status_code)
+            self.assertEqual("I am error", result.body)
 
             # make sure things become failures after three retries
             event.try_count = 2
@@ -559,15 +559,15 @@ class WebHookTest(TembaTest):
 
             self.assertTrue(mock.called)
 
-            self.assertEquals('F', event.status)
-            self.assertEquals(3, event.try_count)
+            self.assertEqual('F', event.status)
+            self.assertEqual(3, event.try_count)
             self.assertFalse(event.next_attempt)
 
             result = WebHookResult.objects.get()
             self.assertIn("Error", result.message)
-            self.assertEquals(500, result.status_code)
-            self.assertEquals("I am error", result.body)
-            self.assertEquals("http://fake.com/webhook.php", result.url)
+            self.assertEqual(500, result.status_code)
+            self.assertEqual("I am error", result.body)
+            self.assertEqual("http://fake.com/webhook.php", result.url)
             self.assertTrue(result.data.find("pop+some+tags") > 0)
 
             # check out our api log
@@ -585,7 +585,7 @@ class WebHookTest(TembaTest):
         self.channel.org.save()
 
         # check that our webhook settings have saved
-        self.assertEquals('http://fake.com/webhook.php', self.channel.org.get_webhook_url())
+        self.assertEqual('http://fake.com/webhook.php', self.channel.org.get_webhook_url())
         self.assertDictEqual({'X-My-Header': 'foobar', 'Authorization': 'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='}, self.channel.org.get_webhook_headers())
 
         with patch('requests.Session.send') as mock:
@@ -600,21 +600,21 @@ class WebHookTest(TembaTest):
 
     def test_webhook(self):
         response = self.client.get(reverse('api.webhook'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertContains(response, "Simulator")
 
         response = self.client.get(reverse('api.webhook_simulator'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertContains(response, "Log in")
 
         self.login(self.admin)
         response = self.client.get(reverse('api.webhook_simulator'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertNotContains(response, "Log in")
 
     def test_tunnel(self):
         response = self.client.post(reverse('api.webhook_tunnel'), dict())
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         self.login(self.non_org_user)
 
@@ -623,12 +623,12 @@ class WebHookTest(TembaTest):
 
             response = self.client.post(reverse('api.webhook_tunnel'),
                                         dict(url="http://webhook.url/", data="phone=250788383383&values=foo&bogus=2"))
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             self.assertContains(response, "I am success")
             self.assertTrue('values' in mock.call_args[1]['data'])
             self.assertTrue('phone' in mock.call_args[1]['data'])
             self.assertFalse('bogus' in mock.call_args[1]['data'])
 
             response = self.client.post(reverse('api.webhook_tunnel'), dict())
-            self.assertEquals(400, response.status_code)
+            self.assertEqual(400, response.status_code)
             self.assertTrue(response.content.find("Must include") >= 0)

--- a/temba/api/v1/tests.py
+++ b/temba/api/v1/tests.py
@@ -83,7 +83,7 @@ class APITest(TembaTest):
         return self.client.delete(url, content_type="application/json", HTTP_X_FORWARDED_HTTPS='https')
 
     def assertResultCount(self, response, count):
-        self.assertEquals(count, response.json()['count'])
+        self.assertEqual(count, response.json()['count'])
 
     def assertJSONArrayContains(self, response, key, value):
         if 'results' in response.json():
@@ -121,7 +121,7 @@ class APITest(TembaTest):
         return
 
     def assertResponseError(self, response, field, message, status_code=400):
-        self.assertEquals(status_code, response.status_code)
+        self.assertEqual(status_code, response.status_code)
 
         body = response.json()
         self.assertTrue(message, field in body)
@@ -130,7 +130,7 @@ class APITest(TembaTest):
 
     def assert403(self, url):
         response = self.fetchHTML(url)
-        self.assertEquals(403, response.status_code)
+        self.assertEqual(403, response.status_code)
 
     def test_redirection(self):
         self.login(self.admin)
@@ -345,7 +345,7 @@ class APITest(TembaTest):
 
         # this time, a 200
         response = self.fetchJSON(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # should contain our single flow in the response
         self.assertEqual(response.json()['results'][0], dict(flow=flow.pk,
@@ -391,22 +391,22 @@ class APITest(TembaTest):
         self.create_flow()
 
         response = self.fetchJSON(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertResultCount(response, 3)
 
         response = self.fetchJSON(url, "uuid=%s&uuid=%s" % (flow.uuid, flow2.uuid))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertResultCount(response, 2)
 
         response = self.fetchJSON(url, "flow=%d&flow=%d" % (flow.pk, flow2.pk))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertResultCount(response, 2)
 
         label2 = FlowLabel.create_unique("Surveys", self.org)
         label2.toggle_label([flow2], add=True)
 
         response = self.fetchJSON(url, "label=Polls&label=Surveys")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertResultCount(response, 2)
 
     def test_api_flow_definition(self):
@@ -417,14 +417,14 @@ class APITest(TembaTest):
         flow = self.get_flow('pick_a_number')
 
         response = self.fetchJSON(url, "uuid=%s" % flow.uuid)
-        self.assertEquals(1, response.json()['metadata']['revision'])
-        self.assertEquals("Pick a Number", response.json()['metadata']['name'])
-        self.assertEquals("F", response.json()['flow_type'])
+        self.assertEqual(1, response.json()['metadata']['revision'])
+        self.assertEqual("Pick a Number", response.json()['metadata']['name'])
+        self.assertEqual("F", response.json()['flow_type'])
 
         # make sure the version that is returned increments properly
         flow.update(flow.as_json())
         response = self.fetchJSON(url, "uuid=%s" % flow.uuid)
-        self.assertEquals(2, response.json()['metadata']['revision'])
+        self.assertEqual(2, response.json()['metadata']['revision'])
 
     def test_api_steps_empty(self):
         url = reverse('api.v1.steps')
@@ -792,19 +792,19 @@ class APITest(TembaTest):
             # this version doesn't have our node
             data['revision'] = 3
             response = self.postJSON(url, data)
-            self.assertEquals(400, response.status_code)
+            self.assertEqual(400, response.status_code)
             self.assertResponseError(response, 'non_field_errors', "No such node with UUID %s in flow 'Color Flow'" % new_node_uuid)
 
             # this version doesn't exist
             data['revision'] = 12
             response = self.postJSON(url, data)
-            self.assertEquals(400, response.status_code)
+            self.assertEqual(400, response.status_code)
             self.assertResponseError(response, 'non_field_errors', "Invalid revision: 12")
 
             # this one exists and has our node
             data['revision'] = 2
             response = self.postJSON(url, data)
-            self.assertEquals(201, response.status_code)
+            self.assertEqual(201, response.status_code)
             self.assertIsNotNone(self.joe.urns.filter(path='+13605551212').first())
 
             # submitted_by is optional
@@ -814,7 +814,7 @@ class APITest(TembaTest):
             del data['revision']
             data['version'] = 2
             response = self.postJSON(url, data)
-            self.assertEquals(201, response.status_code)
+            self.assertEqual(201, response.status_code)
             self.assertIsNotNone(self.joe.urns.filter(path='+13605551212').first())
 
             # rule uuid not existing we should find the actual matching rule
@@ -845,7 +845,7 @@ class APITest(TembaTest):
                         completed=True)
 
             response = self.postJSON(url, data)
-            self.assertEquals(201, response.status_code)
+            self.assertEqual(201, response.status_code)
 
             with patch('temba.flows.models.RuleSet.find_matching_rule') as mock_find_matching_rule:
                 mock_find_matching_rule.return_value = None, None
@@ -879,11 +879,11 @@ class APITest(TembaTest):
 
         # Invalid data
         response = self.postJSON(url, ['tel:+250788123123'])
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # add a contact using deprecated phone field
         response = self.postJSON(url, dict(name='Snoop Dog', phone='+250788123123'))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         # should be one contact now
         contact = Contact.objects.get()
@@ -892,9 +892,9 @@ class APITest(TembaTest):
         self.assertContains(response, contact.uuid, status_code=201)
 
         # and that the contact fields were properly set
-        self.assertEquals("+250788123123", contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals("Snoop Dog", contact.name)
-        self.assertEquals(self.org, contact.org)
+        self.assertEqual("+250788123123", contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual("Snoop Dog", contact.name)
+        self.assertEqual(self.org, contact.org)
 
         Contact.objects.all().delete()
 
@@ -903,42 +903,42 @@ class APITest(TembaTest):
 
         contact = Contact.objects.get()
 
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
         self.assertContains(response, contact.uuid, status_code=201)
 
-        self.assertEquals("+250788123456", contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals("snoop", contact.get_urn(TWITTER_SCHEME).path)
-        self.assertEquals("Snoop Dog", contact.name)
-        self.assertEquals(None, contact.language)
-        self.assertEquals(self.org, contact.org)
+        self.assertEqual("+250788123456", contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual("snoop", contact.get_urn(TWITTER_SCHEME).path)
+        self.assertEqual("Snoop Dog", contact.name)
+        self.assertEqual(None, contact.language)
+        self.assertEqual(self.org, contact.org)
 
         # try to update the language to something longer than 3-letters
         response = self.postJSON(url, dict(name='Snoop Dog', urns=['tel:+250788123456'], language='ENGRISH'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'language', "Ensure this field has no more than 3 characters.")
 
         # try to update the language to something shorter than 3-letters
         response = self.postJSON(url, dict(name='Snoop Dog', urns=['tel:+250788123456'], language='X'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'language', "Ensure this field has at least 3 characters.")
 
         # now try 'eng' for English
         response = self.postJSON(url, dict(name='Snoop Dog', urns=['tel:+250788123456'], language='eng'))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         contact = Contact.objects.get()
-        self.assertEquals('eng', contact.language)
+        self.assertEqual('eng', contact.language)
 
         # update the contact using deprecated phone field
         response = self.postJSON(url, dict(name='Eminem', phone='+250788123456'))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         contact = Contact.objects.get()
-        self.assertEquals("+250788123456", contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals("snoop", contact.get_urn(TWITTER_SCHEME).path)
-        self.assertEquals("Eminem", contact.name)
-        self.assertEquals('eng', contact.language)
-        self.assertEquals(self.org, contact.org)
+        self.assertEqual("+250788123456", contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual("snoop", contact.get_urn(TWITTER_SCHEME).path)
+        self.assertEqual("Eminem", contact.name)
+        self.assertEqual('eng', contact.language)
+        self.assertEqual(self.org, contact.org)
 
         # try to update with an unparseable phone number
         response = self.postJSON(url, dict(name='Eminem', phone='nope'))
@@ -954,31 +954,31 @@ class APITest(TembaTest):
 
         # clearing the contact name is allowed
         response = self.postJSON(url, dict(name="", uuid=contact.uuid))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
         contact = Contact.objects.get()
         self.assertIsNone(contact.name)
 
         # update the contact using uuid, URNs will remain the same
         response = self.postJSON(url, dict(name="Mathers", uuid=contact.uuid))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         contact = Contact.objects.get()
-        self.assertEquals("+250788123456", contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals("snoop", contact.get_urn(TWITTER_SCHEME).path)
-        self.assertEquals("Mathers", contact.name)
-        self.assertEquals('eng', contact.language)
-        self.assertEquals(self.org, contact.org)
+        self.assertEqual("+250788123456", contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual("snoop", contact.get_urn(TWITTER_SCHEME).path)
+        self.assertEqual("Mathers", contact.name)
+        self.assertEqual('eng', contact.language)
+        self.assertEqual(self.org, contact.org)
 
         # update the contact using uuid, this time change the urns to just the phone number
         response = self.postJSON(url, dict(name="Mathers", uuid=contact.uuid, urns=['tel:+250788123456']))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         contact = Contact.objects.get()
-        self.assertEquals("+250788123456", contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual("+250788123456", contact.get_urn(TEL_SCHEME).path)
         self.assertFalse(contact.get_urn(TWITTER_SCHEME))
-        self.assertEquals("Mathers", contact.name)
-        self.assertEquals('eng', contact.language)
-        self.assertEquals(self.org, contact.org)
+        self.assertEqual("Mathers", contact.name)
+        self.assertEqual('eng', contact.language)
+        self.assertEqual(self.org, contact.org)
 
         # try to update a contact using an invalid UUID
         response = self.postJSON(url, dict(name="Mathers", uuid='nope', urns=['tel:+250788123456']))
@@ -991,10 +991,10 @@ class APITest(TembaTest):
         with AnonymousOrg(self.org):
             # anon orgs can update contacts by uuid
             response = self.postJSON(url, dict(name="Anon", uuid=contact.uuid))
-            self.assertEquals(201, response.status_code)
+            self.assertEqual(201, response.status_code)
 
             contact = Contact.objects.get()
-            self.assertEquals("Anon", contact.name)
+            self.assertEqual("Anon", contact.name)
 
             # but can't update phone
             response = self.postJSON(url, dict(name="Anon", uuid=contact.uuid, phone='+250788123456'))
@@ -1006,20 +1006,20 @@ class APITest(TembaTest):
 
         # finally try clearing our language
         response = self.postJSON(url, dict(phone='+250788123456', language=None))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         contact = Contact.objects.get()
-        self.assertEquals(None, contact.language)
+        self.assertEqual(None, contact.language)
 
         # update the contact using urns field, matching on one URN, adding another
         response = self.postJSON(url, dict(name='Dr Dre', urns=['tel:+250788123456', 'twitter:drdre'], language='eng'))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         contact = Contact.objects.get()
         contact_urns = [six.text_type(urn) for urn in contact.urns.all().order_by('scheme', 'path')]
-        self.assertEquals(["tel:+250788123456", "twitter:drdre"], contact_urns)
-        self.assertEquals("Dr Dre", contact.name)
-        self.assertEquals(self.org, contact.org)
+        self.assertEqual(["tel:+250788123456", "twitter:drdre"], contact_urns)
+        self.assertEqual("Dr Dre", contact.name)
+        self.assertEqual(self.org, contact.org)
 
         # try to update the contact with and un-parseable urn
         response = self.postJSON(url, dict(name='Dr Dre', urns=['tel250788123456']))
@@ -1036,29 +1036,29 @@ class APITest(TembaTest):
         # add contact to a new group by name
         response = self.postJSON(url, dict(phone='+250788123456', groups=["Music Artists"]))
         artists = ContactGroup.user_groups.get(name="Music Artists")
-        self.assertEquals(201, response.status_code)
-        self.assertEquals("Music Artists", artists.name)
+        self.assertEqual(201, response.status_code)
+        self.assertEqual("Music Artists", artists.name)
         self.assertEqual(1, artists.contacts.count())
         self.assertEqual(1, artists.get_member_count())  # check trigger-based count
 
         # remove contact from a group by name
         response = self.postJSON(url, dict(phone='+250788123456', groups=[]))
         artists = ContactGroup.user_groups.get(name="Music Artists")
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
         self.assertEqual(0, artists.contacts.count())
         self.assertEqual(0, artists.get_member_count())
 
         # add contact to a existing group by UUID
         response = self.postJSON(url, dict(phone='+250788123456', group_uuids=[artists.uuid]))
         artists = ContactGroup.user_groups.get(name="Music Artists")
-        self.assertEquals(201, response.status_code)
-        self.assertEquals("Music Artists", artists.name)
+        self.assertEqual(201, response.status_code)
+        self.assertEqual("Music Artists", artists.name)
         self.assertEqual(1, artists.contacts.count())
         self.assertEqual(1, artists.get_member_count())
 
         # specifying both groups and group_uuids should return error
         response = self.postJSON(url, dict(phone='+250788123456', groups=[artists.name], group_uuids=[artists.uuid]))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # specifying invalid group_uuid should return error
         response = self.postJSON(url, dict(phone='+250788123456', group_uuids=['nope']))
@@ -1075,42 +1075,42 @@ class APITest(TembaTest):
 
         # try updating with a reserved word field
         response = self.postJSON(url, dict(phone='+250788123456', fields={"email": "andy@example.com"}))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'fields', "Invalid contact field key: 'email' is a reserved word")
 
         # try updating a non-existent field
         response = self.postJSON(url, dict(phone='+250788123456', fields={"real_name": "Andy"}))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
         self.assertIsNotNone(contact.get_field('real_name'))
-        self.assertEquals("Andy", contact.get_field_display("real_name"))
+        self.assertEqual("Andy", contact.get_field_display("real_name"))
 
         # create field and try again
         ContactField.get_or_create(self.org, self.user, 'real_name', "Real Name", value_type='T')
         response = self.postJSON(url, dict(phone='+250788123456', fields={"real_name": "Andy"}))
         contact = Contact.objects.get()
         self.assertContains(response, "Andy", status_code=201)
-        self.assertEquals("Andy", contact.get_field_display("real_name"))
+        self.assertEqual("Andy", contact.get_field_display("real_name"))
 
         # update field via label (deprecated but allowed)
         response = self.postJSON(url, dict(phone='+250788123456', fields={"Real Name": "Andre"}))
         contact = Contact.objects.get()
         self.assertContains(response, "Andre", status_code=201)
-        self.assertEquals("Andre", contact.get_field_display("real_name"))
+        self.assertEqual("Andre", contact.get_field_display("real_name"))
 
         # try when contact field have same key and label
         state = ContactField.get_or_create(self.org, self.user, 'state', "state", value_type='T')
         response = self.postJSON(url, dict(phone='+250788123456', fields={"state": "IL"}))
         self.assertContains(response, "IL", status_code=201)
         contact = Contact.objects.get()
-        self.assertEquals("IL", contact.get_field_display("state"))
-        self.assertEquals("Andre", contact.get_field_display("real_name"))
+        self.assertEqual("IL", contact.get_field_display("state"))
+        self.assertEqual("Andre", contact.get_field_display("real_name"))
 
         # try when contact field is not active
         state.is_active = False
         state.save()
         response = self.postJSON(url, dict(phone='+250788123456', fields={"state": "VA"}))
         self.assertEqual(response.status_code, 201)
-        self.assertEquals("VA", Value.objects.get(contact=contact, contact_field=state).string_value)   # unchanged
+        self.assertEqual("VA", Value.objects.get(contact=contact, contact_field=state).string_value)   # unchanged
 
         drdre = Contact.objects.get()
 
@@ -1134,7 +1134,7 @@ class APITest(TembaTest):
         # fetch all with blank query
         self.clear_cache()
         response = self.fetchJSON(url, "")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         resp_json = response.json()
         self.assertEqual(len(resp_json['results']), 2)
@@ -1234,11 +1234,11 @@ class APITest(TembaTest):
         # check fetching deleted contacts
         drdre.release(self.user)
         response = self.fetchJSON(url, "deleted=true")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertEqual(len(response.json()['results']), 1)
 
         resp_json = response.json()
-        self.assertEquals(resp_json['results'][0]['uuid'], drdre.uuid)
+        self.assertEqual(resp_json['results'][0]['uuid'], drdre.uuid)
         self.assertIsNone(resp_json['results'][0]['name'])
         self.assertFalse(resp_json['results'][0]['urns'])
         self.assertFalse(resp_json['results'][0]['fields'])
@@ -1250,21 +1250,21 @@ class APITest(TembaTest):
         # add a naked contact
         response = self.postJSON(url, dict())
         self.assertIsNotNone(response.json()['uuid'])
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         # create a contact with an email urn
         response = self.postJSON(url, dict(name='Snoop Dogg', urns=['mailto:snoop@foshizzle.com']))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         # lookup that contact from an urn
         contact = Contact.from_urn(self.org, "mailto:snoop@foshizzle.com")
-        self.assertEquals('Snoop', contact.first_name(self.org))
+        self.assertEqual('Snoop', contact.first_name(self.org))
 
         # find it via the api
         response = self.fetchJSON(url, 'urns=%s' % (urlquote_plus("mailto:snoop@foshizzle.com")))
         self.assertResultCount(response, 1)
         results = response.json()['results']
-        self.assertEquals('Snoop Dogg', results[0]['name'])
+        self.assertEqual('Snoop Dogg', results[0]['name'])
 
         # add two existing contacts
         self.create_contact("Zinedine", number="+250788111222")
@@ -1342,59 +1342,59 @@ class APITest(TembaTest):
 
         # add a field
         response = self.postJSON(url, dict(label='Real Age', value_type='T'))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         # should be one field now
         field = ContactField.objects.get()
-        self.assertEquals('Real Age', field.label)
-        self.assertEquals('T', field.value_type)
-        self.assertEquals('real_age', field.key)
-        self.assertEquals(self.org, field.org)
+        self.assertEqual('Real Age', field.label)
+        self.assertEqual('T', field.value_type)
+        self.assertEqual('real_age', field.key)
+        self.assertEqual(self.org, field.org)
 
         # update that field to change value type
         response = self.postJSON(url, dict(key='real_age', label='Actual Age', value_type='N'))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
         field = ContactField.objects.get()
-        self.assertEquals('Actual Age', field.label)
-        self.assertEquals('N', field.value_type)
-        self.assertEquals('real_age', field.key)
-        self.assertEquals(self.org, field.org)
+        self.assertEqual('Actual Age', field.label)
+        self.assertEqual('N', field.value_type)
+        self.assertEqual('real_age', field.key)
+        self.assertEqual(self.org, field.org)
 
         # update with invalid value type
         response = self.postJSON(url, dict(key='real_age', value_type='X'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'value_type', "Invalid field value type")
 
         # update without label
         response = self.postJSON(url, dict(key='real_age', value_type='N'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'label', "This field is required.")
 
         # update without value type
         response = self.postJSON(url, dict(key='real_age', label='Actual Age'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'value_type', "This field is required.")
 
         # create with invalid label
         response = self.postJSON(url, dict(label='!@#', value_type='T'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'label', "Field can only contain letters, numbers and hypens")
 
         # create with label that would be an invalid key
         response = self.postJSON(url, dict(label='Name', value_type='T'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'non_field_errors', "Generated key for 'Name' is invalid or a reserved name")
 
         # create with key specified
         response = self.postJSON(url, dict(key='real_age_2', label="Actual Age 2", value_type='N'))
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
         field = ContactField.objects.get(key='real_age_2')
         self.assertEqual(field.label, "Actual Age 2")
         self.assertEqual(field.value_type, 'N')
 
         # create with invalid key specified
         response = self.postJSON(url, dict(key='name', label='Real Name', value_type='T'))
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertResponseError(response, 'key', "Field is invalid or a reserved name")
 
         ContactField.objects.all().delete()

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -328,19 +328,19 @@ class APITest(TembaTest):
         url = reverse('api.v2.explorer')
 
         response = self.fetchHTML(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertContains(response, "Log in to use the Explorer")
 
         # login as non-org user
         self.login(self.non_org_user)
         response = self.fetchHTML(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertContains(response, "Log in to use the Explorer")
 
         # login as administrator
         self.login(self.admin)
         response = self.fetchHTML(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertNotContains(response, "Log in to use the Explorer")
 
     def test_pagination(self):

--- a/temba/assets/tests.py
+++ b/temba/assets/tests.py
@@ -74,10 +74,10 @@ class AssetTest(TembaTest):
         # as this asset belongs to org #1, request will have that context
         response = self.client.get(reverse('assets.download',
                                            kwargs=dict(type='message_export', pk=message_export_task.pk)))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         user = response.context_data['view'].request.user
-        self.assertEquals(user, self.admin)
-        self.assertEquals(user.get_org(), self.org)
+        self.assertEqual(user, self.admin)
+        self.assertEqual(user.get_org(), self.org)
 
     def test_stream(self):
         # create a message export

--- a/temba/campaigns/tests.py
+++ b/temba/campaigns/tests.py
@@ -78,11 +78,11 @@ class CampaignTest(TembaTest):
         event4 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, self.planting_date,
                                                  offset=2, unit='W', flow=flow, delivery_hour='5')
 
-        self.assertEquals(flow.version_number, 3)
+        self.assertEqual(flow.version_number, 3)
         self.assertEqual(campaign.get_sorted_events(), [event2, event1, event3, event4])
         flow.refresh_from_db()
-        self.assertNotEquals(flow.version_number, 3)
-        self.assertEquals(flow.version_number, CURRENT_EXPORT_VERSION)
+        self.assertNotEqual(flow.version_number, 3)
+        self.assertEqual(flow.version_number, CURRENT_EXPORT_VERSION)
 
     def test_message_event(self):
         # update the planting date for our contacts
@@ -144,7 +144,7 @@ class CampaignTest(TembaTest):
         # should have one event, which created a corresponding flow
         event = CampaignEvent.objects.get()
         flow = event.flow
-        self.assertEquals(Flow.MESSAGE, flow.flow_type)
+        self.assertEqual(Flow.MESSAGE, flow.flow_type)
 
         entry = ActionSet.objects.filter(uuid=flow.entry_uuid)[0]
         msg = entry.get_actions()[0].msg
@@ -214,7 +214,7 @@ class CampaignTest(TembaTest):
 
         # go to to the creation page
         response = self.client.get(reverse('campaigns.campaign_create'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = dict(name="Planting Reminders", group=self.farmers.pk)
         response = self.client.post(reverse('campaigns.campaign_create'), post_data)
@@ -280,7 +280,7 @@ class CampaignTest(TembaTest):
         response = self.client.get(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk)
         self.assertContains(response, self.reminder_flow.name)
         self.assertContains(response, self.voice_flow.name)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = dict(relative_to=self.planting_date.pk, delivery_hour=-1, base='', direction='A', offset=2, unit='D', event_type='M', flow_to_start=self.reminder_flow.pk)
         response = self.client.post(reverse('campaigns.campaignevent_create') + "?campaign=%d" % campaign.pk, post_data)
@@ -310,9 +310,9 @@ class CampaignTest(TembaTest):
 
         # should now have a campaign event
         event = CampaignEvent.objects.get()
-        self.assertEquals(self.reminder_flow, event.flow)
-        self.assertEquals(self.planting_date, event.relative_to)
-        self.assertEquals(2, event.offset)
+        self.assertEqual(self.reminder_flow, event.flow)
+        self.assertEqual(self.planting_date, event.relative_to)
+        self.assertEqual(2, event.offset)
 
         # read the campaign read page
         response = self.client.get(reverse('campaigns.campaign_read', args=[campaign.pk]))
@@ -325,12 +325,12 @@ class CampaignTest(TembaTest):
 
         # should also have event fires scheduled for our contacts
         fire = EventFire.objects.get()
-        self.assertEquals(scheduled_date.hour, fire.scheduled.hour)
-        self.assertEquals(scheduled_date.minute, fire.scheduled.minute)
-        self.assertEquals(scheduled_date.day, fire.scheduled.day)
-        self.assertEquals(scheduled_date.month, fire.scheduled.month)
-        self.assertEquals(scheduled_date.year, fire.scheduled.year)
-        self.assertEquals(event, fire.event)
+        self.assertEqual(scheduled_date.hour, fire.scheduled.hour)
+        self.assertEqual(scheduled_date.minute, fire.scheduled.minute)
+        self.assertEqual(scheduled_date.day, fire.scheduled.day)
+        self.assertEqual(scheduled_date.month, fire.scheduled.month)
+        self.assertEqual(scheduled_date.year, fire.scheduled.year)
+        self.assertEqual(event, fire.event)
 
         post_data = dict(relative_to=self.planting_date.pk, delivery_hour=15, base='', direction='A', offset=1, unit='D', event_type='F', flow_to_start=self.reminder_flow.pk)
         response = self.client.post(reverse('campaigns.campaignevent_update', args=[event.pk]), post_data)
@@ -340,20 +340,20 @@ class CampaignTest(TembaTest):
 
         # should now have update the campaign event
         event = CampaignEvent.objects.get()
-        self.assertEquals(self.reminder_flow, event.flow)
-        self.assertEquals(self.planting_date, event.relative_to)
-        self.assertEquals(1, event.offset)
+        self.assertEqual(self.reminder_flow, event.flow)
+        self.assertEqual(self.planting_date, event.relative_to)
+        self.assertEqual(1, event.offset)
 
         # should also event fires rescheduled for our contacts
         fire = EventFire.objects.get()
-        self.assertEquals(13, fire.scheduled.hour)
-        self.assertEquals(0, fire.scheduled.minute)
-        self.assertEquals(0, fire.scheduled.second)
-        self.assertEquals(0, fire.scheduled.microsecond)
-        self.assertEquals(2, fire.scheduled.day)
-        self.assertEquals(10, fire.scheduled.month)
-        self.assertEquals(2020, fire.scheduled.year)
-        self.assertEquals(event, fire.event)
+        self.assertEqual(13, fire.scheduled.hour)
+        self.assertEqual(0, fire.scheduled.minute)
+        self.assertEqual(0, fire.scheduled.second)
+        self.assertEqual(0, fire.scheduled.microsecond)
+        self.assertEqual(2, fire.scheduled.day)
+        self.assertEqual(10, fire.scheduled.month)
+        self.assertEqual(2020, fire.scheduled.year)
+        self.assertEqual(event, fire.event)
 
         post_data = dict(relative_to=self.planting_date.pk, delivery_hour=15, base='', direction='A', offset=2,
                          unit='D', event_type='F', flow_to_start=self.reminder2_flow.pk)
@@ -392,35 +392,35 @@ class CampaignTest(TembaTest):
 
         # should have two fire events now
         fires = EventFire.objects.all()
-        self.assertEquals(2, len(fires))
+        self.assertEqual(2, len(fires))
 
         fire = fires[0]
-        self.assertEquals(2, fire.scheduled.day)
-        self.assertEquals(10, fire.scheduled.month)
-        self.assertEquals(2020, fire.scheduled.year)
-        self.assertEquals(event, fire.event)
+        self.assertEqual(2, fire.scheduled.day)
+        self.assertEqual(10, fire.scheduled.month)
+        self.assertEqual(2020, fire.scheduled.year)
+        self.assertEqual(event, fire.event)
 
         fire = fires[1]
-        self.assertEquals(2, fire.scheduled.day)
-        self.assertEquals(6, fire.scheduled.month)
-        self.assertEquals(2022, fire.scheduled.year)
-        self.assertEquals(event, fire.event)
+        self.assertEqual(2, fire.scheduled.day)
+        self.assertEqual(6, fire.scheduled.month)
+        self.assertEqual(2022, fire.scheduled.year)
+        self.assertEqual(event, fire.event)
 
         # setting a planting date on our outside contact has no effect
         self.nonfarmer.set_field(self.user, 'planting_date', '1/7/2025')
-        self.assertEquals(2, EventFire.objects.all().count())
+        self.assertEqual(2, EventFire.objects.all().count())
 
         # remove one of the farmers from the group
         response = self.client.post(reverse('contacts.contact_read', args=[self.farmer1.uuid]),
                                     dict(contact=self.farmer1.pk, group=self.farmers.pk))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # should only be one event now (on farmer 2)
         fire = EventFire.objects.get()
-        self.assertEquals(2, fire.scheduled.day)
-        self.assertEquals(6, fire.scheduled.month)
-        self.assertEquals(2022, fire.scheduled.year)
-        self.assertEquals(event, fire.event)
+        self.assertEqual(2, fire.scheduled.day)
+        self.assertEqual(6, fire.scheduled.month)
+        self.assertEqual(2022, fire.scheduled.year)
+        self.assertEqual(event, fire.event)
 
         # but if we add him back in, should be updated
         post_data = dict(name=self.farmer1.name,
@@ -434,22 +434,22 @@ class CampaignTest(TembaTest):
         self.assertRedirect(response, reverse('contacts.contact_read', args=[self.farmer1.uuid]))
 
         fires = EventFire.objects.all()
-        self.assertEquals(2, len(fires))
+        self.assertEqual(2, len(fires))
 
         fire = fires[0]
-        self.assertEquals(5, fire.scheduled.day)
-        self.assertEquals(8, fire.scheduled.month)
-        self.assertEquals(2020, fire.scheduled.year)
-        self.assertEquals(event, fire.event)
-        self.assertEquals(str(fire), "%s - %s" % (fire.event, fire.contact))
+        self.assertEqual(5, fire.scheduled.day)
+        self.assertEqual(8, fire.scheduled.month)
+        self.assertEqual(2020, fire.scheduled.year)
+        self.assertEqual(event, fire.event)
+        self.assertEqual(str(fire), "%s - %s" % (fire.event, fire.contact))
 
         event = CampaignEvent.objects.get()
 
         # get the detail page of the event
         response = self.client.get(reverse('campaigns.campaignevent_read', args=[event.pk]))
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.context['scheduled_event_fires_count'], 0)
-        self.assertEquals(len(response.context['scheduled_event_fires']), 2)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.context['scheduled_event_fires_count'], 0)
+        self.assertEqual(len(response.context['scheduled_event_fires']), 2)
 
         # delete an event
         self.client.post(reverse('campaigns.campaignevent_delete', args=[event.pk]), dict())
@@ -464,26 +464,26 @@ class CampaignTest(TembaTest):
         planting_reminder = CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
                                                             offset=3, unit='D', flow=self.reminder_flow)
 
-        self.assertEquals(0, EventFire.objects.all().count())
+        self.assertEqual(0, EventFire.objects.all().count())
         self.farmer1.set_field(self.user, 'planting_date', "10-05-2020 12:30:10")
         self.farmer2.set_field(self.user, 'planting_date', "15-05-2020 12:30:10")
 
         # now we have event fires accordingly
-        self.assertEquals(2, EventFire.objects.all().count())
+        self.assertEqual(2, EventFire.objects.all().count())
 
         # farmer one fire
         scheduled = EventFire.objects.get(contact=self.farmer1, event=planting_reminder).scheduled
-        self.assertEquals("13-5-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+        self.assertEqual("13-5-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
 
         # farmer two fire
         scheduled = EventFire.objects.get(contact=self.farmer2, event=planting_reminder).scheduled
-        self.assertEquals("18-5-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+        self.assertEqual("18-5-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
 
         # delete our farmers group
         self.farmers.release()
 
         # this should have removed all the event fires for that group
-        self.assertEquals(0, EventFire.objects.filter(event=planting_reminder).count())
+        self.assertEqual(0, EventFire.objects.filter(event=planting_reminder).count())
 
         # and our group is no longer active
         self.assertFalse(campaign.group.is_active)
@@ -506,10 +506,10 @@ class CampaignTest(TembaTest):
         self.farmer2 = Contact.objects.get(pk=self.farmer2.pk)
 
         planting = self.farmer1.get_field('planting_date').datetime_value
-        self.assertEquals("10-8-2020", "%s-%s-%s" % (planting.day, planting.month, planting.year))
+        self.assertEqual("10-8-2020", "%s-%s-%s" % (planting.day, planting.month, planting.year))
 
         planting = self.farmer2.get_field('planting_date').datetime_value
-        self.assertEquals("15-8-2020", "%s-%s-%s" % (planting.day, planting.month, planting.year))
+        self.assertEqual("15-8-2020", "%s-%s-%s" % (planting.day, planting.month, planting.year))
 
         # now update the campaign
         from temba.contacts.models import ContactGroup
@@ -519,15 +519,15 @@ class CampaignTest(TembaTest):
         self.client.post(reverse('campaigns.campaign_update', args=[campaign.pk]), post_data)
 
         # should have two fresh new fires
-        self.assertEquals(2, EventFire.objects.all().count())
+        self.assertEqual(2, EventFire.objects.all().count())
 
         # check their new planting dates
         scheduled = EventFire.objects.get(contact=self.farmer1, event=planting_reminder).scheduled
-        self.assertEquals("13-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+        self.assertEqual("13-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
 
         # farmer two fire
         scheduled = EventFire.objects.get(contact=self.farmer2, event=planting_reminder).scheduled
-        self.assertEquals("18-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
+        self.assertEqual("18-8-2020", "%s-%s-%s" % (scheduled.day, scheduled.month, scheduled.year))
 
         # give our non farmer a planting date
         self.nonfarmer.set_field(self.user, 'planting_date', "20-05-2020 12:30:10")
@@ -538,8 +538,8 @@ class CampaignTest(TembaTest):
         self.client.post(reverse('campaigns.campaign_update', args=[campaign.pk]), post_data)
 
         # only one fire for the non-farmer the previous two should be deleted by the group change
-        self.assertEquals(1, EventFire.objects.all().count())
-        self.assertEquals(1, EventFire.objects.filter(contact=self.nonfarmer).count())
+        self.assertEqual(1, EventFire.objects.all().count())
+        self.assertEqual(1, EventFire.objects.filter(contact=self.nonfarmer).count())
 
     def test_dst_scheduling(self):
         # set our timezone to something that honors DST
@@ -558,9 +558,9 @@ class CampaignTest(TembaTest):
 
         # we should be scheduled to go off on the 5th at 12:30:10 Eastern
         fire = EventFire.objects.get()
-        self.assertEquals(5, fire.scheduled.day)
-        self.assertEquals(11, fire.scheduled.month)
-        self.assertEquals(2029, fire.scheduled.year)
+        self.assertEqual(5, fire.scheduled.day)
+        self.assertEqual(11, fire.scheduled.month)
+        self.assertEqual(2029, fire.scheduled.year)
         self.assertEqual(12, fire.scheduled.astimezone(eastern).hour)
 
         # assert our offsets are different (we crossed DST)
@@ -576,9 +576,9 @@ class CampaignTest(TembaTest):
         EventFire.update_campaign_events(campaign)
 
         fire = EventFire.objects.get()
-        self.assertEquals(12, fire.scheduled.day)
-        self.assertEquals(3, fire.scheduled.month)
-        self.assertEquals(2029, fire.scheduled.year)
+        self.assertEqual(12, fire.scheduled.day)
+        self.assertEqual(3, fire.scheduled.month)
+        self.assertEqual(2029, fire.scheduled.year)
         self.assertEqual(2, fire.scheduled.astimezone(eastern).hour)
 
         # assert our offsets changed (we crossed DST)
@@ -591,19 +591,19 @@ class CampaignTest(TembaTest):
 
     def test_scheduling(self):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)
-        self.assertEquals("Planting Reminders", six.text_type(campaign))
+        self.assertEqual("Planting Reminders", six.text_type(campaign))
 
         # create a reminder for our first planting event
         planting_reminder = CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
                                                             offset=0, unit='D', flow=self.reminder_flow, delivery_hour=17)
 
-        self.assertEquals("Planting Date == 0 -> Reminder Flow", six.text_type(planting_reminder))
+        self.assertEqual("Planting Date == 0 -> Reminder Flow", six.text_type(planting_reminder))
 
         # schedule our reminders
         EventFire.update_campaign_events(campaign)
 
         # we should haven't any event fires created, since neither of our farmers have a planting date
-        self.assertEquals(0, EventFire.objects.all().count())
+        self.assertEqual(0, EventFire.objects.all().count())
 
         # ok, set a planting date on one of our contacts
         self.farmer1.set_field(self.user, 'planting_date', "05-10-2020 12:30:10")
@@ -613,15 +613,15 @@ class CampaignTest(TembaTest):
 
         # should have one event now
         fire = EventFire.objects.get()
-        self.assertEquals(5, fire.scheduled.day)
-        self.assertEquals(10, fire.scheduled.month)
-        self.assertEquals(2020, fire.scheduled.year)
+        self.assertEqual(5, fire.scheduled.day)
+        self.assertEqual(10, fire.scheduled.month)
+        self.assertEqual(2020, fire.scheduled.year)
 
         # account for timezone difference, our org is in UTC+2
-        self.assertEquals(17 - 2, fire.scheduled.hour)
+        self.assertEqual(17 - 2, fire.scheduled.hour)
 
-        self.assertEquals(self.farmer1, fire.contact)
-        self.assertEquals(planting_reminder, fire.event)
+        self.assertEqual(self.farmer1, fire.contact)
+        self.assertEqual(planting_reminder, fire.event)
 
         self.assertIsNone(fire.fired)
 
@@ -630,11 +630,11 @@ class CampaignTest(TembaTest):
 
         EventFire.update_campaign_events_for_contact(campaign, self.farmer1)
         fire = EventFire.objects.get()
-        self.assertEquals(6, fire.scheduled.day)
-        self.assertEquals(10, fire.scheduled.month)
-        self.assertEquals(2020, fire.scheduled.year)
-        self.assertEquals(self.farmer1, fire.contact)
-        self.assertEquals(planting_reminder, fire.event)
+        self.assertEqual(6, fire.scheduled.day)
+        self.assertEqual(10, fire.scheduled.month)
+        self.assertEqual(2020, fire.scheduled.year)
+        self.assertEqual(self.farmer1, fire.contact)
+        self.assertEqual(planting_reminder, fire.event)
 
         # set it to something invalid
         self.farmer1.set_field(self.user, 'planting_date', "what?")
@@ -646,17 +646,17 @@ class CampaignTest(TembaTest):
 
         EventFire.update_campaign_events_for_contact(campaign, self.farmer1)
         fire = EventFire.objects.get()
-        self.assertEquals(7, fire.scheduled.day)
-        self.assertEquals(10, fire.scheduled.month)
-        self.assertEquals(2020, fire.scheduled.year)
-        self.assertEquals(self.farmer1, fire.contact)
-        self.assertEquals(planting_reminder, fire.event)
+        self.assertEqual(7, fire.scheduled.day)
+        self.assertEqual(10, fire.scheduled.month)
+        self.assertEqual(2020, fire.scheduled.year)
+        self.assertEqual(self.farmer1, fire.contact)
+        self.assertEqual(planting_reminder, fire.event)
 
         # create another reminder
         planting_reminder2 = CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=self.planting_date,
                                                              offset=1, unit='D', flow=self.reminder2_flow)
 
-        self.assertEquals(1, planting_reminder2.abs_offset())
+        self.assertEqual(1, planting_reminder2.abs_offset())
 
         # update the campaign
         EventFire.update_campaign_events(campaign)
@@ -664,11 +664,11 @@ class CampaignTest(TembaTest):
         # should have two events now, ordered by date
         events = EventFire.objects.all()
 
-        self.assertEquals(planting_reminder, events[0].event)
-        self.assertEquals(7, events[0].scheduled.day)
+        self.assertEqual(planting_reminder, events[0].event)
+        self.assertEqual(7, events[0].scheduled.day)
 
-        self.assertEquals(planting_reminder2, events[1].event)
-        self.assertEquals(8, events[1].scheduled.day)
+        self.assertEqual(planting_reminder2, events[1].event)
+        self.assertEqual(8, events[1].scheduled.day)
 
         # mark one of the events as inactive
         planting_reminder2.is_active = False
@@ -679,16 +679,16 @@ class CampaignTest(TembaTest):
 
         # back to only one event
         event = EventFire.objects.get()
-        self.assertEquals(planting_reminder, event.event)
-        self.assertEquals(7, event.scheduled.day)
+        self.assertEqual(planting_reminder, event.event)
+        self.assertEqual(7, event.scheduled.day)
 
         # update our date
         self.farmer1.set_field(self.user, 'planting_date', '09-10-2020 12:30')
 
         # should have updated
         event = EventFire.objects.get()
-        self.assertEquals(planting_reminder, event.event)
-        self.assertEquals(9, event.scheduled.day)
+        self.assertEqual(planting_reminder, event.event)
+        self.assertEqual(9, event.scheduled.day)
 
         # let's remove our contact field
         ContactField.hide_field(self.org, self.user, 'planting_date')
@@ -701,8 +701,8 @@ class CampaignTest(TembaTest):
 
         # should be back!
         event = EventFire.objects.get()
-        self.assertEquals(planting_reminder, event.event)
-        self.assertEquals(9, event.scheduled.day)
+        self.assertEqual(planting_reminder, event.event)
+        self.assertEqual(9, event.scheduled.day)
 
         # change our fire date to sometime in the past so it gets triggered
         event.scheduled = timezone.now() - timedelta(hours=1)
@@ -713,7 +713,7 @@ class CampaignTest(TembaTest):
 
         # should have one flow run now
         run = FlowRun.objects.get()
-        self.assertEquals(event.contact, run.contact)
+        self.assertEqual(event.contact, run.contact)
 
     def test_translations(self):
         campaign = Campaign.create(self.org, self.admin, "Planting Reminders", self.farmers)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -102,7 +102,7 @@ class ChannelTest(TembaTest):
             return list(msg)
 
     def assertHasCommand(self, cmd_name, response):
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         data = response.json()
 
         for cmd in data['cmds']:
@@ -138,7 +138,7 @@ class ChannelTest(TembaTest):
         self.tel_channel.is_active = False
         self.tel_channel.save()
         response = self.client.get(reverse('channels.channel_read', args=[self.tel_channel.uuid]))
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
     def test_channelog_links(self):
         self.login(self.admin)
@@ -180,8 +180,8 @@ class ChannelTest(TembaTest):
 
         # try adding a caller for an invalid channel
         response = self.client.post('%s?channel=20000' % reverse('channels.channel_create_caller'))
-        self.assertEquals(200, response.status_code)
-        self.assertEquals('Sorry, a caller cannot be added for that number', response.context['form'].errors['channel'][0])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('Sorry, a caller cannot be added for that number', response.context['form'].errors['channel'][0])
 
         # disable our twilio connection
         self.org.remove_twilio_account(self.admin)
@@ -197,12 +197,12 @@ class ChannelTest(TembaTest):
         # shouldn't have added, so no ivr yet
         self.assertFalse(self.assertFalse(self.org.supports_ivr()))
 
-        self.assertEquals('A connection to a Twilio account is required', response.context['form'].errors['connection'][0])
+        self.assertEqual('A connection to a Twilio account is required', response.context['form'].errors['connection'][0])
 
     def test_get_channel_type_name(self):
-        self.assertEquals(self.tel_channel.get_channel_type_name(), "Android Phone")
-        self.assertEquals(self.twitter_channel.get_channel_type_name(), "Twitter Channel")
-        self.assertEquals(self.released_channel.get_channel_type_name(), "Nexmo Channel")
+        self.assertEqual(self.tel_channel.get_channel_type_name(), "Android Phone")
+        self.assertEqual(self.twitter_channel.get_channel_type_name(), "Twitter Channel")
+        self.assertEqual(self.released_channel.get_channel_type_name(), "Nexmo Channel")
 
     def test_channel_selection(self):
         # make our default tel channel MTN
@@ -215,31 +215,31 @@ class ChannelTest(TembaTest):
 
         # new contact on MTN should send with the MTN channel
         msg = self.send_message(['+250788382382'], "Sent to an MTN number")
-        self.assertEquals(mtn, self.org.get_send_channel(contact_urn=msg.contact_urn))
-        self.assertEquals(mtn, msg.channel)
+        self.assertEqual(mtn, self.org.get_send_channel(contact_urn=msg.contact_urn))
+        self.assertEqual(mtn, msg.channel)
 
         # new contact on Tigo should send with the Tigo channel
         msg = self.send_message(['+250728382382'], "Sent to a Tigo number")
-        self.assertEquals(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
-        self.assertEquals(tigo, msg.channel)
+        self.assertEqual(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
+        self.assertEqual(tigo, msg.channel)
 
         # now our MTN contact texts, the tigo number which should change their affinity
         msg = Msg.create_incoming(tigo, "tel:+250788382382", "Send an inbound message to Tigo")
-        self.assertEquals(tigo, msg.channel)
-        self.assertEquals(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
-        self.assertEquals(tigo, ContactURN.objects.get(path='+250788382382').channel)
+        self.assertEqual(tigo, msg.channel)
+        self.assertEqual(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
+        self.assertEqual(tigo, ContactURN.objects.get(path='+250788382382').channel)
 
         # new contact on Airtel (some overlap) should send with the Tigo channel since it is newest
         msg = self.send_message(['+250738382382'], "Sent to a Airtel number")
-        self.assertEquals(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
-        self.assertEquals(tigo, msg.channel)
+        self.assertEqual(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
+        self.assertEqual(tigo, msg.channel)
 
         # add a voice caller
         caller = Channel.add_call_channel(self.org, self.user, self.tel_channel)
 
         # set our affinity to the caller (ie, they were on an ivr call)
         ContactURN.objects.filter(path='+250788382382').update(channel=caller)
-        self.assertEquals(mtn, self.org.get_send_channel(contact_urn=ContactURN.objects.get(path='+250788382382')))
+        self.assertEqual(mtn, self.org.get_send_channel(contact_urn=ContactURN.objects.get(path='+250788382382')))
 
         # change channel numbers to be shortcodes, i.e. no overlap with contact numbers
         mtn.address = '1234'
@@ -249,27 +249,27 @@ class ChannelTest(TembaTest):
 
         # should return the newest channel which is TIGO
         msg = self.send_message(['+250788382382'], "Sent to an MTN number, but with shortcode channels")
-        self.assertEquals(tigo, msg.channel)
-        self.assertEquals(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
+        self.assertEqual(tigo, msg.channel)
+        self.assertEqual(tigo, self.org.get_send_channel(contact_urn=msg.contact_urn))
 
         # if we have prefixes matching set should honor those
         mtn.config = json.dumps({Channel.CONFIG_SHORTCODE_MATCHING_PREFIXES: ['25078', '25072']})
         mtn.save()
 
         msg = self.send_message(['+250788382382'], "Sent to an MTN number with shortcode channels and prefixes set")
-        self.assertEquals(mtn, msg.channel)
-        self.assertEquals(mtn, self.org.get_send_channel(contact_urn=msg.contact_urn))
+        self.assertEqual(mtn, msg.channel)
+        self.assertEqual(mtn, self.org.get_send_channel(contact_urn=msg.contact_urn))
 
         msg = self.send_message(['+250728382382'], "Sent to a TIGO number with shortcode channels and prefixes set")
-        self.assertEquals(mtn, msg.channel)
-        self.assertEquals(mtn, self.org.get_send_channel(contact_urn=msg.contact_urn))
+        self.assertEqual(mtn, msg.channel)
+        self.assertEqual(mtn, self.org.get_send_channel(contact_urn=msg.contact_urn))
 
         # check for twitter
-        self.assertEquals(self.twitter_channel, self.org.get_send_channel(scheme=TWITTER_SCHEME))
+        self.assertEqual(self.twitter_channel, self.org.get_send_channel(scheme=TWITTER_SCHEME))
 
         contact = self.create_contact("Billy", number="+250722222222", twitter="billy_bob")
         twitter_urn = contact.get_urn(schemes=[TWITTER_SCHEME])
-        self.assertEquals(self.twitter_channel, self.org.get_send_channel(contact_urn=twitter_urn))
+        self.assertEqual(self.twitter_channel, self.org.get_send_channel(contact_urn=twitter_urn))
 
     def test_message_splitting(self):
         # external API requires messages to be <= 160 chars
@@ -304,9 +304,9 @@ class ChannelTest(TembaTest):
         norm_c2 = Contact.objects.get(pk=contact2.pk)
         norm_c3 = Contact.objects.get(pk=contact3.pk)
 
-        self.assertEquals(norm_c1.get_urn(TEL_SCHEME).path, "+250788111222")
-        self.assertEquals(norm_c2.get_urn(TEL_SCHEME).path, "+250788333444")
-        self.assertEquals(norm_c3.get_urn(TEL_SCHEME).path, "+18006927753")
+        self.assertEqual(norm_c1.get_urn(TEL_SCHEME).path, "+250788111222")
+        self.assertEqual(norm_c2.get_urn(TEL_SCHEME).path, "+250788333444")
+        self.assertEqual(norm_c3.get_urn(TEL_SCHEME).path, "+18006927753")
 
     def test_channel_create(self):
 
@@ -340,12 +340,12 @@ class ChannelTest(TembaTest):
 
         self.assertEqual(self.org, msg.org)
         self.assertEqual(self.tel_channel, msg.channel)
-        self.assertEquals(1, Msg.get_messages(self.org).count())
-        self.assertEquals(1, ChannelEvent.get_all(self.org).count())
-        self.assertEquals(1, Broadcast.get_broadcasts(self.org).count())
+        self.assertEqual(1, Msg.get_messages(self.org).count())
+        self.assertEqual(1, ChannelEvent.get_all(self.org).count())
+        self.assertEqual(1, Broadcast.get_broadcasts(self.org).count())
 
         # start off in the pending state
-        self.assertEquals('P', msg.status)
+        self.assertEqual('P', msg.status)
 
         response = self.fetch_protected(reverse('channels.channel_delete', args=[self.tel_channel.pk]), self.user)
         self.assertContains(response, 'Test Channel')
@@ -358,25 +358,25 @@ class ChannelTest(TembaTest):
         self.assertIsNotNone(msg.channel)
         self.assertIsNone(msg.channel.gcm_id)
         self.assertIsNone(msg.channel.secret)
-        self.assertEquals(self.org, msg.org)
+        self.assertEqual(self.org, msg.org)
 
         # queued messages for the channel should get marked as failed
-        self.assertEquals('F', msg.status)
+        self.assertEqual('F', msg.status)
 
         call = ChannelEvent.objects.get(pk=call.pk)
         self.assertIsNotNone(call.channel)
         self.assertIsNone(call.channel.gcm_id)
         self.assertIsNone(call.channel.secret)
 
-        self.assertEquals(self.org, call.org)
+        self.assertEqual(self.org, call.org)
 
         broadcast = Broadcast.objects.get(pk=msg.broadcast.pk)
-        self.assertEquals(self.org, broadcast.org)
+        self.assertEqual(self.org, broadcast.org)
 
         # should still be considered that user's message, call and broadcast
-        self.assertEquals(1, Msg.get_messages(self.org).count())
-        self.assertEquals(1, ChannelEvent.get_all(self.org).count())
-        self.assertEquals(1, Broadcast.get_broadcasts(self.org).count())
+        self.assertEqual(1, Msg.get_messages(self.org).count())
+        self.assertEqual(1, ChannelEvent.get_all(self.org).count())
+        self.assertEqual(1, Broadcast.get_broadcasts(self.org).count())
 
         # syncing this channel should result in a release
         post_data = dict(cmds=[dict(cmd="status", p_sts="CHA", p_src="BAT", p_lvl="60", net="UMTS", pending=[], retry=[])])
@@ -545,14 +545,14 @@ class ChannelTest(TembaTest):
 
         other_user.set_org(self.org2)
 
-        self.assertEquals(self.org2, other_user.get_org())
+        self.assertEqual(self.org2, other_user.get_org())
         response = self.client.get('/', follow=True)
         self.assertNotIn('channel_type', response.context, msg="Found channel_type in context")
 
         other_user.set_org(self.org)
 
-        self.assertEquals(1, self.org.channels.filter(is_active=True).count())
-        self.assertEquals(self.org, other_user.get_org())
+        self.assertEqual(1, self.org.channels.filter(is_active=True).count())
+        self.assertEqual(self.org, other_user.get_org())
 
         response = self.client.get('/', follow=True)
         # self.assertIn('channel_type', response.context)
@@ -583,18 +583,18 @@ class ChannelTest(TembaTest):
         self.client.logout()
         self.login(self.user)
         response = self.client.get(update_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         self.login(self.user)
         # visit the channel's update page as a manager within the channel's organization
         self.org.administrators.add(self.user)
         response = self.fetch_protected(update_url, self.user)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], update_url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], update_url)
 
         channel = Channel.objects.get(pk=self.tel_channel.id)
-        self.assertEquals(channel.name, "Test Channel")
-        self.assertEquals(channel.address, "+250785551212")
+        self.assertEqual(channel.name, "Test Channel")
+        self.assertEqual(channel.address, "+250785551212")
 
         postdata = dict()
         postdata['name'] = "Test Channel Update1"
@@ -603,8 +603,8 @@ class ChannelTest(TembaTest):
         self.login(self.user)
         response = self.client.post(update_url, postdata, follow=True)
         channel = Channel.objects.get(pk=self.tel_channel.id)
-        self.assertEquals(channel.name, "Test Channel Update1")
-        self.assertEquals(channel.address, "+250785551313")
+        self.assertEqual(channel.name, "Test Channel Update1")
+        self.assertEqual(channel.address, "+250785551313")
 
         # if we change the channel to a twilio type, shouldn't be able to edit our address
         channel.channel_type = Channel.TYPE_TWILIO
@@ -621,11 +621,11 @@ class ChannelTest(TembaTest):
         self.org.administrators.add(self.user)
         self.user.set_org(self.org)
         response = self.fetch_protected(update_url, self.user)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], update_url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], update_url)
         channel = Channel.objects.get(pk=self.tel_channel.id)
-        self.assertEquals(channel.name, "Test Channel Update1")
-        self.assertEquals(channel.address, "+250785551313")
+        self.assertEqual(channel.name, "Test Channel Update1")
+        self.assertEqual(channel.address, "+250785551313")
 
         postdata = dict()
         postdata['name'] = "Test Channel Update2"
@@ -633,17 +633,17 @@ class ChannelTest(TembaTest):
 
         response = self.fetch_protected(update_url, self.user, postdata)
         channel = Channel.objects.get(pk=self.tel_channel.id)
-        self.assertEquals(channel.name, "Test Channel Update2")
-        self.assertEquals(channel.address, "+250785551414")
+        self.assertEqual(channel.name, "Test Channel Update2")
+        self.assertEqual(channel.address, "+250785551414")
 
         # visit the channel's update page as superuser
         self.superuser.set_org(self.org)
         response = self.fetch_protected(update_url, self.superuser)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], update_url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], update_url)
         channel = Channel.objects.get(pk=self.tel_channel.id)
-        self.assertEquals(channel.name, "Test Channel Update2")
-        self.assertEquals(channel.address, "+250785551414")
+        self.assertEqual(channel.name, "Test Channel Update2")
+        self.assertEqual(channel.address, "+250785551414")
 
         postdata = dict()
         postdata['name'] = "Test Channel Update3"
@@ -651,13 +651,13 @@ class ChannelTest(TembaTest):
 
         response = self.fetch_protected(update_url, self.superuser, postdata)
         channel = Channel.objects.get(pk=self.tel_channel.id)
-        self.assertEquals(channel.name, "Test Channel Update3")
-        self.assertEquals(channel.address, "+250785551515")
+        self.assertEqual(channel.name, "Test Channel Update3")
+        self.assertEqual(channel.address, "+250785551515")
 
         # make sure channel works with alphanumeric numbers
         channel.address = "EATRIGHT"
-        self.assertEquals("EATRIGHT", channel.get_address_display())
-        self.assertEquals("EATRIGHT", channel.get_address_display(e164=True))
+        self.assertEqual("EATRIGHT", channel.get_address_display())
+        self.assertEqual("EATRIGHT", channel.get_address_display(e164=True))
 
         # change channel type to Twitter
         channel.channel_type = 'TT'
@@ -667,11 +667,11 @@ class ChannelTest(TembaTest):
         channel.config = json.dumps({'handle_id': 12345, 'oauth_token': 'abcdef', 'oauth_token_secret': '23456'})
         channel.save()
 
-        self.assertEquals('@billy_bob', channel.get_address_display())
-        self.assertEquals('@billy_bob', channel.get_address_display(e164=True))
+        self.assertEqual('@billy_bob', channel.get_address_display())
+        self.assertEqual('@billy_bob', channel.get_address_display(e164=True))
 
         response = self.fetch_protected(update_url, self.user)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertIn('name', response.context['fields'])
         self.assertIn('alert_email', response.context['fields'])
         self.assertIn('address', response.context['fields'])
@@ -684,9 +684,9 @@ class ChannelTest(TembaTest):
 
         self.fetch_protected(update_url, self.user, postdata)
         channel = Channel.objects.get(pk=self.tel_channel.id)
-        self.assertEquals(channel.name, "Twitter2")
-        self.assertEquals(channel.alert_email, "bob@example.com")
-        self.assertEquals(channel.address, "billy_bob")
+        self.assertEqual(channel.name, "Twitter2")
+        self.assertEqual(channel.alert_email, "bob@example.com")
+        self.assertEqual(channel.address, "billy_bob")
 
     def test_read(self):
         post_data = dict(cmds=[
@@ -703,7 +703,7 @@ class ChannelTest(TembaTest):
 
         # now send the channel's updates
         self.sync(self.tel_channel, post_data)
-        self.assertEquals(2, SyncEvent.objects.all().count())
+        self.assertEqual(2, SyncEvent.objects.all().count())
 
         # non-org users can't view our channels
         self.login(self.non_org_user)
@@ -713,17 +713,17 @@ class ChannelTest(TembaTest):
         # org users can
         response = self.fetch_protected(reverse('channels.channel_read', args=[self.tel_channel.uuid]), self.user)
 
-        self.assertEquals(len(response.context['source_stats']), len(SyncEvent.objects.values_list('power_source', flat=True).distinct()))
-        self.assertEquals('AC', response.context['source_stats'][0][0])
-        self.assertEquals(1, response.context['source_stats'][0][1])
-        self.assertEquals('BAT', response.context['source_stats'][1][0])
-        self.assertEquals(1, response.context['source_stats'][0][1])
+        self.assertEqual(len(response.context['source_stats']), len(SyncEvent.objects.values_list('power_source', flat=True).distinct()))
+        self.assertEqual('AC', response.context['source_stats'][0][0])
+        self.assertEqual(1, response.context['source_stats'][0][1])
+        self.assertEqual('BAT', response.context['source_stats'][1][0])
+        self.assertEqual(1, response.context['source_stats'][0][1])
 
-        self.assertEquals(len(response.context['network_stats']), len(SyncEvent.objects.values_list('network_type', flat=True).distinct()))
-        self.assertEquals('UMTS', response.context['network_stats'][0][0])
-        self.assertEquals(1, response.context['network_stats'][0][1])
-        self.assertEquals('WIFI', response.context['network_stats'][1][0])
-        self.assertEquals(1, response.context['network_stats'][1][1])
+        self.assertEqual(len(response.context['network_stats']), len(SyncEvent.objects.values_list('network_type', flat=True).distinct()))
+        self.assertEqual('UMTS', response.context['network_stats'][0][0])
+        self.assertEqual(1, response.context['network_stats'][0][1])
+        self.assertEqual('WIFI', response.context['network_stats'][1][0])
+        self.assertEqual(1, response.context['network_stats'][1][1])
 
         self.assertTrue(len(response.context['latest_sync_events']) <= 5)
 
@@ -761,44 +761,44 @@ class ChannelTest(TembaTest):
 
         # with superuser
         response = self.fetch_protected(reverse('channels.channel_read', args=[self.tel_channel.uuid]), self.superuser)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # now that we can access the channel, which messages do we display in the chart?
         joe = self.create_contact('Joe', '+2501234567890')
         test_contact = Contact.get_test_contact(self.admin)
 
         # should have two series, one for incoming one for outgoing
-        self.assertEquals(2, len(response.context['message_stats']))
+        self.assertEqual(2, len(response.context['message_stats']))
 
         # but only an outgoing message so far
-        self.assertEquals(0, len(response.context['message_stats'][0]['data']))
-        self.assertEquals(1, response.context['message_stats'][1]['data'][-1]['count'])
+        self.assertEqual(0, len(response.context['message_stats'][0]['data']))
+        self.assertEqual(1, response.context['message_stats'][1]['data'][-1]['count'])
 
         # we have one row for the message stats table
-        self.assertEquals(1, len(response.context['message_stats_table']))
+        self.assertEqual(1, len(response.context['message_stats_table']))
         # only one outgoing message
-        self.assertEquals(0, response.context['message_stats_table'][0]['incoming_messages_count'])
-        self.assertEquals(1, response.context['message_stats_table'][0]['outgoing_messages_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['incoming_messages_count'])
+        self.assertEqual(1, response.context['message_stats_table'][0]['outgoing_messages_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
 
         # send messages with a test contact
         Msg.create_incoming(self.tel_channel, six.text_type(test_contact.get_urn()), 'This incoming message will not be counted')
         Msg.create_outgoing(self.org, self.user, test_contact, 'This outgoing message will not be counted')
 
         response = self.fetch_protected(reverse('channels.channel_read', args=[self.tel_channel.uuid]), self.superuser)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # nothing should change since it's a test contact
-        self.assertEquals(0, len(response.context['message_stats'][0]['data']))
-        self.assertEquals(1, response.context['message_stats'][1]['data'][-1]['count'])
+        self.assertEqual(0, len(response.context['message_stats'][0]['data']))
+        self.assertEqual(1, response.context['message_stats'][1]['data'][-1]['count'])
 
         # no change on the table starts too
-        self.assertEquals(1, len(response.context['message_stats_table']))
-        self.assertEquals(0, response.context['message_stats_table'][0]['incoming_messages_count'])
-        self.assertEquals(1, response.context['message_stats_table'][0]['outgoing_messages_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
+        self.assertEqual(1, len(response.context['message_stats_table']))
+        self.assertEqual(0, response.context['message_stats_table'][0]['incoming_messages_count'])
+        self.assertEqual(1, response.context['message_stats_table'][0]['outgoing_messages_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
 
         # send messages with a normal contact
         Msg.create_incoming(self.tel_channel, six.text_type(joe.get_urn(TEL_SCHEME)), 'This incoming message will be counted')
@@ -806,18 +806,18 @@ class ChannelTest(TembaTest):
 
         # now we have an inbound message and two outbounds
         response = self.fetch_protected(reverse('channels.channel_read', args=[self.tel_channel.uuid]), self.superuser)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(1, response.context['message_stats'][0]['data'][-1]['count'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.context['message_stats'][0]['data'][-1]['count'])
 
         # this assertion is problematic causing time-sensitive failures, to reconsider
-        # self.assertEquals(2, response.context['message_stats'][1]['data'][-1]['count'])
+        # self.assertEqual(2, response.context['message_stats'][1]['data'][-1]['count'])
 
         # message stats table have an inbound and two outbounds in the last month
-        self.assertEquals(1, len(response.context['message_stats_table']))
-        self.assertEquals(1, response.context['message_stats_table'][0]['incoming_messages_count'])
-        self.assertEquals(2, response.context['message_stats_table'][0]['outgoing_messages_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
+        self.assertEqual(1, len(response.context['message_stats_table']))
+        self.assertEqual(1, response.context['message_stats_table'][0]['incoming_messages_count'])
+        self.assertEqual(2, response.context['message_stats_table'][0]['outgoing_messages_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
 
         # test cases for IVR messaging, make our relayer accept calls
         self.tel_channel.role = 'SCAR'
@@ -829,45 +829,45 @@ class ChannelTest(TembaTest):
         response = self.fetch_protected(reverse('channels.channel_read', args=[self.tel_channel.uuid]), self.superuser)
 
         # nothing should have changed
-        self.assertEquals(2, len(response.context['message_stats']))
+        self.assertEqual(2, len(response.context['message_stats']))
 
-        self.assertEquals(1, len(response.context['message_stats_table']))
-        self.assertEquals(1, response.context['message_stats_table'][0]['incoming_messages_count'])
-        self.assertEquals(2, response.context['message_stats_table'][0]['outgoing_messages_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
-        self.assertEquals(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
+        self.assertEqual(1, len(response.context['message_stats_table']))
+        self.assertEqual(1, response.context['message_stats_table'][0]['incoming_messages_count'])
+        self.assertEqual(2, response.context['message_stats_table'][0]['outgoing_messages_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['incoming_ivr_count'])
+        self.assertEqual(0, response.context['message_stats_table'][0]['outgoing_ivr_count'])
 
         # now let's create an ivr interaction from a real contact
         Msg.create_incoming(self.tel_channel, six.text_type(joe.get_urn()), 'incoming ivr', msg_type=IVR)
         Msg.create_outgoing(self.org, self.user, joe, 'outgoing ivr', msg_type=IVR)
         response = self.fetch_protected(reverse('channels.channel_read', args=[self.tel_channel.uuid]), self.superuser)
 
-        self.assertEquals(4, len(response.context['message_stats']))
-        self.assertEquals(1, response.context['message_stats'][2]['data'][0]['count'])
-        self.assertEquals(1, response.context['message_stats'][3]['data'][0]['count'])
+        self.assertEqual(4, len(response.context['message_stats']))
+        self.assertEqual(1, response.context['message_stats'][2]['data'][0]['count'])
+        self.assertEqual(1, response.context['message_stats'][3]['data'][0]['count'])
 
-        self.assertEquals(1, len(response.context['message_stats_table']))
-        self.assertEquals(1, response.context['message_stats_table'][0]['incoming_messages_count'])
-        self.assertEquals(2, response.context['message_stats_table'][0]['outgoing_messages_count'])
-        self.assertEquals(1, response.context['message_stats_table'][0]['incoming_ivr_count'])
-        self.assertEquals(1, response.context['message_stats_table'][0]['outgoing_ivr_count'])
+        self.assertEqual(1, len(response.context['message_stats_table']))
+        self.assertEqual(1, response.context['message_stats_table'][0]['incoming_messages_count'])
+        self.assertEqual(2, response.context['message_stats_table'][0]['outgoing_messages_count'])
+        self.assertEqual(1, response.context['message_stats_table'][0]['incoming_ivr_count'])
+        self.assertEqual(1, response.context['message_stats_table'][0]['outgoing_ivr_count'])
 
     def test_invalid(self):
 
         # Must be POST
         response = self.client.get("%s?signature=sig&ts=123" % (reverse('sync', args=[100])), content_type='application/json')
-        self.assertEquals(500, response.status_code)
+        self.assertEqual(500, response.status_code)
 
         # Unknown channel
         response = self.client.post("%s?signature=sig&ts=123" % (reverse('sync', args=[999])), content_type='application/json')
-        self.assertEquals(200, response.status_code)
-        self.assertEquals('rel', response.json()['cmds'][0]['cmd'])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('rel', response.json()['cmds'][0]['cmd'])
 
         # too old
         ts = int(time.time()) - 60 * 16
         response = self.client.post("%s?signature=sig&ts=%d" % (reverse('sync', args=[self.tel_channel.pk]), ts), content_type='application/json')
-        self.assertEquals(401, response.status_code)
-        self.assertEquals(3, response.json()['error_id'])
+        self.assertEqual(401, response.status_code)
+        self.assertEqual(3, response.json()['error_id'])
 
     def test_is_ussd_channel(self):
         Channel.objects.all().delete()
@@ -1270,8 +1270,8 @@ class ChannelTest(TembaTest):
 
             mock_search.return_value = []
             response = self.client.post(search_url, {'country': 'US', 'area_code': ''})
-            self.assertEquals(json.loads(response.content)['error'],
-                              "Sorry, no numbers found, please enter another area code and try again.")
+            self.assertEqual(json.loads(response.content)['error'],
+                             "Sorry, no numbers found, please enter another area code and try again.")
 
             # try searching for non-US number
             mock_search.return_value = [MockTwilioClient.MockPhoneNumber('+442812345678')]
@@ -1280,8 +1280,8 @@ class ChannelTest(TembaTest):
 
             mock_search.return_value = []
             response = self.client.post(search_url, {'country': 'GB', 'area_code': ''})
-            self.assertEquals(json.loads(response.content)['error'],
-                              "Sorry, no numbers found, please enter another pattern and try again.")
+            self.assertEqual(json.loads(response.content)['error'],
+                             "Sorry, no numbers found, please enter another pattern and try again.")
 
         with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.list') as mock_numbers:
             mock_numbers.return_value = [MockTwilioClient.MockPhoneNumber('+12062345678')]
@@ -1362,7 +1362,7 @@ class ChannelTest(TembaTest):
         # make channel support both sms and voice to check we clear both applications
         twilio_channel.role = Channel.ROLE_SEND + Channel.ROLE_RECEIVE + Channel.ROLE_ANSWER + Channel.ROLE_CALL
         twilio_channel.save()
-        self.assertEquals('T', twilio_channel.channel_type)
+        self.assertEqual('T', twilio_channel.channel_type)
 
         with self.settings(IS_PROD=True):
             with patch('temba.tests.MockTwilioClient.MockPhoneNumbers.update') as mock_numbers:
@@ -1525,7 +1525,7 @@ class ChannelTest(TembaTest):
             post_data = dict(country='US', area_code='360')
             response = self.client.post(search_nexmo_url, post_data, follow=True)
 
-            self.assertEquals(response.json(), ['+1 360-788-4540', '+1 360-788-4550'])
+            self.assertEqual(response.json(), ['+1 360-788-4540', '+1 360-788-4550'])
 
     def test_plivo_search_numbers(self):
         self.login(self.admin)
@@ -1621,11 +1621,11 @@ class ChannelTest(TembaTest):
 
     def test_unclaimed(self):
         response = self.sync(self.released_channel)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         response = response.json()
 
         # should be a registration command containing a new claim code
-        self.assertEquals(response['cmds'][0]['cmd'], 'reg')
+        self.assertEqual(response['cmds'][0]['cmd'], 'reg')
 
         post_data = dict(cmds=[dict(cmd="status",
                                     org_id=self.released_channel.pk,
@@ -1644,7 +1644,7 @@ class ChannelTest(TembaTest):
         response = response.json()
 
         # registration command
-        self.assertEquals(response['cmds'][0]['cmd'], 'reg')
+        self.assertEqual(response['cmds'][0]['cmd'], 'reg')
 
         # claim the channel on the site
         self.released_channel.org = self.org
@@ -1663,7 +1663,7 @@ class ChannelTest(TembaTest):
         response = response.json()
 
         # should now be a claim command in return
-        self.assertEquals(response['cmds'][0]['cmd'], 'claim')
+        self.assertEqual(response['cmds'][0]['cmd'], 'claim')
 
         # now try releasing the channel from the client
         post_data = dict(cmds=[dict(cmd="reset", p_id=1)])
@@ -1682,19 +1682,19 @@ class ChannelTest(TembaTest):
         self.org.save()
         self.org.topups.all().update(credits=10)
 
-        self.assertEquals(10, self.org.get_credits_remaining())
-        self.assertEquals(0, self.org.get_credits_used())
+        self.assertEqual(10, self.org.get_credits_remaining())
+        self.assertEqual(0, self.org.get_credits_used())
 
         # if we sync should get one message back
         self.send_message(['250788382382'], "How is it going?")
 
         response = self.sync(self.tel_channel)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         response = response.json()
         self.assertEqual(1, len(response['cmds']))
 
-        self.assertEquals(9, self.org.get_credits_remaining())
-        self.assertEquals(1, self.org.get_credits_used())
+        self.assertEqual(9, self.org.get_credits_remaining())
+        self.assertEqual(1, self.org.get_credits_used())
 
         # let's create 10 other messages, this will put our last message above our quota
         for i in range(10):
@@ -1702,7 +1702,7 @@ class ChannelTest(TembaTest):
 
         # should get the 10 messages we are allotted back, not the 11 that exist
         response = self.sync(self.tel_channel)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         response = response.json()
         self.assertEqual(10, len(response['cmds']))
 
@@ -1729,7 +1729,7 @@ class ChannelTest(TembaTest):
 
         # Should contain messages for the the channel only
         response = self.sync(self.tel_channel)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.tel_channel.refresh_from_db()
 
@@ -1741,7 +1741,7 @@ class ChannelTest(TembaTest):
 
         # Should contain messages for the the channel only
         response = self.sync(channel2)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         channel2.refresh_from_db()
 
@@ -1773,7 +1773,7 @@ class ChannelTest(TembaTest):
 
         # Check our sync point has all three messages queued for delivery
         response = self.sync(self.tel_channel)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # check last seen and gcm id were updated
         self.tel_channel.refresh_from_db()
@@ -1784,7 +1784,7 @@ class ChannelTest(TembaTest):
 
         # assert that our first command is the two message broadcast
         cmd = cmds[0]
-        self.assertEquals("How is it going?", cmd['msg'])
+        self.assertEqual("How is it going?", cmd['msg'])
         self.assertTrue('+250788382382' in [m['phone'] for m in cmd['to']])
         self.assertTrue('+250788383383' in [m['phone'] for m in cmd['to']])
 
@@ -1847,7 +1847,7 @@ class ChannelTest(TembaTest):
         self.assertTrue(self.tel_channel.last_seen > six_mins_ago)
 
         # new batch, our ack and our claim command for new org
-        self.assertEquals(4, len(response.json()['cmds']))
+        self.assertEqual(4, len(response.json()['cmds']))
         self.assertContains(response, "Hello, we heard from you.")
         self.assertContains(response, "mt_bcast")
 
@@ -1864,12 +1864,12 @@ class ChannelTest(TembaTest):
         self.assertTrue(Msg.objects.filter(direction='I', contact_urn__path='empty'))
 
         # We should now have one sync
-        self.assertEquals(1, SyncEvent.objects.filter(channel=self.tel_channel).count())
+        self.assertEqual(1, SyncEvent.objects.filter(channel=self.tel_channel).count())
 
         # check our channel gcm and uuid were updated
         self.tel_channel = Channel.objects.get(pk=self.tel_channel.pk)
-        self.assertEquals('12345', self.tel_channel.gcm_id)
-        self.assertEquals('abcde', self.tel_channel.uuid)
+        self.assertEqual('12345', self.tel_channel.gcm_id)
+        self.assertEqual('abcde', self.tel_channel.uuid)
 
         # should ignore incoming messages without text
         post_data = dict(cmds=[
@@ -1889,7 +1889,7 @@ class ChannelTest(TembaTest):
         self.tel_channel.save()
 
         # We should not have an alert this time
-        self.assertEquals(0, Alert.objects.all().count())
+        self.assertEqual(0, Alert.objects.all().count())
 
         # the case the status must be be reported
         post_data = dict(cmds=[
@@ -1901,10 +1901,10 @@ class ChannelTest(TembaTest):
         response = self.sync(self.tel_channel, post_data)
 
         # we should now have an Alert
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
 
         # and at this time it must be not ended
-        self.assertEquals(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
+        self.assertEqual(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
 
         # the case the status must be be reported but already notification sent
         post_data = dict(cmds=[
@@ -1916,10 +1916,10 @@ class ChannelTest(TembaTest):
         response = self.sync(self.tel_channel, post_data)
 
         # we should not create a new alert
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
 
         # still not ended
-        self.assertEquals(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
+        self.assertEqual(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
 
         # Let plug the channel to charger
         post_data = dict(cmds=[
@@ -1931,10 +1931,10 @@ class ChannelTest(TembaTest):
         response = self.sync(self.tel_channel, post_data)
 
         # only one alert
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
 
         # and we end all alert related to this issue
-        self.assertEquals(0, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
+        self.assertEqual(0, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
 
         # clear the alerts
         Alert.objects.all().delete()
@@ -1950,10 +1950,10 @@ class ChannelTest(TembaTest):
         response = self.sync(self.tel_channel, post_data)
 
         # we should now create a new alert
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
 
         # one alert not ended
-        self.assertEquals(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
+        self.assertEqual(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
 
         # Let plug the channel to charger to end this unknown power status
         post_data = dict(cmds=[
@@ -1965,10 +1965,10 @@ class ChannelTest(TembaTest):
         response = self.sync(self.tel_channel, post_data)
 
         # still only one alert
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
 
         # and we end all alert related to this issue
-        self.assertEquals(0, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
+        self.assertEqual(0, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
 
         # clear all the alerts
         Alert.objects.all().delete()
@@ -1983,10 +1983,10 @@ class ChannelTest(TembaTest):
         response = self.sync(self.tel_channel, post_data)
 
         # we should now create a new alert
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
 
         # one alert not ended
-        self.assertEquals(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
+        self.assertEqual(1, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
 
         # Let plug the channel to charger to end this unknown power status
         post_data = dict(cmds=[
@@ -1998,10 +1998,10 @@ class ChannelTest(TembaTest):
         response = self.sync(self.tel_channel, post_data)
 
         # first we have a new alert created
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
 
         # and we end all alert related to this issue
-        self.assertEquals(0, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
+        self.assertEqual(0, Alert.objects.filter(sync_event__channel=self.tel_channel, ended_on=None, alert_type='P').count())
 
         post_data = dict(cmds=[
             # device fcm data
@@ -2016,10 +2016,10 @@ class ChannelTest(TembaTest):
 
     def test_signing(self):
         # good signature
-        self.assertEquals(200, self.sync(self.tel_channel).status_code)
+        self.assertEqual(200, self.sync(self.tel_channel).status_code)
 
         # bad signature, should result in 401 Unauthorized
-        self.assertEquals(401, self.sync(self.tel_channel, signature="badsig").status_code)
+        self.assertEqual(401, self.sync(self.tel_channel, signature="badsig").status_code)
 
     def test_ignore_android_incoming_msg_invalid_phone(self):
         date = timezone.now()
@@ -2029,7 +2029,7 @@ class ChannelTest(TembaTest):
             dict(cmd="mo_sms", phone="_@", msg="First message", p_id="1", ts=date)])
 
         response = self.sync(self.tel_channel, post_data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         responses = response.json()
         cmds = responses['cmds']
@@ -2054,7 +2054,7 @@ class ChannelTest(TembaTest):
         ])
 
         response = self.sync(self.tel_channel, post_data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         responses = response.json()
         cmds = responses['cmds']
@@ -2069,7 +2069,7 @@ class ChannelTest(TembaTest):
         self.assertIsNotNone(r2)
 
         # first two should have the same server id
-        self.assertEquals(r0['extra'], r1['extra'])
+        self.assertEqual(r0['extra'], r1['extra'])
 
         # One was a duplicate, should only have 2
         self.assertEqual(2, Msg.objects.filter(direction='I').count())
@@ -2136,8 +2136,8 @@ class ChannelTest(TembaTest):
         self.org.save()
 
         self.assertTrue(self.org.get_chatbase_credentials())
-        self.assertEquals(self.org.config_json()['CHATBASE_API_KEY'], '123456abcdef')
-        self.assertEquals(self.org.config_json()['CHATBASE_VERSION'], '1.0')
+        self.assertEqual(self.org.config_json()['CHATBASE_API_KEY'], '123456abcdef')
+        self.assertEqual(self.org.config_json()['CHATBASE_VERSION'], '1.0')
 
         with self.settings(SEND_CHATBASE=True):
             joe = self.create_contact("Joe", urn="fcm:forrest_gump", auth="1234567890")
@@ -2163,7 +2163,7 @@ class ChannelBatchTest(TembaTest):
         now = now.replace(microsecond=now.microsecond / 1000 * 1000)
 
         epoch = datetime_to_ms(now)
-        self.assertEquals(ms_to_datetime(epoch), now)
+        self.assertEqual(ms_to_datetime(epoch), now)
 
 
 class ChannelEventTest(TembaTest):
@@ -2195,7 +2195,7 @@ class ChannelEventCRUDLTest(TembaTest):
 
         response = self.fetch_protected(list_url, self.user)
 
-        self.assertEquals(response.context['object_list'].count(), 2)
+        self.assertEqual(response.context['object_list'].count(), 2)
         self.assertContains(response, "Missed Incoming Call")
         self.assertContains(response, "Incoming Call (600 seconds)")
 
@@ -2212,18 +2212,18 @@ class SyncEventTest(SmartminTest):
     def test_sync_event_model(self):
         self.sync_event = SyncEvent.create(self.tel_channel, dict(p_src="AC", p_sts="DIS", p_lvl=80, net="WIFI",
                                                                   pending=[1, 2], retry=[3, 4], cc='RW'), [1, 2])
-        self.assertEquals(SyncEvent.objects.all().count(), 1)
-        self.assertEquals(self.sync_event.get_pending_messages(), [1, 2])
-        self.assertEquals(self.sync_event.get_retry_messages(), [3, 4])
-        self.assertEquals(self.sync_event.incoming_command_count, 0)
+        self.assertEqual(SyncEvent.objects.all().count(), 1)
+        self.assertEqual(self.sync_event.get_pending_messages(), [1, 2])
+        self.assertEqual(self.sync_event.get_retry_messages(), [3, 4])
+        self.assertEqual(self.sync_event.incoming_command_count, 0)
 
         self.sync_event = SyncEvent.create(self.tel_channel, dict(p_src="AC", p_sts="DIS", p_lvl=80, net="WIFI",
                                                                   pending=[1, 2], retry=[3, 4], cc='US'), [1])
-        self.assertEquals(self.sync_event.incoming_command_count, 0)
+        self.assertEqual(self.sync_event.incoming_command_count, 0)
         self.tel_channel = Channel.objects.get(pk=self.tel_channel.pk)
 
         # we shouldn't update country once the relayer is claimed
-        self.assertEquals('RW', self.tel_channel.country)
+        self.assertEqual('RW', self.tel_channel.country)
 
 
 class ChannelAlertTest(TembaTest):
@@ -2276,17 +2276,17 @@ class ChannelClaimTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('BR', channel.country)
-        self.assertEquals(post_data['account'], channel.config_json()['account'])
-        self.assertEquals(post_data['code'], channel.config_json()['code'])
-        self.assertEquals(post_data['shortcode'], channel.address)
-        self.assertEquals('ZV', channel.channel_type)
+        self.assertEqual('BR', channel.country)
+        self.assertEqual(post_data['account'], channel.config_json()['account'])
+        self.assertEqual(post_data['code'], channel.config_json()['code'])
+        self.assertEqual(post_data['shortcode'], channel.address)
+        self.assertEqual('ZV', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.zv', args=[channel.uuid, 'status']))
         self.assertContains(response, reverse('courier.zv', args=[channel.uuid, 'receive']))
@@ -2296,7 +2296,7 @@ class ChannelClaimTest(TembaTest):
         self.login(self.admin)
 
         response = self.client.get(reverse('channels.channel_create_viber'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         response = self.client.post(reverse('channels.channel_create_viber'), dict(name="Macklemore"))
 
         # should create a new viber channel, but without an address
@@ -2305,7 +2305,7 @@ class ChannelClaimTest(TembaTest):
         self.assertEqual(channel.address, Channel.VIBER_NO_SERVICE_ID)
         self.assertIsNone(channel.country.code)
         self.assertEqual(channel.name, "Macklemore")
-        self.assertEquals(Channel.TYPE_VIBER, channel.channel_type)
+        self.assertEqual(Channel.TYPE_VIBER, channel.channel_type)
 
         # we should be redirecting to the claim page to enter in our service id
         claim_url = reverse('channels.channel_claim_viber', args=[channel.id])
@@ -2346,8 +2346,8 @@ class ChannelClaimTest(TembaTest):
         self.login(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim_chikka'))
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.context['view'].get_country({}), 'Philippines')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.context['view'].get_country({}), 'Philippines')
 
         post_data = response.context['form'].initial
 
@@ -2359,17 +2359,17 @@ class ChannelClaimTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('chikka', channel.config_json()[Channel.CONFIG_USERNAME])
-        self.assertEquals('password', channel.config_json()[Channel.CONFIG_PASSWORD])
-        self.assertEquals('5259', channel.address)
-        self.assertEquals('PH', channel.country)
-        self.assertEquals(Channel.TYPE_CHIKKA, channel.channel_type)
+        self.assertEqual('chikka', channel.config_json()[Channel.CONFIG_USERNAME])
+        self.assertEqual('password', channel.config_json()[Channel.CONFIG_PASSWORD])
+        self.assertEqual('5259', channel.address)
+        self.assertEqual('PH', channel.country)
+        self.assertEqual(Channel.TYPE_CHIKKA, channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.ck', args=[channel.uuid]))
 
@@ -2378,7 +2378,7 @@ class ChannelClaimTest(TembaTest):
         self.login(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim_vumi_ussd'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = {
             "country": "ZA",
@@ -2392,19 +2392,19 @@ class ChannelClaimTest(TembaTest):
         channel = Channel.objects.get()
 
         self.assertTrue(uuid.UUID(channel.config_json()['access_token'], version=4))
-        self.assertEquals(channel.country, post_data['country'])
-        self.assertEquals(channel.address, post_data['number'])
-        self.assertEquals(channel.config_json()['account_key'], post_data['account_key'])
-        self.assertEquals(channel.config_json()['conversation_key'], post_data['conversation_key'])
-        self.assertEquals(channel.config_json()['api_url'], Channel.VUMI_GO_API_URL)
-        self.assertEquals(channel.channel_type, Channel.TYPE_VUMI_USSD)
-        self.assertEquals(channel.role, Channel.ROLE_USSD)
+        self.assertEqual(channel.country, post_data['country'])
+        self.assertEqual(channel.address, post_data['number'])
+        self.assertEqual(channel.config_json()['account_key'], post_data['account_key'])
+        self.assertEqual(channel.config_json()['conversation_key'], post_data['conversation_key'])
+        self.assertEqual(channel.config_json()['api_url'], Channel.VUMI_GO_API_URL)
+        self.assertEqual(channel.channel_type, Channel.TYPE_VUMI_USSD)
+        self.assertEqual(channel.role, Channel.ROLE_USSD)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.vm', args=[channel.uuid, 'receive']))
         self.assertContains(response, reverse('courier.vm', args=[channel.uuid, 'event']))
@@ -2414,7 +2414,7 @@ class ChannelClaimTest(TembaTest):
         self.login(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim_vumi_ussd'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = {
             "country": "ZA",
@@ -2429,20 +2429,20 @@ class ChannelClaimTest(TembaTest):
         channel = Channel.objects.get()
 
         self.assertTrue(uuid.UUID(channel.config_json()['access_token'], version=4))
-        self.assertEquals(channel.country, post_data['country'])
-        self.assertEquals(channel.address, post_data['number'])
-        self.assertEquals(channel.config_json()['account_key'], post_data['account_key'])
-        self.assertEquals(channel.config_json()['conversation_key'], post_data['conversation_key'])
-        self.assertEquals(channel.config_json()['api_url'], "http://custom.api.url")
-        self.assertEquals(channel.channel_type, Channel.TYPE_VUMI_USSD)
-        self.assertEquals(channel.role, Channel.ROLE_USSD)
+        self.assertEqual(channel.country, post_data['country'])
+        self.assertEqual(channel.address, post_data['number'])
+        self.assertEqual(channel.config_json()['account_key'], post_data['account_key'])
+        self.assertEqual(channel.config_json()['conversation_key'], post_data['conversation_key'])
+        self.assertEqual(channel.config_json()['api_url'], "http://custom.api.url")
+        self.assertEqual(channel.channel_type, Channel.TYPE_VUMI_USSD)
+        self.assertEqual(channel.role, Channel.ROLE_USSD)
 
     def test_claim_vumi_ussd_custom_api_short_code(self):
         Channel.objects.all().delete()
         self.login(self.admin)
 
         response = self.client.get(reverse('channels.channel_claim_vumi_ussd'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = {
             "country": "ZA",
@@ -2457,8 +2457,8 @@ class ChannelClaimTest(TembaTest):
         channel = Channel.objects.get()
 
         self.assertTrue(uuid.UUID(channel.config_json()['access_token'], version=4))
-        self.assertEquals(channel.country, post_data['country'])
-        self.assertEquals(channel.address, post_data['number'])
+        self.assertEqual(channel.country, post_data['country'])
+        self.assertEqual(channel.address, post_data['number'])
 
     @override_settings(SEND_EMAILS=True)
     def test_disconnected_alert(self):
@@ -2471,8 +2471,8 @@ class ChannelClaimTest(TembaTest):
 
         # should have created one alert
         alert = Alert.objects.get()
-        self.assertEquals(self.channel, alert.channel)
-        self.assertEquals(Alert.TYPE_DISCONNECTED, alert.alert_type)
+        self.assertEqual(self.channel, alert.channel)
+        self.assertEqual(Alert.TYPE_DISCONNECTED, alert.alert_type)
         self.assertFalse(alert.ended_on)
 
         self.assertTrue(len(mail.outbox) == 1)
@@ -2484,13 +2484,13 @@ class ChannelClaimTest(TembaTest):
         text_template = loader.get_template(template)
         text = text_template.render(context)
 
-        self.assertEquals(mail.outbox[0].body, text)
+        self.assertEqual(mail.outbox[0].body, text)
 
         # call it again
         check_channels_task()
 
         # still only one alert
-        self.assertEquals(1, Alert.objects.all().count())
+        self.assertEqual(1, Alert.objects.all().count())
         self.assertTrue(len(mail.outbox) == 1)
 
         # ok, let's have the channel show up again
@@ -2511,7 +2511,7 @@ class ChannelClaimTest(TembaTest):
         text_template = loader.get_template(template)
         text = text_template.render(context)
 
-        self.assertEquals(mail.outbox[1].body, text)
+        self.assertEqual(mail.outbox[1].body, text)
 
     @override_settings(SEND_EMAILS=True)
     def test_sms_alert(self):
@@ -2537,11 +2537,11 @@ class ChannelClaimTest(TembaTest):
         check_channels_task()
 
         # we don't have  successfully sent message and we have an alert and only one
-        self.assertEquals(Alert.objects.all().count(), 1)
+        self.assertEqual(Alert.objects.all().count(), 1)
 
         alert = Alert.objects.get()
-        self.assertEquals(self.channel, alert.channel)
-        self.assertEquals(Alert.TYPE_SMS, alert.alert_type)
+        self.assertEqual(self.channel, alert.channel)
+        self.assertEqual(Alert.TYPE_SMS, alert.alert_type)
         self.assertFalse(alert.ended_on)
         self.assertTrue(len(mail.outbox) == 1)
 
@@ -2559,7 +2559,7 @@ class ChannelClaimTest(TembaTest):
         check_channels_task()
 
         # if latest_sent_message is after our queued message no alert is created
-        self.assertEquals(Alert.objects.all().count(), 1)
+        self.assertEqual(Alert.objects.all().count(), 1)
 
         # consider the sent message was sent before our queued msg
         sent_msg.sent_on = three_hours_ago
@@ -2572,7 +2572,7 @@ class ChannelClaimTest(TembaTest):
         check_channels_task()
 
         #  no new alert created because we sent one in the past hour
-        self.assertEquals(Alert.objects.all().count(), 1)
+        self.assertEqual(Alert.objects.all().count(), 1)
 
         sent_msg.sent_on = six_hours_ago
         sent_msg.save()
@@ -2585,12 +2585,12 @@ class ChannelClaimTest(TembaTest):
         check_channels_task()
 
         # this time we have a new alert and should create only one
-        self.assertEquals(Alert.objects.all().count(), 2)
+        self.assertEqual(Alert.objects.all().count(), 2)
 
         # get the alert which is not ended
         alert = Alert.objects.get(ended_on=None)
-        self.assertEquals(self.channel, alert.channel)
-        self.assertEquals(Alert.TYPE_SMS, alert.alert_type)
+        self.assertEqual(self.channel, alert.channel)
+        self.assertEqual(Alert.TYPE_SMS, alert.alert_type)
         self.assertFalse(alert.ended_on)
         self.assertTrue(len(mail.outbox) == 2)
 
@@ -2618,7 +2618,7 @@ class ChannelCountTest(TembaTest):
 
     def assertDailyCount(self, channel, assert_count, count_type, day):
         calculated_count = ChannelCount.get_day_count(channel, count_type, day)
-        self.assertEquals(assert_count, calculated_count)
+        self.assertEqual(assert_count, calculated_count)
 
     def test_daily_counts(self):
         # test that messages to test contacts aren't counted
@@ -2650,7 +2650,7 @@ class ChannelCountTest(TembaTest):
         self.assertDailyCount(self.channel, 2, ChannelCount.INCOMING_MSG_TYPE, msg.created_on.date())
 
         # and only one channel count
-        self.assertEquals(ChannelCount.objects.all().count(), 1)
+        self.assertEqual(ChannelCount.objects.all().count(), 1)
 
         # deleting a message doesn't decrement the count
         msg.delete()
@@ -2715,22 +2715,22 @@ class AfricasTalkingTest(TembaTest):
         # ok, what happens with an invalid uuid?
         post_data = dict(id="external1", status="Success")
         response = self.client.post(reverse('handlers.africas_talking_handler', args=['delivery', 'not-real-uuid']), post_data)
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id
         delivery_url = reverse('handlers.africas_talking_handler', args=['delivery', self.channel.uuid])
         response = self.client.post(delivery_url, post_data)
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
         # requires posts
         delivery_url = reverse('handlers.africas_talking_handler', args=['delivery', self.channel.uuid])
         response = self.client.get(delivery_url, post_data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # missing status
         del post_data['status']
         response = self.client.post(delivery_url, post_data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -2741,9 +2741,9 @@ class AfricasTalkingTest(TembaTest):
         def assertStatus(sms, post_status, assert_status):
             post_data['status'] = post_status
             response = self.client.post(delivery_url, post_data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'Success', DELIVERED)
         assertStatus(msg, 'Sent', SENT)
@@ -2763,18 +2763,18 @@ class AfricasTalkingTest(TembaTest):
 
         # missing test data
         response = self.client.post(callback_url, dict())
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         response = self.client.post(callback_url, post_data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+254788123123", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual("+254788123123", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -2791,12 +2791,12 @@ class AfricasTalkingTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('msg1', msg.external_id)
+                self.assertEqual('msg1', msg.external_id)
 
                 # check that our from was set
-                self.assertEquals(self.channel.address, mock.call_args[1]['data']['from'])
+                self.assertEqual(self.channel.address, mock.call_args[1]['data']['from'])
 
                 self.clear_cache()
 
@@ -2809,9 +2809,9 @@ class AfricasTalkingTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
+                self.assertEqual(ERRORED, msg.status)
 
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.clear_cache()
@@ -2838,8 +2838,8 @@ class AfricasTalkingTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.post') as mock:
@@ -2850,8 +2850,8 @@ class AfricasTalkingTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -2875,12 +2875,12 @@ class AfricasTalkingTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('msg1', msg.external_id)
+                self.assertEqual('msg1', msg.external_id)
 
                 # check that our from was set
-                self.assertEquals(self.channel.address, mock.call_args[1]['data']['from'])
+                self.assertEqual(self.channel.address, mock.call_args[1]['data']['from'])
                 self.assertEqual(mock.call_args[1]['data']['message'],
                                  "Test message\nhttps://example.com/attachments/pic.jpg")
 
@@ -2982,9 +2982,9 @@ class ExternalTest(TembaTest):
 
         def assertStatus(sms, status, assert_status):
             resp = self.client.post(reverse('handlers.external_handler', args=[status, self.channel.uuid]), payload)
-            self.assertEquals(200, resp.status_code)
+            self.assertEqual(200, resp.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'delivered', DELIVERED)
         assertStatus(msg, 'sent', SENT)
@@ -2992,7 +2992,7 @@ class ExternalTest(TembaTest):
 
         # check when called with phone number rather than UUID
         response = self.client.post(reverse('handlers.external_handler', args=['sent', '250788123123']), {'id': msg.pk})
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         msg.refresh_from_db()
         self.assertEqual(msg.status, SENT)
 
@@ -3001,20 +3001,20 @@ class ExternalTest(TembaTest):
         callback_url = reverse('handlers.external_handler', args=['received', self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+5511996458779", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World!", msg.text)
+        self.assertEqual("+5511996458779", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World!", msg.text)
 
         data = {'from': "", 'text': "Hi there"}
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         Msg.objects.all().delete()
 
@@ -3023,21 +3023,21 @@ class ExternalTest(TembaTest):
         callback_url = reverse('handlers.external_handler', args=['received', self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message, make sure the date was saved properly
         msg = Msg.objects.get()
-        self.assertEquals(2012, msg.sent_on.year)
-        self.assertEquals(18, msg.sent_on.hour)
+        self.assertEqual(2012, msg.sent_on.year)
+        self.assertEqual(18, msg.sent_on.hour)
 
         Msg.objects.all().delete()
 
         data = {'from': '5511996458779', 'text': 'Hello World!', 'date': '2012-04-23T18:25:43Z'}
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(400, response.status_code)
-        self.assertEquals("Bad parameter error: time data '2012-04-23T18:25:43Z' "
-                          "does not match format '%Y-%m-%dT%H:%M:%S.%fZ'", response.content)
+        self.assertEqual(400, response.status_code)
+        self.assertEqual("Bad parameter error: time data '2012-04-23T18:25:43Z' "
+                         "does not match format '%Y-%m-%dT%H:%M:%S.%fZ'", response.content)
         self.assertFalse(Msg.objects.all())
 
     def test_receive_external(self):
@@ -3048,15 +3048,15 @@ class ExternalTest(TembaTest):
         callback_url = reverse('handlers.external_handler', args=['received', self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # check our message
         msg = Msg.objects.get()
-        self.assertEquals('lynch24', msg.contact.get_urn(EXTERNAL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals('Beast Mode!', msg.text)
+        self.assertEqual('lynch24', msg.contact.get_urn(EXTERNAL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual('Beast Mode!', msg.text)
 
     def test_send_replacement(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -3153,7 +3153,7 @@ class ExternalTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertTrue("text=Test+message" in mock.call_args[1]['data'])
@@ -3168,8 +3168,8 @@ class ExternalTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.post') as mock:
@@ -3180,8 +3180,8 @@ class ExternalTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -3194,19 +3194,19 @@ class ExternalTest(TembaTest):
         self.login(self.admin)
         log_item = ChannelLog.objects.all().order_by('created_on').first()
         response = self.client.get(reverse('channels.channellog_read', args=[log_item.pk]))
-        self.assertEquals(response.context['object'].description, 'Successfully delivered')
+        self.assertEqual(response.context['object'].description, 'Successfully delivered')
 
         # make sure we can't see it as anon
         self.org.is_anon = True
         self.org.save()
 
         response = self.client.get(reverse('channels.channellog_read', args=[log_item.pk]))
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # change our admin to be a CS rep, see if they can see the page
         self.admin.groups.add(Group.objects.get(name='Customer Support'))
         response = self.client.get(reverse('channels.channellog_read', args=[log_item.pk]))
-        self.assertEquals(response.context['object'].description, 'Successfully delivered')
+        self.assertEqual(response.context['object'].description, 'Successfully delivered')
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -3223,7 +3223,7 @@ class ExternalTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertIn("text=Test+message%0Ahttps%3A%2F%2Fexample.com%2Fattachments%2Fpic.jpg", mock.call_args[1]['data'])
@@ -3282,23 +3282,23 @@ class YoTest(TembaTest):
         callback_url = reverse('handlers.yo_handler', args=['received', self.channel.uuid])
         response = self.client.get(callback_url + "?sender=252788123123&message=Hello+World")
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+252788123123", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual("+252788123123", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
         # fails if missing sender
         response = self.client.get(callback_url + "?sender=252788123123")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # fails if missing message
         response = self.client.get(callback_url + "?message=Hello+World")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+252788383383")
@@ -3315,7 +3315,7 @@ class YoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertTrue("sms_content=Test+message" in mock.call_args[0][0])
@@ -3330,11 +3330,11 @@ class YoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # check that requests was called twice, using the backup URL the second time
-                self.assertEquals(2, mock.call_count)
+                self.assertEqual(2, mock.call_count)
                 self.clear_cache()
 
             with patch('requests.get') as mock:
@@ -3345,8 +3345,8 @@ class YoTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.clear_cache()
@@ -3364,8 +3364,8 @@ class YoTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 # contact should not be stopped
@@ -3382,8 +3382,8 @@ class YoTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 # contact should not be stopped
@@ -3404,8 +3404,8 @@ class YoTest(TembaTest):
 
                 # message should be marked as a failure
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 # contact should also be stopped
@@ -3430,7 +3430,7 @@ class YoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertIn("sms_content=Test+message%0Ahttps%3A%2F%2Fexample.com%2Fattachments%2Fpic.jpg", mock.call_args[0][0])
@@ -3458,15 +3458,15 @@ class ShaqodoonTest(TembaTest):
         callback_url = reverse('handlers.shaqodoon_handler', args=['received', self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+252788123456", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World!", msg.text)
+        self.assertEqual("+252788123456", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World!", msg.text)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -3483,7 +3483,7 @@ class ShaqodoonTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertTrue("msg=Test+message" in mock.call_args[0][0])
@@ -3498,8 +3498,8 @@ class ShaqodoonTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.get') as mock:
@@ -3510,7 +3510,7 @@ class ShaqodoonTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
+                self.assertEqual(ERRORED, msg.status)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                                   "referenced before assignment"))
@@ -3533,7 +3533,7 @@ class ShaqodoonTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 self.assertIn("msg=Test+message%0Ahttps%3A%2F%2Fexample.com%2Fattachments%2Fpic.jpg", mock.call_args[0][0])
                 self.clear_cache()
@@ -3556,15 +3556,15 @@ class M3TechTest(TembaTest):
         callback_url = reverse('handlers.m3tech_handler', args=['received', self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+252788123456", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World!", msg.text)
+        self.assertEqual("+252788123456", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World!", msg.text)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -3585,7 +3585,7 @@ class M3TechTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertEqual(mock.call_args[1]['params']['SMS'], 'Test message')
@@ -3604,7 +3604,7 @@ class M3TechTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.clear_cache()
@@ -3619,7 +3619,7 @@ class M3TechTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
+                self.assertEqual(ERRORED, msg.status)
                 self.clear_cache()
 
             with patch('requests.get') as mock:
@@ -3630,8 +3630,8 @@ class M3TechTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.clear_cache()
@@ -3644,8 +3644,8 @@ class M3TechTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.clear_cache()
@@ -3658,8 +3658,8 @@ class M3TechTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -3690,7 +3690,7 @@ class M3TechTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.clear_cache()
@@ -3712,12 +3712,12 @@ class KannelTest(TembaTest):
         # ok, what happens with an invalid uuid?
         data = dict(id="-1", status="4")
         response = self.client.post(reverse('handlers.kannel_handler', args=['status', 'not-real-uuid']), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id -1
         delivery_url = reverse('handlers.kannel_handler', args=['status', self.channel.uuid])
         response = self.client.post(delivery_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -3728,9 +3728,9 @@ class KannelTest(TembaTest):
         def assertStatus(sms, status, assert_status):
             data['status'] = status
             response = self.client.post(reverse('handlers.kannel_handler', args=['status', self.channel.uuid]), data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, '4', SENT)
         assertStatus(msg, '1', DELIVERED)
@@ -3751,15 +3751,15 @@ class KannelTest(TembaTest):
         callback_url = reverse('handlers.kannel_handler', args=['receive', self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+250788383383", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World!", msg.text)
+        self.assertEqual("+250788383383", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World!", msg.text)
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -3776,12 +3776,12 @@ class KannelTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert verify was set to true
                 self.assertTrue(mock.call_args[1]['verify'])
-                self.assertEquals('+250788383383', mock.call_args[1]['params']['to'])
+                self.assertEqual('+250788383383', mock.call_args[1]['params']['to'])
                 self.assertEqual(mock.call_args[1]['params']['text'],
                                  'Test message\nhttps://example.com/attachments/pic.jpg')
 
@@ -3804,12 +3804,12 @@ class KannelTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert verify was set to true
                 self.assertTrue(mock.call_args[1]['verify'])
-                self.assertEquals('+250788383383', mock.call_args[1]['params']['to'])
+                self.assertEqual('+250788383383', mock.call_args[1]['params']['to'])
                 self.assertEqual(mock.call_args[1]['params']['text'], 'Test message')
                 self.clear_cache()
 
@@ -3829,12 +3829,12 @@ class KannelTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert verify was set to true
-                self.assertEquals('No capital accented E!', mock.call_args[1]['params']['text'])
-                self.assertEquals('788383383', mock.call_args[1]['params']['to'])
+                self.assertEqual('No capital accented E!', mock.call_args[1]['params']['text'])
+                self.assertEqual('788383383', mock.call_args[1]['params']['to'])
                 self.assertFalse('coding' in mock.call_args[1]['params'])
                 self.assertFalse('priority' in mock.call_args[1]['params'])
                 self.clear_cache()
@@ -3852,14 +3852,14 @@ class KannelTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert verify was set to true
-                self.assertEquals("Unicode. ☺", mock.call_args[1]['params']['text'])
-                self.assertEquals('2', mock.call_args[1]['params']['coding'])
-                self.assertEquals('utf8', mock.call_args[1]['params']['charset'])
-                self.assertEquals(1, mock.call_args[1]['params']['priority'])
+                self.assertEqual("Unicode. ☺", mock.call_args[1]['params']['text'])
+                self.assertEqual('2', mock.call_args[1]['params']['coding'])
+                self.assertEqual('utf8', mock.call_args[1]['params']['charset'])
+                self.assertEqual(1, mock.call_args[1]['params']['priority'])
 
                 self.clear_cache()
 
@@ -3874,11 +3874,11 @@ class KannelTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert verify was set to true
-                self.assertEquals("Normal", mock.call_args[1]['params']['text'])
+                self.assertEqual("Normal", mock.call_args[1]['params']['text'])
                 self.assertFalse('coding' in mock.call_args[1]['params'])
                 self.assertFalse('charset' in mock.call_args[1]['params'])
 
@@ -3897,13 +3897,13 @@ class KannelTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert verify was set to true
-                self.assertEquals("Normal", mock.call_args[1]['params']['text'])
-                self.assertEquals('2', mock.call_args[1]['params']['coding'])
-                self.assertEquals('utf8', mock.call_args[1]['params']['charset'])
+                self.assertEqual("Normal", mock.call_args[1]['params']['text'])
+                self.assertEqual('2', mock.call_args[1]['params']['coding'])
+                self.assertEqual('utf8', mock.call_args[1]['params']['charset'])
 
                 self.clear_cache()
 
@@ -3922,8 +3922,8 @@ class KannelTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.get') as mock:
@@ -3937,7 +3937,7 @@ class KannelTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
+                self.assertEqual(ERRORED, msg.status)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                                   "referenced before assignment"))
@@ -3969,14 +3969,14 @@ class NexmoTest(TembaTest):
         # ok, what happens with an invalid uuid and number
         data = dict(to='250788123111', messageId='external1')
         response = self.client.get(reverse('handlers.nexmo_handler', args=['status', 'not-real-uuid']), data)
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id -1, should return 200
         # these are probably multipart message callbacks, which we don't track
         data = dict(to='250788123123', messageId='-1')
         delivery_url = reverse('handlers.nexmo_handler', args=['status', self.nexmo_uuid])
         response = self.client.get(delivery_url, data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -3989,9 +3989,9 @@ class NexmoTest(TembaTest):
         def assertStatus(sms, status, assert_status):
             data['status'] = status
             response = self.client.get(reverse('handlers.nexmo_handler', args=['status', self.nexmo_uuid]), data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'delivered', DELIVERED)
         assertStatus(msg, 'expired', FAILED)
@@ -4004,16 +4004,16 @@ class NexmoTest(TembaTest):
         callback_url = reverse('handlers.nexmo_handler', args=['receive', self.nexmo_uuid])
         response = self.client.get(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+250788111222", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World!", msg.text)
-        self.assertEquals('external1', msg.external_id)
+        self.assertEqual("+250788111222", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World!", msg.text)
+        self.assertEqual('external1', msg.external_id)
 
     def test_send(self):
         from temba.orgs.models import NEXMO_KEY, NEXMO_SECRET, NEXMO_APP_ID, NEXMO_APP_PRIVATE_KEY
@@ -4043,9 +4043,9 @@ class NexmoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('12', msg.external_id)
+                self.assertEqual('12', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['params']['text'], "Test message")
 
@@ -4058,7 +4058,7 @@ class NexmoTest(TembaTest):
                     r.delete(timezone.now().strftime(MSG_SENT_KEY))
 
                     msg.refresh_from_db()
-                    self.assertEquals(SENT, msg.status)
+                    self.assertEqual(SENT, msg.status)
 
                 # assert we sent the messages out in a reasonable amount of time
                 end = time.time()
@@ -4077,9 +4077,9 @@ class NexmoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('12', msg.external_id)
+                self.assertEqual('12', msg.external_id)
 
                 # assert that we were called with unicode
                 mock.assert_called_once_with('https://rest.nexmo.com/sms/json',
@@ -4104,7 +4104,7 @@ class NexmoTest(TembaTest):
 
                 # check status
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
+                self.assertEqual(ERRORED, msg.status)
 
                 # and that we have a decent log
                 log = ChannelLog.objects.get(msg=msg)
@@ -4132,7 +4132,7 @@ class NexmoTest(TembaTest):
 
                 # should be sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
 
                 self.clear_cache()
 
@@ -4144,8 +4144,8 @@ class NexmoTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
         finally:
             settings.SEND_MESSAGES = False
@@ -4177,9 +4177,9 @@ class NexmoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('12', msg.external_id)
+                self.assertEqual('12', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['params']['text'],
                                  'Test message\nhttps://example.com/attachments/pic.jpg')
@@ -4223,11 +4223,11 @@ class VumiTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         msg = Msg.objects.get()
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello from Vumi", msg.text)
-        self.assertEquals('123456', msg.external_id)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello from Vumi", msg.text)
+        self.assertEqual('123456', msg.external_id)
 
     def test_delivery_reports(self):
 
@@ -4243,11 +4243,11 @@ class VumiTest(TembaTest):
         callback_url = reverse('handlers.vumi_handler', args=['event', self.channel.uuid])
 
         # response = self.client.post(callback_url, json.dumps(data), content_type="application/json")
-        # self.assertEquals(200, response.status_code)
+        # self.assertEqual(200, response.status_code)
 
         # check that we've become errored
         # sms = Msg.objects.get(pk=sms.pk)
-        # self.assertEquals(ERRORED, sms.status)
+        # self.assertEqual(ERRORED, sms.status)
 
         # couple more failures should move to failure
         # Msg.objects.filter(pk=sms.pk).update(status=WIRED)
@@ -4257,20 +4257,20 @@ class VumiTest(TembaTest):
         # self.client.post(callback_url, json.dumps(data), content_type="application/json")
 
         # sms = Msg.objects.get(pk=sms.pk)
-        # self.assertEquals(FAILED, sms.status)
+        # self.assertEqual(FAILED, sms.status)
 
         # successful deliveries shouldn't stomp on failures
         # del data['delivery_status']
         # self.client.post(callback_url, json.dumps(data), content_type="application/json")
         # sms = Msg.objects.get(pk=sms.pk)
-        # self.assertEquals(FAILED, sms.status)
+        # self.assertEqual(FAILED, sms.status)
 
         # if we are wired we can now be successful again
         data['delivery_status'] = 'delivered'
         Msg.objects.filter(pk=msg.pk).update(status=WIRED)
         self.client.post(callback_url, json.dumps(data), content_type="application/json")
         msg.refresh_from_db()
-        self.assertEquals(DELIVERED, msg.status)
+        self.assertEqual(DELIVERED, msg.status)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -4298,14 +4298,14 @@ class VumiTest(TembaTest):
                 [call] = mock.call_args_list
                 (args, kwargs) = call
                 payload = json.loads(kwargs['data'])
-                self.assertEquals(payload['in_reply_to'], 'vumi-message-id')
+                self.assertEqual(payload['in_reply_to'], 'vumi-message-id')
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1515", msg.external_id)
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual("1515", msg.external_id)
+                self.assertEqual(1, mock.call_count)
 
                 # should have a failsafe that it was sent
                 self.assertTrue(r.sismember(timezone.now().strftime(MSG_SENT_KEY), str(msg.id)))
@@ -4314,7 +4314,7 @@ class VumiTest(TembaTest):
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
                 # we shouldn't have been called again
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual(1, mock.call_count)
 
                 # simulate Vumi calling back to us telling us it failed
                 data = dict(event_type='delivery_report',
@@ -4327,7 +4327,7 @@ class VumiTest(TembaTest):
 
                 # get the message again
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 # self.assertTrue(msg.next_attempt)
                 # self.assertFalse(r.sismember(timezone.now().strftime(MSG_SENT_KEY), str(msg.id)))
 
@@ -4343,14 +4343,14 @@ class VumiTest(TembaTest):
                 [call] = mock.call_args_list
                 (args, kwargs) = call
                 payload = json.loads(kwargs['data'])
-                self.assertEquals(payload['in_reply_to'], None)
+                self.assertEqual(payload['in_reply_to'], None)
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1516", msg.external_id)
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual("1516", msg.external_id)
+                self.assertEqual(1, mock.call_count)
 
                 self.clear_cache()
 
@@ -4362,10 +4362,10 @@ class VumiTest(TembaTest):
 
                 # message should be marked as errored, we'll retry in a bit
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt > timezone.now())
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual(1, mock.call_count)
 
                 self.clear_cache()
 
@@ -4377,10 +4377,10 @@ class VumiTest(TembaTest):
 
                 # message should be marked as errored, we'll retry in a bit
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt > timezone.now())
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual(1, mock.call_count)
 
                 # Joe shouldn't be stopped and should still be in a group
                 joe = Contact.objects.get(id=joe.id)
@@ -4401,8 +4401,8 @@ class VumiTest(TembaTest):
 
                 # message should be marked as failed
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                                   "referenced before assignment"))
@@ -4419,10 +4419,10 @@ class VumiTest(TembaTest):
 
                 # message should be marked as failed
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt < timezone.now())
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual(1, mock.call_count)
 
                 # could should now be stopped as well and in no groups
                 joe = Contact.objects.get(id=joe.id)
@@ -4452,10 +4452,10 @@ class VumiTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1515", msg.external_id)
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual("1515", msg.external_id)
+                self.assertEqual(1, mock.call_count)
         finally:
             settings.SEND_MESSAGES = False
 
@@ -4475,13 +4475,13 @@ class ZenviaTest(TembaTest):
         data = dict(id="-1", status="500")
         response = self.client.get(reverse('handlers.zenvia_handler', args=['status', 'not-real-uuid']), data)
 
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id -1
         delivery_url = reverse('handlers.zenvia_handler', args=['status', self.channel.uuid])
         response = self.client.get(delivery_url, data)
 
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -4492,9 +4492,9 @@ class ZenviaTest(TembaTest):
         def assertStatus(sms, status, assert_status):
             data['status'] = status
             response = self.client.get(delivery_url, data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, '120', DELIVERED)
         assertStatus(msg, '111', SENT)
@@ -4509,15 +4509,15 @@ class ZenviaTest(TembaTest):
         callback_url = reverse('handlers.zenvia_handler', args=['receive', self.channel.uuid]) + encoded_message
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+5511996458779", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Héllo World!", msg.text)
+        self.assertEqual("+5511996458779", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Héllo World!", msg.text)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -4534,7 +4534,7 @@ class ZenviaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertEqual(mock.call_args[1]['params']['msg'], "Test message")
@@ -4549,8 +4549,8 @@ class ZenviaTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.get') as mock:
@@ -4561,8 +4561,8 @@ class ZenviaTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -4576,8 +4576,8 @@ class ZenviaTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
         finally:
@@ -4598,7 +4598,7 @@ class ZenviaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertEqual(mock.call_args[1]['params']['msg'],
@@ -4626,15 +4626,15 @@ class InfobipTest(TembaTest):
         callback_url = reverse('handlers.infobip_handler', args=['received', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+2347030767143', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual('+2347030767143', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
         # try it with an invalid receiver, should fail as UUID and receiver id are mismatched
         data['receiver'] = '2347030767145'
@@ -4644,7 +4644,7 @@ class InfobipTest(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 404 as the channel wasn't found
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
     def test_delivered(self):
         contact = self.create_contact("Joe", '+2347030767143')
@@ -4659,21 +4659,21 @@ class InfobipTest(TembaTest):
 
         # assert our SENT status
         response = self.client.post(delivery_url, data=base_body.replace('STATUS', 'SENT'), content_type='application/xml')
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         msg = Msg.objects.get()
-        self.assertEquals(SENT, msg.status)
+        self.assertEqual(SENT, msg.status)
 
         # assert our DELIVERED status
         response = self.client.post(delivery_url, data=base_body.replace('STATUS', 'DELIVERED'), content_type='application/xml')
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         msg = Msg.objects.get()
-        self.assertEquals(DELIVERED, msg.status)
+        self.assertEqual(DELIVERED, msg.status)
 
         # assert our FAILED status
         response = self.client.post(delivery_url, data=base_body.replace('STATUS', 'NOT_SENT'), content_type='application/xml')
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         msg = Msg.objects.get()
-        self.assertEquals(FAILED, msg.status)
+        self.assertEqual(FAILED, msg.status)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -4690,9 +4690,9 @@ class InfobipTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('12', msg.external_id)
+                self.assertEqual('12', msg.external_id)
 
                 self.clear_cache()
 
@@ -4704,8 +4704,8 @@ class InfobipTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.post') as mock:
@@ -4716,8 +4716,8 @@ class InfobipTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
         finally:
@@ -4738,9 +4738,9 @@ class InfobipTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('12', msg.external_id)
+                self.assertEqual('12', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['json']['text'],
                                  "Test message\nhttps://example.com/attachments/pic.jpg")
@@ -4778,7 +4778,7 @@ class MacrokioskTest(TembaTest):
                                args=['receive', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, "-1")
 
         # load our message
@@ -4807,7 +4807,7 @@ class MacrokioskTest(TembaTest):
                                args=['receive', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, "-1")
 
         # load our message
@@ -4829,7 +4829,7 @@ class MacrokioskTest(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         data = {'longcode': '1212', 'from': '+9771488532', 'text': 'Hello World', 'msgid': 'abc1234',
                 'time': datetime_to_str(two_hour_ago, format="%Y-%m-%d%H:%M:%S")}
@@ -4840,7 +4840,7 @@ class MacrokioskTest(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # try missing param
         data = {'from': '+9771488532', 'text': 'Hello World', 'msgid': 'abc1234',
@@ -4851,7 +4851,7 @@ class MacrokioskTest(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # try it with an invalid receiver, should fail as UUID and receiver id are mismatched
         data['shortcode'] = '1515'
@@ -4861,21 +4861,21 @@ class MacrokioskTest(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_status(self):
         # an invalid uuid
         data = dict(msgid='-1', status='ACCEPTED')
         response = self.client.get(reverse('handlers.macrokiosk_handler', args=['status', 'not-real-uuid']), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # a valid uuid, but invalid data
         status_url = reverse('handlers.macrokiosk_handler', args=['status', self.channel.uuid])
         response = self.client.get(status_url, dict())
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         response = self.client.get(status_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -4890,9 +4890,9 @@ class MacrokioskTest(TembaTest):
             sms.save()
             data['status'] = status
             response = self.client.get(status_url, data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(external_id=sms.external_id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'PROCESSING', WIRED)
         assertStatus(msg, 'ACCEPTED', SENT)
@@ -4915,9 +4915,9 @@ class MacrokioskTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('asdf-asdf-asdf-asdf', msg.external_id)
+                self.assertEqual('asdf-asdf-asdf-asdf', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['json']['text'], 'Test message')
                 self.assertEqual(mock.call_args[1]['json']['from'], 'macro')
@@ -4936,13 +4936,13 @@ class MacrokioskTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert verify was set to true
-                self.assertEquals(mock.call_args[1]['json']['text'], "Unicode. ☺")
-                self.assertEquals(mock.call_args[1]['json']['type'], 5)
-                self.assertEquals(mock.call_args[1]['json']['servid'], 'SERVICE-ID')
+                self.assertEqual(mock.call_args[1]['json']['text'], "Unicode. ☺")
+                self.assertEqual(mock.call_args[1]['json']['type'], 5)
+                self.assertEqual(mock.call_args[1]['json']['servid'], 'SERVICE-ID')
 
                 self.clear_cache()
 
@@ -4956,8 +4956,8 @@ class MacrokioskTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             # return something that isn't JSON
@@ -4969,14 +4969,14 @@ class MacrokioskTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 # we should have "Error" in our error log
                 log = ChannelLog.objects.filter(msg=msg).order_by('-pk')[0]
-                self.assertEquals("Error", log.response)
-                self.assertEquals(200, log.response_status)
+                self.assertEqual("Error", log.response)
+                self.assertEqual(200, log.response_status)
 
         finally:
             settings.SEND_MESSAGES = False
@@ -4998,9 +4998,9 @@ class MacrokioskTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('asdf-asdf-asdf-asdf', msg.external_id)
+                self.assertEqual('asdf-asdf-asdf-asdf', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['json']['text'],
                                  'Test message\nhttps://example.com/attachments/pic.jpg')
@@ -5028,15 +5028,15 @@ class BlackmynaTest(TembaTest):
         callback_url = reverse('handlers.blackmyna_handler', args=['receive', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+9771488532', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual('+9771488532', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
         # try it with an invalid receiver, should fail as UUID and receiver id are mismatched
         data['to'] = '1515'
@@ -5046,7 +5046,7 @@ class BlackmynaTest(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+9771488532")
@@ -5064,9 +5064,9 @@ class BlackmynaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('asdf-asdf-asdf-asdf', msg.external_id)
+                self.assertEqual('asdf-asdf-asdf-asdf', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['data']['message'], 'Test message')
 
@@ -5081,8 +5081,8 @@ class BlackmynaTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             # return something that isn't JSON
@@ -5094,14 +5094,14 @@ class BlackmynaTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 # we should have "Error" in our error log
                 log = ChannelLog.objects.filter(msg=msg).order_by('-pk')[0]
-                self.assertEquals("Error", log.response)
-                self.assertEquals(200, log.response_status)
+                self.assertEqual("Error", log.response)
+                self.assertEqual(200, log.response_status)
 
         finally:
             settings.SEND_MESSAGES = False
@@ -5122,9 +5122,9 @@ class BlackmynaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals('asdf-asdf-asdf-asdf', msg.external_id)
+                self.assertEqual('asdf-asdf-asdf-asdf', msg.external_id)
 
                 self.assertEqual(mock.call_args[1]['data']['message'],
                                  'Test message\nhttps://example.com/attachments/pic.jpg')
@@ -5138,15 +5138,15 @@ class BlackmynaTest(TembaTest):
         # an invalid uuid
         data = dict(id='-1', status='10')
         response = self.client.get(reverse('handlers.blackmyna_handler', args=['status', 'not-real-uuid']), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # a valid uuid, but invalid data
         status_url = reverse('handlers.blackmyna_handler', args=['status', self.channel.uuid])
         response = self.client.get(status_url, dict())
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         response = self.client.get(status_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -5161,9 +5161,9 @@ class BlackmynaTest(TembaTest):
             sms.save()
             data['status'] = status
             response = self.client.get(status_url, data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(external_id=sms.external_id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, '0', WIRED)
         assertStatus(msg, '1', DELIVERED)
@@ -5191,22 +5191,22 @@ class SMSCentralTest(TembaTest):
         callback_url = reverse('handlers.smscentral_handler', args=['receive', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+9771488532', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual('+9771488532', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
         # try it with an invalid channel
         callback_url = reverse('handlers.smscentral_handler', args=['receive', '1234-asdf']) + "?" + encoded_message
         response = self.client.get(callback_url)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+9771488532")
@@ -5223,7 +5223,7 @@ class SMSCentralTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 mock.assert_called_with('http://smail.smscentral.com.np/bp/ApiSms.php',
@@ -5243,8 +5243,8 @@ class SMSCentralTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             # return 400
@@ -5256,8 +5256,8 @@ class SMSCentralTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -5281,7 +5281,7 @@ class SMSCentralTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 mock.assert_called_with('http://smail.smscentral.com.np/bp/ApiSms.php',
@@ -5322,15 +5322,15 @@ class Hub9Test(TembaTest):
         callback_url = reverse('handlers.hub9_handler', args=['received', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+6289881134560', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual('+6289881134560', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
         # try it with an invalid receiver, should fail as UUID and receiver id are mismatched
         data['sendto'] = '6289881131111'
@@ -5340,7 +5340,7 @@ class Hub9Test(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 404 as the channel wasn't found
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
         # the case of 11 digits numer from hub9
         data = {
@@ -5355,15 +5355,15 @@ class Hub9Test(TembaTest):
         callback_url = reverse('handlers.hub9_handler', args=['received', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.all().order_by('-pk').first()
-        self.assertEquals('+62811999374', msg.contact.raw_tel())
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello Jakarta", msg.text)
+        self.assertEqual('+62811999374', msg.contact.raw_tel())
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello Jakarta", msg.text)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -5380,7 +5380,7 @@ class Hub9Test(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertTrue(mock.call_args[0][0].startswith(HUB9_ENDPOINT))
@@ -5396,8 +5396,8 @@ class Hub9Test(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
         finally:
             settings.SEND_MESSAGES = False
@@ -5417,7 +5417,7 @@ class Hub9Test(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.clear_cache()
@@ -5455,15 +5455,15 @@ class DartMediaTest(TembaTest):
         callback_url = reverse('handlers.dartmedia_handler', args=['received', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+6289881134560', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual('+6289881134560', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
         # try it with an invalid receiver, should fail as UUID and receiver id are mismatched
         data['sendto'] = '6289881131111'
@@ -5473,7 +5473,7 @@ class DartMediaTest(TembaTest):
         response = self.client.get(callback_url)
 
         # should get 404 as the channel wasn't found
-        self.assertEquals(404, response.status_code)
+        self.assertEqual(404, response.status_code)
 
         # the case of 11 digits number from dartmedia
         data = {
@@ -5488,15 +5488,15 @@ class DartMediaTest(TembaTest):
         callback_url = reverse('handlers.dartmedia_handler', args=['received', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.all().order_by('-pk').first()
-        self.assertEquals('+62811999374', msg.contact.raw_tel())
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello Jakarta", msg.text)
+        self.assertEqual('+62811999374', msg.contact.raw_tel())
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello Jakarta", msg.text)
 
         # short code do not have + in address
         self.channel.address = '12345'
@@ -5514,8 +5514,8 @@ class DartMediaTest(TembaTest):
         callback_url = reverse('handlers.dartmedia_handler', args=['received', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(401, response.status_code)
-        self.assertEquals(response.content, "Parameters message, original and sendto should not be null.")
+        self.assertEqual(401, response.status_code)
+        self.assertEqual(response.content, "Parameters message, original and sendto should not be null.")
 
         # all needed params
         data = {
@@ -5530,15 +5530,15 @@ class DartMediaTest(TembaTest):
         callback_url = reverse('handlers.dartmedia_handler', args=['received', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.all().order_by('-pk').first()
-        self.assertEquals('+62811999375', msg.contact.raw_tel())
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello Indonesia", msg.text)
+        self.assertEqual('+62811999375', msg.contact.raw_tel())
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello Indonesia", msg.text)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -5555,7 +5555,7 @@ class DartMediaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertTrue("message=Test+message" in mock.call_args[0][0])
@@ -5572,8 +5572,8 @@ class DartMediaTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
         finally:
             settings.SEND_MESSAGES = False
@@ -5593,7 +5593,7 @@ class DartMediaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertIn("message=Test+message%0Ahttps%3A%2F%2Fexample.com%2Fattachments%2Fpic.jpg", mock.call_args[0][0])
@@ -5621,23 +5621,23 @@ class HighConnectionTest(TembaTest):
         callback_url = reverse('handlers.hcnx_handler', args=['receive', self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+33610346460', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
-        self.assertEquals(14, msg.sent_on.astimezone(pytz.utc).hour)
+        self.assertEqual('+33610346460', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
+        self.assertEqual(14, msg.sent_on.astimezone(pytz.utc).hour)
 
         # try it with an invalid receiver, should fail as UUID isn't known
         callback_url = reverse('handlers.hcnx_handler', args=['receive', uuid.uuid4()])
         response = self.client.post(callback_url, data)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # create an outgoing message instead
         contact = msg.contact
@@ -5653,10 +5653,10 @@ class HighConnectionTest(TembaTest):
         callback_url = reverse('handlers.hcnx_handler', args=['status', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         msg = Msg.objects.get()
-        self.assertEquals(DELIVERED, msg.status)
+        self.assertEqual(DELIVERED, msg.status)
 
     def test_send_media(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -5673,7 +5673,7 @@ class HighConnectionTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 self.assertIn("text=Test+message%0Ahttps%3A%2F%2Fexample.com%2Fattachments%2Fpic.jpg", mock.call_args[0][0])
                 self.clear_cache()
@@ -5695,7 +5695,7 @@ class HighConnectionTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertTrue("text=Test+message" in mock.call_args[0][0])
@@ -5710,8 +5710,8 @@ class HighConnectionTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.get') as mock:
@@ -5722,8 +5722,8 @@ class HighConnectionTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -5784,7 +5784,7 @@ class TwilioTest(TembaTest):
             mock.add_header('Content-Type', 'audio/x-wav')
             response.return_value = mock
             response = self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
-            self.assertEquals(201, response.status_code)
+            self.assertEqual(201, response.status_code)
 
         # should have a single message with text and attachment
         msg = Msg.objects.get()
@@ -5854,7 +5854,7 @@ class TwilioTest(TembaTest):
         signature = validator.compute_signature('https://' + settings.TEMBA_HOST + '/handlers/twilio/', post_data)
         response = self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # connect twilio again
         self.channel.org.config = json.dumps({ACCOUNT_SID: self.account_sid,
@@ -5868,11 +5868,11 @@ class TwilioTest(TembaTest):
 
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("Hello World", msg1.text)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("Hello World", msg1.text)
 
         # try without including number, but with country
         del post_data['To']
@@ -5888,7 +5888,7 @@ class TwilioTest(TembaTest):
 
         # and we should have another new message
         msg2 = Msg.objects.exclude(pk=msg1.pk).get()
-        self.assertEquals(self.channel, msg2.channel)
+        self.assertEqual(self.channel, msg2.channel)
 
         # create an outgoing message instead
         contact = msg2.contact
@@ -5922,7 +5922,7 @@ class TwilioTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         msg = Msg.objects.get()
-        self.assertEquals(SENT, msg.status)
+        self.assertEqual(SENT, msg.status)
 
         # try it with a failed SMS
         Msg.objects.all().delete()
@@ -5936,7 +5936,7 @@ class TwilioTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         msg = Msg.objects.get()
-        self.assertEquals(FAILED, msg.status)
+        self.assertEqual(FAILED, msg.status)
 
         # no message with id
         Msg.objects.all().delete()
@@ -5978,14 +5978,14 @@ class TwilioTest(TembaTest):
             post_data
         )
         response = self.client.post(twiml_api_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383300", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("Hello World", msg1.text)
+        self.assertEqual("+250788383300", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("Hello World", msg1.text)
 
     def test_send(self):
         from temba.orgs.models import ACCOUNT_SID, ACCOUNT_TOKEN, APPLICATION_SID
@@ -6026,7 +6026,7 @@ class TwilioTest(TembaTest):
 
                     # check the status of the message is now sent
                     msg.refresh_from_db()
-                    self.assertEquals(WIRED, msg.status)
+                    self.assertEqual(WIRED, msg.status)
                     self.assertTrue(msg.sent_on)
 
                     self.clear_cache()
@@ -6043,9 +6043,9 @@ class TwilioTest(TembaTest):
 
                     response = self.client.post(callback_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
-                    self.assertEquals(response.status_code, 200)
+                    self.assertEqual(response.status_code, 200)
                     msg.refresh_from_db()
-                    self.assertEquals(msg.status, DELIVERED)
+                    self.assertEqual(msg.status, DELIVERED)
 
                     msg.status = WIRED
                     msg.save()
@@ -6056,9 +6056,9 @@ class TwilioTest(TembaTest):
 
                     response = self.client.post(callback_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
-                    self.assertEquals(response.status_code, 200)
+                    self.assertEqual(response.status_code, 200)
                     msg.refresh_from_db()
-                    self.assertEquals(msg.status, SENT)
+                    self.assertEqual(msg.status, SENT)
 
                     msg.status = WIRED
                     msg.save()
@@ -6069,9 +6069,9 @@ class TwilioTest(TembaTest):
 
                     response = self.client.post(callback_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
-                    self.assertEquals(response.status_code, 200)
+                    self.assertEqual(response.status_code, 200)
                     msg.refresh_from_db()
-                    self.assertEquals(msg.status, FAILED)
+                    self.assertEqual(msg.status, FAILED)
 
                     msg.status = WIRED
                     msg.save()
@@ -6084,8 +6084,8 @@ class TwilioTest(TembaTest):
 
                     # message should be marked as an error
                     msg.refresh_from_db()
-                    self.assertEquals(ERRORED, msg.status)
-                    self.assertEquals(1, msg.error_count)
+                    self.assertEqual(ERRORED, msg.status)
+                    self.assertEqual(1, msg.error_count)
                     self.assertTrue(msg.next_attempt)
 
                     mock.side_effect = TwilioRestException(400, "https://twilio.com/", "User has opted out", code=21610)
@@ -6095,22 +6095,22 @@ class TwilioTest(TembaTest):
 
                     # message should be marked as failed and the contact should be stopped
                     msg.refresh_from_db()
-                    self.assertEquals(FAILED, msg.status)
+                    self.assertEqual(FAILED, msg.status)
                     self.assertTrue(Contact.objects.get(id=msg.contact_id))
 
                     msg.channel = None
                     msg.save()
                     response = self.client.post(callback_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
-                    self.assertEquals(response.status_code, 200)
+                    self.assertEqual(response.status_code, 200)
 
                     missing_sms_callback_url = Channel.build_twilio_callback_url(channel_type, self.channel.uuid, msg.id + 100)
                     response = self.client.post(missing_sms_callback_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
-                    self.assertEquals(response.status_code, 400)
+                    self.assertEqual(response.status_code, 400)
 
                     with patch('temba.orgs.models.Org.is_connected_to_twilio') as mock_connected_twilio:
                         mock_connected_twilio.return_value = False
                         response = self.client.post(callback_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
-                        self.assertEquals(response.status_code, 400)
+                        self.assertEqual(response.status_code, 400)
 
             # check that our channel log works as well
             self.login(self.admin)
@@ -6118,12 +6118,12 @@ class TwilioTest(TembaTest):
             response = self.client.get(reverse('channels.channellog_list') + "?channel=%d" % (self.channel.pk))
 
             # there should be three log items for the three times we sent
-            self.assertEquals(3, len(response.context['channellog_list']))
+            self.assertEqual(3, len(response.context['channellog_list']))
 
             # number of items on this page should be right as well
-            self.assertEquals(3, response.context['paginator'].count)
-            self.assertEquals(2, self.channel.get_error_log_count())
-            self.assertEquals(1, self.channel.get_success_log_count())
+            self.assertEqual(3, response.context['paginator'].count)
+            self.assertEqual(2, self.channel.get_error_log_count())
+            self.assertEqual(1, self.channel.get_success_log_count())
 
             # view the detailed information for one of them
             response = self.client.get(reverse('channels.channellog_read', args=[ChannelLog.objects.order_by('id')[1].id]))
@@ -6136,8 +6136,8 @@ class TwilioTest(TembaTest):
 
             # our channel counts should be updated
             self.channel = Channel.objects.get(id=self.channel.pk)
-            self.assertEquals(0, self.channel.get_error_log_count())
-            self.assertEquals(1, self.channel.get_success_log_count())
+            self.assertEqual(0, self.channel.get_error_log_count())
+            self.assertEqual(1, self.channel.get_success_log_count())
 
     def test_send_media(self):
         from temba.orgs.models import ACCOUNT_SID, ACCOUNT_TOKEN, APPLICATION_SID
@@ -6161,11 +6161,11 @@ class TwilioTest(TembaTest):
 
             # check the status of the message is now sent
             msg.refresh_from_db()
-            self.assertEquals(WIRED, msg.status)
+            self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
 
-            self.assertEquals(mock.call_args[1]['media_url'], [])
-            self.assertEquals(mock.call_args[1]['body'], "Test message\nhttps://example.com/attachments/pic.jpg")
+            self.assertEqual(mock.call_args[1]['media_url'], [])
+            self.assertEqual(mock.call_args[1]['body'], "Test message\nhttps://example.com/attachments/pic.jpg")
 
             self.clear_cache()
 
@@ -6179,9 +6179,9 @@ class TwilioTest(TembaTest):
 
             response = self.client.post(callback_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             msg.refresh_from_db()
-            self.assertEquals(msg.status, DELIVERED)
+            self.assertEqual(msg.status, DELIVERED)
 
             self.channel.country = 'US'
             self.channel.save()
@@ -6194,11 +6194,11 @@ class TwilioTest(TembaTest):
 
             # check the status of the message is now sent
             msg.refresh_from_db()
-            self.assertEquals(WIRED, msg.status)
+            self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
 
-            self.assertEquals(mock.call_args[1]['media_url'], ['https://example.com/attachments/pic.jpg'])
-            self.assertEquals(mock.call_args[1]['body'], "MT")
+            self.assertEqual(mock.call_args[1]['media_url'], ['https://example.com/attachments/pic.jpg'])
+            self.assertEqual(mock.call_args[1]['body'], "MT")
 
             self.clear_cache()
 
@@ -6240,15 +6240,15 @@ class TwilioMessagingServiceTest(TembaTest):
         )
         response = self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("Hello World", msg1.text)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("Hello World", msg1.text)
 
         # remove twilio connection
         self.channel.org.config = json.dumps({})
@@ -6260,7 +6260,7 @@ class TwilioMessagingServiceTest(TembaTest):
         )
         response = self.client.post(twilio_url, post_data, **{'HTTP_X_TWILIO_SIGNATURE': signature})
 
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
 
 class ClickatellTest(TembaTest):
@@ -6289,17 +6289,17 @@ class ClickatellTest(TembaTest):
 
         response = self.client.get(receive_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals(u"mexico k mis papas no ten\xeda dinero para comprarnos lo q quer\xedamos..", msg1.text)
-        self.assertEquals(2012, msg1.sent_on.year)
-        self.assertEquals('id1234', msg1.external_id)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual(u"mexico k mis papas no ten\xeda dinero para comprarnos lo q quer\xedamos..", msg1.text)
+        self.assertEqual(2012, msg1.sent_on.year)
+        self.assertEqual('id1234', msg1.external_id)
 
     def test_receive_iso_8859_1(self):
         self.channel.org.config = json.dumps({Channel.CONFIG_API_ID: '12345', Channel.CONFIG_USERNAME: 'uname', Channel.CONFIG_PASSWORD: 'pword'})
@@ -6317,17 +6317,17 @@ class ClickatellTest(TembaTest):
 
         response = self.client.get(receive_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals(u'4Ai mapfumbamwe vana 4 kuwacha handingapedze izvozvo ndozvikukonzera kt varoorwe varipwere ngapaonekwe ipapo ndatenda.', msg1.text)
-        self.assertEquals(2012, msg1.sent_on.year)
-        self.assertEquals('id1234', msg1.external_id)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual(u'4Ai mapfumbamwe vana 4 kuwacha handingapedze izvozvo ndozvikukonzera kt varoorwe varipwere ngapaonekwe ipapo ndatenda.', msg1.text)
+        self.assertEqual(2012, msg1.sent_on.year)
+        self.assertEqual('id1234', msg1.external_id)
 
         Msg.objects.all().delete()
 
@@ -6338,16 +6338,16 @@ class ClickatellTest(TembaTest):
 
         response = self.client.get(receive_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("Artwell Sìbbnda", msg1.text)
-        self.assertEquals(2012, msg1.sent_on.year)
-        self.assertEquals('id1234', msg1.external_id)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("Artwell Sìbbnda", msg1.text)
+        self.assertEqual(2012, msg1.sent_on.year)
+        self.assertEqual('id1234', msg1.external_id)
 
         Msg.objects.all().delete()
 
@@ -6358,16 +6358,16 @@ class ClickatellTest(TembaTest):
 
         response = self.client.get(receive_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("a? £irvine stinta?¥.  ", msg1.text)
-        self.assertEquals(2012, msg1.sent_on.year)
-        self.assertEquals('id1234', msg1.external_id)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("a? £irvine stinta?¥.  ", msg1.text)
+        self.assertEqual(2012, msg1.sent_on.year)
+        self.assertEqual('id1234', msg1.external_id)
 
         Msg.objects.all().delete()
 
@@ -6379,16 +6379,16 @@ class ClickatellTest(TembaTest):
 
         response = self.client.get(receive_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("when? or What? is this ", msg1.text)
-        self.assertEquals(2012, msg1.sent_on.year)
-        self.assertEquals('id1234', msg1.external_id)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("when? or What? is this ", msg1.text)
+        self.assertEqual(2012, msg1.sent_on.year)
+        self.assertEqual('id1234', msg1.external_id)
 
     def test_receive(self):
         self.channel.org.config = json.dumps({Channel.CONFIG_API_ID: '12345', Channel.CONFIG_USERNAME: 'uname', Channel.CONFIG_PASSWORD: 'pword'})
@@ -6405,20 +6405,20 @@ class ClickatellTest(TembaTest):
 
         response = self.client.get(receive_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("Hello World", msg1.text)
-        self.assertEquals(2012, msg1.sent_on.year)
+        self.assertEqual("+250788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("Hello World", msg1.text)
+        self.assertEqual(2012, msg1.sent_on.year)
 
         # times are sent as GMT+2
-        self.assertEquals(8, msg1.sent_on.hour)
-        self.assertEquals('id1234', msg1.external_id)
+        self.assertEqual(8, msg1.sent_on.hour)
+        self.assertEqual('id1234', msg1.external_id)
 
     def test_status(self):
         self.channel.org.config = json.dumps({Channel.CONFIG_API_ID: '12345', Channel.CONFIG_USERNAME: 'uname', Channel.CONFIG_PASSWORD: 'pword'})
@@ -6435,13 +6435,13 @@ class ClickatellTest(TembaTest):
         callback_url = reverse('handlers.clickatell_handler', args=['status', self.channel.uuid]) + "?" + encoded_message
         response = self.client.get(callback_url)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # reload our message
         msg = Msg.objects.get(pk=msg.pk)
 
         # make sure it is marked as failed
-        self.assertEquals(FAILED, msg.status)
+        self.assertEqual(FAILED, msg.status)
 
         # reset our status to WIRED
         msg.status = WIRED
@@ -6458,7 +6458,7 @@ class ClickatellTest(TembaTest):
         msg = Msg.objects.all().order_by('-pk').first()
 
         # make sure it is marked as delivered
-        self.assertEquals(DELIVERED, msg.status)
+        self.assertEqual(DELIVERED, msg.status)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -6476,7 +6476,7 @@ class ClickatellTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 params = {'api_id': 'api1',
                           'user': 'uname',
@@ -6502,7 +6502,7 @@ class ClickatellTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 self.assertEqual(msg.external_id, "15")
                 params = {'api_id': 'api1',
@@ -6528,8 +6528,8 @@ class ClickatellTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.get') as mock:
@@ -6540,8 +6540,8 @@ class ClickatellTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -6566,7 +6566,7 @@ class ClickatellTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 params = {'api_id': 'api1',
                           'user': 'uname',
@@ -6622,15 +6622,15 @@ class TelegramTest(TembaTest):
 
         receive_url = reverse('handlers.telegram_handler', args=[self.channel.uuid])
         response = self.client.post(receive_url, data, content_type='application/json')
-        self.assertEquals(201, response.status_code)
+        self.assertEqual(201, response.status_code)
 
         # and we should have a new message
         msg1 = Msg.objects.get()
-        self.assertEquals('3527065', msg1.contact.get_urn(TELEGRAM_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("Hello World", msg1.text)
+        self.assertEqual('3527065', msg1.contact.get_urn(TELEGRAM_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("Hello World", msg1.text)
         self.assertEqual(msg1.contact.name, 'Nic Pottier')
 
         def test_file_message(data, file_path, content_type, extension, caption=None):
@@ -6644,7 +6644,7 @@ class TelegramTest(TembaTest):
                     get.return_value = MockResponse(200, "Fake image bits", headers={"Content-Type": content_type})
 
                     response = self.client.post(receive_url, data, content_type='application/json')
-                    self.assertEquals(201, response.status_code)
+                    self.assertEqual(201, response.status_code)
 
                     # should have a new message
                     msg = Msg.objects.get()
@@ -6978,11 +6978,11 @@ class TelegramTest(TembaTest):
         self.assertEqual(response_json.get("description"), "Message accepted")
 
         msg1 = Msg.objects.get()
-        self.assertEquals('3527065', msg1.contact.get_urn(TELEGRAM_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("/startup", msg1.text)
+        self.assertEqual('3527065', msg1.contact.get_urn(TELEGRAM_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("/startup", msg1.text)
         self.assertEqual(msg1.contact.name, 'Nic Pottier')
 
         Msg.objects.all().delete()
@@ -7016,11 +7016,11 @@ class TelegramTest(TembaTest):
         self.assertEqual(response_json.get("description"), "Message accepted")
 
         msg1 = Msg.objects.get()
-        self.assertEquals('3527065', msg1.contact.get_urn(TELEGRAM_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals("start Hello World", msg1.text)
+        self.assertEqual('3527065', msg1.contact.get_urn(TELEGRAM_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual("start Hello World", msg1.text)
         self.assertEqual(msg1.contact.name, 'Nic Pottier')
 
     def test_send(self):
@@ -7038,7 +7038,7 @@ class TelegramTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 self.clear_cache()
 
@@ -7054,8 +7054,8 @@ class TelegramTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
         finally:
@@ -7075,7 +7075,7 @@ class TelegramTest(TembaTest):
 
             # check the status of the message is now sent
             msg.refresh_from_db()
-            self.assertEquals(WIRED, msg.status)
+            self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
             self.clear_cache()
 
@@ -7090,7 +7090,7 @@ class TelegramTest(TembaTest):
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
             msg.refresh_from_db()
-            self.assertEquals(WIRED, msg.status)
+            self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
             self.clear_cache()
 
@@ -7105,7 +7105,7 @@ class TelegramTest(TembaTest):
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
             msg.refresh_from_db()
-            self.assertEquals(WIRED, msg.status)
+            self.assertEqual(WIRED, msg.status)
             self.assertTrue(msg.sent_on)
             self.clear_cache()
 
@@ -7140,37 +7140,37 @@ class PlivoTest(TembaTest):
 
     def test_receive(self):
         response = self.client.get(reverse('handlers.plivo_handler', args=['receive', 'not-real-uuid']), dict())
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         data = dict(MessageUUID="msg-uuid", Text="Hey, there", To="254788383383", From="254788383383")
         receive_url = reverse('handlers.plivo_handler', args=['receive', self.channel.uuid])
         response = self.client.get(receive_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         data = dict(MessageUUID="msg-uuid", Text="Hey, there", To=self.channel.address.lstrip('+'), From="254788383383")
         response = self.client.get(receive_url, data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         msg1 = Msg.objects.get()
-        self.assertEquals("+254788383383", msg1.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg1.direction)
-        self.assertEquals(self.org, msg1.org)
-        self.assertEquals(self.channel, msg1.channel)
-        self.assertEquals('Hey, there', msg1.text)
+        self.assertEqual("+254788383383", msg1.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg1.direction)
+        self.assertEqual(self.org, msg1.org)
+        self.assertEqual(self.channel, msg1.channel)
+        self.assertEqual('Hey, there', msg1.text)
 
     def test_status(self):
         # an invalid uuid
         data = dict(MessageUUID="-1", Status="delivered", From=self.channel.address.lstrip('+'), To="254788383383")
         response = self.client.get(reverse('handlers.plivo_handler', args=['status', 'not-real-uuid']), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # a valid uuid, but invalid data
         delivery_url = reverse('handlers.plivo_handler', args=['status', self.channel.uuid])
         response = self.client.get(delivery_url, dict())
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         response = self.client.get(delivery_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -7185,9 +7185,9 @@ class PlivoTest(TembaTest):
             sms.save()
             data['Status'] = status
             response = self.client.get(delivery_url, data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(external_id=sms.external_id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'queued', WIRED)
         assertStatus(msg, 'sent', SENT)
@@ -7212,7 +7212,7 @@ class PlivoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertEqual(json.loads(mock.call_args[1]['data'])['text'], "Test message")
@@ -7226,8 +7226,8 @@ class PlivoTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.get') as mock:
@@ -7238,8 +7238,8 @@ class PlivoTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -7265,7 +7265,7 @@ class PlivoTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 self.assertEqual(json.loads(mock.call_args[1]['data'])['text'],
@@ -7382,12 +7382,12 @@ class TwitterTest(TembaTest):
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
                 # assert we were only called once
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual(1, mock.call_count)
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
-                self.assertEquals('1234567890', msg.external_id)
+                self.assertEqual(WIRED, msg.status)
+                self.assertEqual('1234567890', msg.external_id)
                 self.assertTrue(msg.sent_on)
                 self.assertEqual(mock.call_args[1]['text'], "MT\nhttps://example.com/attachments/pic.jpg")
 
@@ -7413,13 +7413,13 @@ class TwitterTest(TembaTest):
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
                 # assert we were only called once
-                self.assertEquals(1, mock.call_count)
-                self.assertEquals("10002", mock.call_args[1]['data']['user_id'])
+                self.assertEqual(1, mock.call_count)
+                self.assertEqual("10002", mock.call_args[1]['data']['user_id'])
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
-                self.assertEquals('1234567890', msg.external_id)
+                self.assertEqual(WIRED, msg.status)
+                self.assertEqual('1234567890', msg.external_id)
                 self.assertTrue(msg.sent_on)
                 self.assertEqual(mock.call_args[1]['data']['text'], msg.text)
 
@@ -7440,13 +7440,13 @@ class TwitterTest(TembaTest):
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
                 # assert we were only called once
-                self.assertEquals(1, mock.call_count)
-                self.assertEquals("joe81", mock.call_args[1]['data']['screen_name'])
+                self.assertEqual(1, mock.call_count)
+                self.assertEqual("joe81", mock.call_args[1]['data']['screen_name'])
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
-                self.assertEquals('1234567890', msg.external_id)
+                self.assertEqual(WIRED, msg.status)
+                self.assertEqual('1234567890', msg.external_id)
                 self.assertTrue(msg.sent_on)
                 self.assertEqual(mock.call_args[1]['data']['text'], msg.text)
 
@@ -7462,10 +7462,10 @@ class TwitterTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
-                self.assertEquals("Failed to send message", ChannelLog.objects.get(msg=msg).description)
+                self.assertEqual("Failed to send message", ChannelLog.objects.get(msg=msg).description)
 
                 self.clear_cache()
 
@@ -7479,8 +7479,8 @@ class TwitterTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 # should not fail the contact
@@ -7500,8 +7500,8 @@ class TwitterTest(TembaTest):
 
                 # should fail the message
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
 
                 # should be stopped
                 contact = Contact.objects.get(id=self.joe.id)
@@ -7523,8 +7523,8 @@ class TwitterTest(TembaTest):
 
                 # should fail the message
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
 
                 # should fail the contact permanently (i.e. removed from groups)
                 contact = Contact.objects.get(id=self.joe.id)
@@ -7780,21 +7780,21 @@ class StartMobileTest(TembaTest):
         callback_url = reverse('handlers.start_handler', args=['receive', self.channel.uuid])
         response = self.client.post(callback_url, content_type='application/xml', data=body)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+250788123123', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World", msg.text)
+        self.assertEqual('+250788123123', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World", msg.text)
 
         # try it with an invalid body
         response = self.client.post(callback_url, content_type='application/xml', data="invalid body")
 
         # should get a 400, as the body is invalid
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         Msg.objects.all().delete()
 
@@ -7809,22 +7809,22 @@ class StartMobileTest(TembaTest):
         """
         response = self.client.post(callback_url, content_type='application/xml', data=body)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals('+250788123123', msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("", msg.text)
+        self.assertEqual('+250788123123', msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("", msg.text)
 
         # try it with an invalid channel
         callback_url = reverse('handlers.start_handler', args=['receive', '1234-asdf'])
         response = self.client.post(callback_url, content_type='application/xml', data=body)
 
         # should get 400 as the channel wasn't found
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_send(self):
         joe = self.create_contact("Joe", "+977788123123")
@@ -7844,7 +7844,7 @@ class StartMobileTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 self.assertEqual(msg.external_id, "380502535130309161501")
 
@@ -7865,8 +7865,8 @@ class StartMobileTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
                 self.clear_cache()
 
@@ -7879,8 +7879,8 @@ class StartMobileTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
                 self.clear_cache()
 
@@ -7893,8 +7893,8 @@ class StartMobileTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
                 self.clear_cache()
 
@@ -7921,7 +7921,7 @@ class StartMobileTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
                 self.assertEqual(msg.external_id, "380502535130309161501")
 
@@ -7953,11 +7953,11 @@ class ChikkaTest(TembaTest):
         # try with an invalid channel uuid
         data = dict(message_type='outgoing', message_id=1001, status='FAILED')
         response = self.client.post(reverse('handlers.chikka_handler', args=['not-real-uuid']), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id 1001, should return 400 as well
         response = self.client.post(reverse('handlers.chikka_handler', args=[self.channel.uuid]), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+63911231234")
@@ -7967,7 +7967,7 @@ class ChikkaTest(TembaTest):
         # valid id, invalid status, 400
         data['status'] = 'INVALID'
         response = self.client.post(reverse('handlers.chikka_handler', args=[self.channel.uuid]), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         def assertStatus(sms, status, assert_status):
             sms.status = WIRED
@@ -7975,9 +7975,9 @@ class ChikkaTest(TembaTest):
 
             data['status'] = status
             response = self.client.post(reverse('handlers.chikka_handler', args=[self.channel.uuid]), data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             updated_sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, updated_sms.status)
+            self.assertEqual(assert_status, updated_sms.status)
 
         assertStatus(msg, 'FAILED', FAILED)
         assertStatus(msg, 'SENT', SENT)
@@ -7988,17 +7988,17 @@ class ChikkaTest(TembaTest):
         callback_url = reverse('handlers.chikka_handler', args=[self.channel.uuid])
         response = self.client.post(callback_url, data)
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+639178020779", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World!", msg.text)
-        self.assertEquals('4004', msg.external_id)
-        self.assertEquals(msg.sent_on.date(), date(day=11, month=3, year=2016))
+        self.assertEqual("+639178020779", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World!", msg.text)
+        self.assertEqual('4004', msg.external_id)
+        self.assertEqual(msg.sent_on.date(), date(day=11, month=3, year=2016))
 
     def test_send(self):
         joe = self.create_contact("Joe", '+63911231234')
@@ -8020,7 +8020,7 @@ class ChikkaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # check we were called as a send
@@ -8038,7 +8038,7 @@ class ChikkaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # assert that we were called as a reply
@@ -8064,7 +8064,7 @@ class ChikkaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 first_call_args = mock.call_args_list[0][1]['data']
@@ -8080,8 +8080,8 @@ class ChikkaTest(TembaTest):
 
                 # our message should be succeeded
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
-                self.assertEquals(0, msg.error_count)
+                self.assertEqual(WIRED, msg.status)
+                self.assertEqual(0, msg.error_count)
 
                 self.clear_cache()
 
@@ -8103,8 +8103,8 @@ class ChikkaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.post') as mock:
@@ -8115,8 +8115,8 @@ class ChikkaTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.clear_cache()
@@ -8129,8 +8129,8 @@ class ChikkaTest(TembaTest):
                 msg.refresh_from_db()
 
                 # third try, we should be failed now
-                self.assertEquals(FAILED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(FAILED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
     def test_send_media(self):
@@ -8153,7 +8153,7 @@ class ChikkaTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
 
                 # check we were called as a send
@@ -8180,12 +8180,12 @@ class JasminTest(TembaTest):
         # ok, what happens with an invalid uuid?
         data = dict(id="-1", dlvr="0", err="0")
         response = self.client.post(reverse('handlers.jasmin_handler', args=['status', 'not-real-uuid']), data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id -1
         delivery_url = reverse('handlers.jasmin_handler', args=['status', self.channel.uuid])
         response = self.client.post(delivery_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -8199,9 +8199,9 @@ class JasminTest(TembaTest):
             data['dlvrd'] = dlvrd
             data['err'] = err
             response = self.client.post(reverse('handlers.jasmin_handler', args=['status', self.channel.uuid]), data)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 0, 0, WIRED)
         assertStatus(msg, 1, 0, DELIVERED)
@@ -8225,11 +8225,11 @@ class JasminTest(TembaTest):
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("+250788383383", msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("événement", msg.text)
+        self.assertEqual("+250788383383", msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("événement", msg.text)
 
     def test_send(self):
         from temba.utils import gsm7
@@ -8264,7 +8264,7 @@ class JasminTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
         with patch('requests.get') as mock:
             # force an exception
@@ -8275,7 +8275,7 @@ class JasminTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
             self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                               "referenced before assignment"))
@@ -8359,14 +8359,14 @@ class JunebugTest(JunebugTestMixin, TembaTest):
         response = self.client.get(
             reverse('handlers.junebug_handler',
                     args=['event', self.channel.uuid]))
-        self.assertEquals(response.status_code, 400)
+        self.assertEqual(response.status_code, 400)
 
     def test_status_with_invalid_event(self):
         delivery_url = reverse('handlers.junebug_handler',
                                args=['event', self.channel.uuid])
         response = self.client.post(delivery_url, data=json.dumps({}),
                                     content_type='application/json')
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertTrue('Missing one of' in response.content)
 
     def test_status(self):
@@ -8377,14 +8377,14 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                     args=['event', 'not-real-uuid']),
             data=json.dumps(data),
             content_type='application/json')
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id -1
         delivery_url = reverse('handlers.junebug_handler',
                                args=['event', self.channel.uuid])
         response = self.client.post(delivery_url, data=json.dumps(data),
                                     content_type='application/json')
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, lets create an outgoing message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -8401,9 +8401,9 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                         args=['event', self.channel.uuid]),
                 data=json.dumps(data),
                 content_type='application/json')
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'submitted', SENT)
         assertStatus(msg, 'delivery_succeeded', DELIVERED)
@@ -8418,8 +8418,8 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                     args=['event', self.channel.uuid]),
             data=json.dumps(data),
             content_type='application/json')
-        self.assertEquals(400, response.status_code)
-        self.assertEquals(
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
             response.content,
             "Message with external id of '%s' not found" % (
                 data['message_id'],))
@@ -8442,9 +8442,9 @@ class JunebugTest(JunebugTestMixin, TembaTest):
                 data=json.dumps(data),
                 content_type='application/json',
                 HTTP_AUTHORIZATION="Token UjOq8ATo2PDS6L08t6vlqSoK")
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'submitted', SENT)
         assertStatus(msg, 'delivery_succeeded', DELIVERED)
@@ -8463,14 +8463,14 @@ class JunebugTest(JunebugTestMixin, TembaTest):
             data=json.dumps(data),
             content_type='application/json',
             HTTP_AUTHORIZATION="Token Not_token")
-        self.assertEquals(401, response.status_code)
+        self.assertEqual(401, response.status_code)
 
     def test_receive_with_invalid_message(self):
         callback_url = reverse('handlers.junebug_handler',
                                args=['inbound', self.channel.uuid])
         response = self.client.post(callback_url, json.dumps({}),
                                     content_type='application/json')
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertTrue('Missing one of' in response.content)
 
     def test_receive(self):
@@ -8485,11 +8485,11 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals(data["from"], msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("événement", msg.text)
+        self.assertEqual(data["from"], msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("événement", msg.text)
 
     def test_receive_with_auth(self):
         self.channel.secret = "UjOq8ATo2PDS6L08t6vlqSoK"
@@ -8507,11 +8507,11 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals(data["from"], msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("événement", msg.text)
+        self.assertEqual(data["from"], msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("événement", msg.text)
 
     def test_receive_with_incorrect_auth(self):
         self.channel.secret = "UjOq8ATo2PDS6L08t6vlqSoK"
@@ -8594,7 +8594,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
     def test_send_errored_exception(self):
         joe = self.create_contact("Joe", "+250788383383")
@@ -8611,7 +8611,7 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
             self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                               "referenced before assignment"))
@@ -8674,24 +8674,24 @@ class MbloxTest(TembaTest):
         data = dict(batch_id="-1", status="Failed", type="recipient_delivery_report_sms")
         response = self.client.post(reverse('handlers.mblox_handler', args=['not-real-uuid']), json.dumps(data),
                                     content_type="application/json")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         delivery_url = reverse('handlers.mblox_handler', args=[self.channel.uuid])
 
         # missing batch_id param
         data = dict(status="Failed", type="recipient_delivery_report_sms")
         response = self.client.post(delivery_url, json.dumps(data), content_type="application/json")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # missing type params
         data = dict(status="Failed")
         response = self.client.post(delivery_url, json.dumps(data), content_type="application/json")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # valid uuid, invalid batch_id
         data = dict(batch_id="-1", status="Failed", type="recipient_delivery_report_sms")
         response = self.client.post(delivery_url, json.dumps(data), content_type="application/json")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # create test message to update
         joe = self.create_contact("Joe Biden", "+254788383383")
@@ -8705,10 +8705,10 @@ class MbloxTest(TembaTest):
             Msg.objects.filter(id=msg.id).update(status=WIRED)
             data['status'] = status
             response = self.client.post(delivery_url, json.dumps(data), content_type="application/json")
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             self.assertEqual(response.content, "SMS Updated: %d" % msg.id)
             msg = Msg.objects.get(pk=msg.id)
-            self.assertEquals(assert_status, msg.status)
+            self.assertEqual(assert_status, msg.status)
 
         assertStatus(msg, "Delivered", DELIVERED)
         assertStatus(msg, "Dispatched", SENT)
@@ -8770,7 +8770,7 @@ class MbloxTest(TembaTest):
             self.assertTrue(mock.called)
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
         with patch('requests.post') as mock:
             mock.side_effect = Exception('Kaboom!')
@@ -8781,7 +8781,7 @@ class MbloxTest(TembaTest):
             self.assertTrue(mock.called)
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
             self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                               "referenced before assignment"))
@@ -8886,18 +8886,18 @@ class FacebookTest(TembaTest):
         body = dict()
         response = self.client.post(reverse('handlers.facebook_handler', args=['invalid']), json.dumps(body),
                                     content_type="application/json")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # invalid body
         response = self.client.post(reverse('handlers.facebook_handler', args=[self.channel.uuid]), json.dumps(body),
                                     content_type="application/json")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # no known msgs, gracefully ignore
         body = dict(entry=[dict()])
         response = self.client.post(reverse('handlers.facebook_handler', args=[self.channel.uuid]), json.dumps(body),
                                     content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # create test message to update
         joe = self.create_contact("Joe Biden", urn='facebook:1234')
@@ -9417,7 +9417,7 @@ class FacebookTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
         with patch('requests.post') as mock:
             mock.side_effect = Exception('Kaboom!')
@@ -9427,7 +9427,7 @@ class FacebookTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
             self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                               "referenced before assignment"))
@@ -9478,7 +9478,7 @@ class FacebookTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
         with patch('requests.post') as mock:
             mock.side_effect = [MockResponse(200, '{"recipient_id":"1234", '
@@ -9490,7 +9490,7 @@ class FacebookTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
 
             self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
                                                                               "referenced before assignment"))
@@ -9611,7 +9611,7 @@ class JiochatTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(msg.status, ERRORED)
+            self.assertEqual(msg.status, ERRORED)
 
         with patch('requests.post') as mock:
             mock.side_effect = Exception('Kaboom!')
@@ -9621,7 +9621,7 @@ class JiochatTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(msg.status, ERRORED)
+            self.assertEqual(msg.status, ERRORED)
 
     @patch('temba.utils.jiochat.JiochatClient.get_user_detail')
     def test_follow(self, mock_get_user_detail):
@@ -9953,7 +9953,7 @@ class GlobeTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
             self.clear_cache()
 
         with patch('requests.get') as mock:
@@ -9964,7 +9964,7 @@ class GlobeTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
             self.clear_cache()
 
         with patch('requests.post') as mock:
@@ -9975,7 +9975,7 @@ class GlobeTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(FAILED, msg.status)
+            self.assertEqual(FAILED, msg.status)
             self.clear_cache()
 
             self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -10024,12 +10024,12 @@ class ViberTest(TembaTest):
         # ok, what happens with an invalid uuid?
         response = self.client.post(reverse('handlers.viber_handler', args=['status', 'not-real-uuid']), json.dumps(data),
                                     content_type="application/json")
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         # ok, try with a valid uuid, but invalid message id (no msg yet)
         status_url = reverse('handlers.viber_handler', args=['status', self.channel.uuid])
         response = self.client.post(status_url, json.dumps(data), content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertContains(response, 'not found')
 
         # ok, lets create an outgoing message to update
@@ -10040,10 +10040,10 @@ class ViberTest(TembaTest):
 
         response = self.client.post(status_url, json.dumps(data), content_type="application/json")
         self.assertNotContains(response, 'not found')
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         msg = Msg.objects.get(pk=msg.id)
-        self.assertEquals(DELIVERED, msg.status)
+        self.assertEqual(DELIVERED, msg.status)
 
         # ignore status report from viber for incoming message
         incoming = self.create_msg(direction=INCOMING, contact=joe, text="Read message")
@@ -10052,7 +10052,7 @@ class ViberTest(TembaTest):
 
         data['message_token'] = 88888
         response = self.client.post(status_url, json.dumps(data), content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
     def test_receive(self):
         # invalid UUID
@@ -10137,7 +10137,7 @@ class ViberTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
             self.clear_cache()
 
         with patch('requests.post') as mock:
@@ -10148,7 +10148,7 @@ class ViberTest(TembaTest):
 
             # check the status of the message now errored
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
             self.clear_cache()
 
     def test_send_media(self):
@@ -10219,17 +10219,17 @@ class LineTest(TembaTest):
         callback_url = reverse('handlers.line_handler', args=[self.channel.uuid])
         response = self.client.post(callback_url, json.dumps(data), content_type="application/json")
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("uabcdefghij", msg.contact.get_urn(LINE_SCHEME).path)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello, world", msg.text)
+        self.assertEqual("uabcdefghij", msg.contact.get_urn(LINE_SCHEME).path)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello, world", msg.text)
 
         response = self.client.get(callback_url)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         data = {
             "events": [{
@@ -10246,7 +10246,7 @@ class LineTest(TembaTest):
         callback_url = reverse('handlers.line_handler', args=[self.channel.uuid])
         response = self.client.post(callback_url, json.dumps(data), content_type="application/json")
 
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_send(self):
         joe = self.create_contact("Joe", urn="line:uabcdefghijkl")
@@ -10274,8 +10274,8 @@ class LineTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
             with patch('requests.post') as mock:
@@ -10286,8 +10286,8 @@ class LineTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(2, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(2, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
                 self.assertFalse(ChannelLog.objects.filter(description__icontains="local variable 'response' "
@@ -10613,14 +10613,14 @@ class ViberPublicTest(TembaTest):
             mock.return_value = MockResponse(401, '{"status":"5"}')
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
             self.clear_cache()
 
         with patch('requests.post') as mock:
             mock.side_effect = Exception("Unable to reach host")
             Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
             msg.refresh_from_db()
-            self.assertEquals(ERRORED, msg.status)
+            self.assertEqual(ERRORED, msg.status)
             self.clear_cache()
 
     def test_send_media(self):
@@ -10675,49 +10675,49 @@ class FcmTest(TembaTest):
 
         data = {'from': '12345abcde', 'msg': 'Hello World!', 'date': '2017-01-01T08:50:00.000'}
         response = self.client.post(self.receive_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         data = {'from': '12345abcde', 'msg': 'Hello World!', 'date': '2017-01-01T08:50:00.000',
                 'fcm_token': '1234567890qwertyuiop'}
         response = self.client.post(self.receive_url, data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         data = {'from': '12345abcde', 'msg': 'Hello World!', 'date': '2017-01-01T08:50:00.000',
                 'fcm_token': '12345678901qwertyuiopq'}
         response = self.client.post(self.receive_url, data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # load our message
         msg = Msg.objects.get()
-        self.assertEquals("12345678901qwertyuiopq", msg.contact.get_urn(FCM_SCHEME).auth)
-        self.assertEquals("fcm:12345abcde", six.text_type(msg.contact.get_urn(FCM_SCHEME)))
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello World!", msg.text)
+        self.assertEqual("12345678901qwertyuiopq", msg.contact.get_urn(FCM_SCHEME).auth)
+        self.assertEqual("fcm:12345abcde", six.text_type(msg.contact.get_urn(FCM_SCHEME)))
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello World!", msg.text)
 
     def test_register(self):
         data = {'urn': '12345abcde'}
         response = self.client.post(self.register_url, data)
-        self.assertEquals(400, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         data = {'urn': '12345abcde', 'fcm_token': '1234567890qwertyuiop'}
         response = self.client.post(self.register_url, data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         contact = json.loads(response.content)
 
         data = {'urn': '12345abcde', 'fcm_token': 'qwertyuiop1234567890'}
         response = self.client.post(self.register_url, data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         updated_contact = json.loads(response.content)
 
-        self.assertEquals(contact.get('contact_uuid'), updated_contact.get('contact_uuid'))
+        self.assertEqual(contact.get('contact_uuid'), updated_contact.get('contact_uuid'))
 
         data = {'urn': '12345abcde', 'fcm_token': '1234567890qwertyuiop', 'contact_uuid': contact.get('contact_uuid')}
         response = self.client.post(self.register_url, data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         updated_contact = json.loads(response.content)
 
-        self.assertEquals(contact.get('contact_uuid'), updated_contact.get('contact_uuid'))
+        self.assertEqual(contact.get('contact_uuid'), updated_contact.get('contact_uuid'))
 
     def test_send(self):
         joe = self.create_contact("Joe", urn="fcm:12345abcde", auth="123456abcdef")
@@ -10771,8 +10771,8 @@ class FcmTest(TembaTest):
 
                 # message should be marked as an error
                 msg.refresh_from_db()
-                self.assertEquals(ERRORED, msg.status)
-                self.assertEquals(1, msg.error_count)
+                self.assertEqual(ERRORED, msg.status)
+                self.assertEqual(1, msg.error_count)
                 self.assertTrue(msg.next_attempt)
 
     def test_send_media(self):

--- a/temba/channels/types/africastalking/tests.py
+++ b/temba/channels/types/africastalking/tests.py
@@ -24,7 +24,7 @@ class AfricastalkingTypeTest(TembaTest):
         self.assertContains(response, url)
         # visit the africa's talking page
         response = self.client.get(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         post_data = response.context['form'].initial
 
         post_data['shortcode'] = '5259'
@@ -36,17 +36,17 @@ class AfricastalkingTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('temba', channel.config_json()['username'])
-        self.assertEquals('asdf-asdf-asdf-asdf-asdf', channel.config_json()['api_key'])
-        self.assertEquals('5259', channel.address)
-        self.assertEquals('KE', channel.country)
-        self.assertEquals('AT', channel.channel_type)
+        self.assertEqual('temba', channel.config_json()['username'])
+        self.assertEqual('asdf-asdf-asdf-asdf-asdf', channel.config_json()['api_key'])
+        self.assertEqual('5259', channel.address)
+        self.assertEqual('KE', channel.country)
+        self.assertEqual('AT', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.at', args=[channel.uuid, 'receive']))
         self.assertContains(response, reverse('courier.at', args=[channel.uuid, 'status']))

--- a/temba/channels/types/blackmyna/tests.py
+++ b/temba/channels/types/blackmyna/tests.py
@@ -37,17 +37,17 @@ class BlackmynaTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('NI', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('+250788123123', channel.address)
-        self.assertEquals('BM', channel.channel_type)
+        self.assertEqual('NI', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('+250788123123', channel.address)
+        self.assertEqual('BM', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.bm', args=[channel.uuid, 'status']))
         self.assertContains(response, reverse('courier.bm', args=[channel.uuid, 'receive']))
@@ -66,8 +66,8 @@ class BlackmynaTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('NI', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('20050', channel.address)
-        self.assertEquals('BM', channel.channel_type)
+        self.assertEqual('NI', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('20050', channel.address)
+        self.assertEqual('BM', channel.channel_type)

--- a/temba/channels/types/clickatell/tests.py
+++ b/temba/channels/types/clickatell/tests.py
@@ -32,19 +32,19 @@ class ClickatellTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('US', channel.country)
+        self.assertEqual('US', channel.country)
         self.assertTrue(channel.uuid)
-        self.assertEquals('+12065551212', channel.address)
-        self.assertEquals(post_data['api_id'], channel.config_json()['api_id'])
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('CT', channel.channel_type)
+        self.assertEqual('+12065551212', channel.address)
+        self.assertEqual(post_data['api_id'], channel.config_json()['api_id'])
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('CT', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.ct', args=[channel.uuid, 'status']))
         self.assertContains(response, reverse('courier.ct', args=[channel.uuid, 'receive']))

--- a/temba/channels/types/dartmedia/tests.py
+++ b/temba/channels/types/dartmedia/tests.py
@@ -28,7 +28,7 @@ class DartMediaTypeTest(TembaTest):
 
         # try to claim a channel
         response = self.client.get(url)
-        self.assertEquals(response.context['view'].get_country({}), 'Indonesia')
+        self.assertEqual(response.context['view'].get_country({}), 'Indonesia')
 
         post_data = response.context['form'].initial
 
@@ -41,18 +41,18 @@ class DartMediaTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('ID', channel.country)
+        self.assertEqual('ID', channel.country)
         self.assertTrue(channel.uuid)
-        self.assertEquals(post_data['number'], channel.address)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('DA', channel.channel_type)
+        self.assertEqual(post_data['number'], channel.address)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('DA', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.da', args=[channel.uuid, 'receive']))
         self.assertContains(response, reverse('courier.da', args=[channel.uuid, 'delivered']))

--- a/temba/channels/types/highconnection/tests.py
+++ b/temba/channels/types/highconnection/tests.py
@@ -37,17 +37,17 @@ class HighConnectionTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('FR', channel.country)
+        self.assertEqual('FR', channel.country)
         self.assertTrue(channel.uuid)
-        self.assertEquals(post_data['number'], channel.address)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('HX', channel.channel_type)
+        self.assertEqual(post_data['number'], channel.address)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('HX', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.hx', args=[channel.uuid, 'receive']))

--- a/temba/channels/types/hub9/tests.py
+++ b/temba/channels/types/hub9/tests.py
@@ -28,7 +28,7 @@ class Hub9TypeTest(TembaTest):
 
         # try to claim a channel
         response = self.client.get(url)
-        self.assertEquals(response.context['view'].get_country({}), 'Indonesia')
+        self.assertEqual(response.context['view'].get_country({}), 'Indonesia')
 
         post_data = response.context['form'].initial
 
@@ -41,18 +41,18 @@ class Hub9TypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('ID', channel.country)
+        self.assertEqual('ID', channel.country)
         self.assertTrue(channel.uuid)
-        self.assertEquals(post_data['number'], channel.address)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('H9', channel.channel_type)
+        self.assertEqual(post_data['number'], channel.address)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('H9', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.h9', args=[channel.uuid, 'receive']))
         self.assertContains(response, reverse('courier.h9', args=[channel.uuid, 'delivered']))

--- a/temba/channels/types/infobip/tests.py
+++ b/temba/channels/types/infobip/tests.py
@@ -31,17 +31,17 @@ class InfobipTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('NI', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('+250788123123', channel.address)
-        self.assertEquals('IB', channel.channel_type)
+        self.assertEqual('NI', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('+250788123123', channel.address)
+        self.assertEqual('IB', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.ib', args=[channel.uuid, 'receive']))
         self.assertContains(response, reverse('courier.ib', args=[channel.uuid, 'delivered']))
@@ -60,8 +60,8 @@ class InfobipTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('NI', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('20050', channel.address)
-        self.assertEquals('IB', channel.channel_type)
+        self.assertEqual('NI', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('20050', channel.address)
+        self.assertEqual('IB', channel.channel_type)

--- a/temba/channels/types/jasmin/tests.py
+++ b/temba/channels/types/jasmin/tests.py
@@ -32,18 +32,18 @@ class JasminTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('UG', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals(post_data['url'], channel.config_json()['send_url'])
-        self.assertEquals('+250788123123', channel.address)
-        self.assertEquals('JS', channel.channel_type)
+        self.assertEqual('UG', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual(post_data['url'], channel.config_json()['send_url'])
+        self.assertEqual('+250788123123', channel.address)
+        self.assertEqual('JS', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.js', args=[channel.uuid, 'receive']))
 
@@ -62,9 +62,9 @@ class JasminTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('UG', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals(post_data['url'], channel.config_json()['send_url'])
-        self.assertEquals('20050', channel.address)
-        self.assertEquals('JS', channel.channel_type)
+        self.assertEqual('UG', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual(post_data['url'], channel.config_json()['send_url'])
+        self.assertEqual('20050', channel.address)
+        self.assertEqual('JS', channel.channel_type)

--- a/temba/channels/types/jiochat/tests.py
+++ b/temba/channels/types/jiochat/tests.py
@@ -26,13 +26,13 @@ class JioChatTypeTest(TembaTest):
 
         channel = Channel.objects.get(channel_type='JC')
 
-        self.assertEquals(channel.config_json(), {'jiochat_app_id': post_data['app_id'], 'jiochat_app_secret': post_data['app_secret']})
+        self.assertEqual(channel.config_json(), {'jiochat_app_id': post_data['app_id'], 'jiochat_app_secret': post_data['app_secret']})
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.jc', args=[channel.uuid]))
         self.assertContains(response, channel.secret)

--- a/temba/channels/types/junebug/tests.py
+++ b/temba/channels/types/junebug/tests.py
@@ -17,7 +17,7 @@ class JunebugTypeTest(TembaTest):
         self.assertContains(response, url)
 
         response = self.client.get(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = {
             "country": "ZA",
@@ -31,19 +31,19 @@ class JunebugTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals(channel.country, post_data['country'])
-        self.assertEquals(channel.address, post_data['number'])
-        self.assertEquals(channel.config_json()['send_url'], post_data['url'])
-        self.assertEquals(channel.config_json()['username'], post_data['username'])
-        self.assertEquals(channel.config_json()['password'], post_data['password'])
-        self.assertEquals(channel.channel_type, 'JN')
-        self.assertEquals(channel.role, Channel.DEFAULT_ROLE)
+        self.assertEqual(channel.country, post_data['country'])
+        self.assertEqual(channel.address, post_data['number'])
+        self.assertEqual(channel.config_json()['send_url'], post_data['url'])
+        self.assertEqual(channel.config_json()['username'], post_data['username'])
+        self.assertEqual(channel.config_json()['password'], post_data['password'])
+        self.assertEqual(channel.channel_type, 'JN')
+        self.assertEqual(channel.role, Channel.DEFAULT_ROLE)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.jn', args=[channel.uuid, 'inbound']))
 
@@ -51,7 +51,7 @@ class JunebugTypeTest(TembaTest):
         self.login(self.admin)
 
         response = self.client.get(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = {
             "country": "ZA",
@@ -66,19 +66,19 @@ class JunebugTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals(channel.country, post_data['country'])
-        self.assertEquals(channel.address, post_data['number'])
-        self.assertEquals(channel.secret, post_data['secret'])
-        self.assertEquals(channel.config_json()['send_url'], post_data['url'])
-        self.assertEquals(channel.config_json()['username'], post_data['username'])
-        self.assertEquals(channel.config_json()['password'], post_data['password'])
-        self.assertEquals(channel.channel_type, 'JN')
-        self.assertEquals(channel.role, Channel.DEFAULT_ROLE)
+        self.assertEqual(channel.country, post_data['country'])
+        self.assertEqual(channel.address, post_data['number'])
+        self.assertEqual(channel.secret, post_data['secret'])
+        self.assertEqual(channel.config_json()['send_url'], post_data['url'])
+        self.assertEqual(channel.config_json()['username'], post_data['username'])
+        self.assertEqual(channel.config_json()['password'], post_data['password'])
+        self.assertEqual(channel.channel_type, 'JN')
+        self.assertEqual(channel.role, Channel.DEFAULT_ROLE)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.jn', args=[channel.uuid, 'inbound']))

--- a/temba/channels/types/junebug_ussd/tests.py
+++ b/temba/channels/types/junebug_ussd/tests.py
@@ -19,7 +19,7 @@ class JunebugTypeTest(TembaTest):
         self.assertContains(response, url)
 
         response = self.client.get(url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         post_data = {
             "country": "ZA",
@@ -33,6 +33,6 @@ class JunebugTypeTest(TembaTest):
         response = self.client.post(url, post_data)
 
         channel = Channel.objects.get()
-        self.assertEquals(channel.channel_type, 'JNU')
-        self.assertEquals(channel.role, Channel.ROLE_USSD)
+        self.assertEqual(channel.channel_type, 'JNU')
+        self.assertEqual(channel.role, Channel.ROLE_USSD)
         self.assertEqual(channel.secret, "secret-word")

--- a/temba/channels/types/kannel/tests.py
+++ b/temba/channels/types/kannel/tests.py
@@ -32,23 +32,23 @@ class KannelTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('RW', channel.country)
+        self.assertEqual('RW', channel.country)
         self.assertTrue(channel.uuid)
-        self.assertEquals(post_data['number'], channel.address)
-        self.assertEquals(post_data['url'], channel.config_json()['send_url'])
-        self.assertEquals(False, channel.config_json()['verify_ssl'])
-        self.assertEquals(Channel.ENCODING_SMART, channel.config_json()[Channel.CONFIG_ENCODING])
+        self.assertEqual(post_data['number'], channel.address)
+        self.assertEqual(post_data['url'], channel.config_json()['send_url'])
+        self.assertEqual(False, channel.config_json()['verify_ssl'])
+        self.assertEqual(Channel.ENCODING_SMART, channel.config_json()[Channel.CONFIG_ENCODING])
 
         # make sure we generated a username and password
         self.assertTrue(channel.config_json()['username'])
         self.assertTrue(channel.config_json()['password'])
-        self.assertEquals('KN', channel.channel_type)
+        self.assertEqual('KN', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # our configuration page should list our receive URL
         self.assertContains(response, reverse('courier.kn', args=[channel.uuid, 'receive']))

--- a/temba/channels/types/m3tech/tests.py
+++ b/temba/channels/types/m3tech/tests.py
@@ -37,17 +37,17 @@ class M3TechTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('PK', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('+250788123123', channel.address)
-        self.assertEquals('M3', channel.channel_type)
+        self.assertEqual('PK', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('+250788123123', channel.address)
+        self.assertEqual('M3', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.m3', args=[channel.uuid, 'receive']))
         self.assertContains(response, reverse('courier.m3', args=[channel.uuid, 'sent']))
@@ -68,8 +68,8 @@ class M3TechTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('PK', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('20050', channel.address)
-        self.assertEquals('M3', channel.channel_type)
+        self.assertEqual('PK', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('20050', channel.address)
+        self.assertEqual('M3', channel.channel_type)

--- a/temba/channels/types/macrokiosk/tests.py
+++ b/temba/channels/types/macrokiosk/tests.py
@@ -38,19 +38,19 @@ class MacrokioskTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals(channel.country, 'MY')
-        self.assertEquals(channel.config_json()['username'], post_data['username'])
-        self.assertEquals(channel.config_json()['password'], post_data['password'])
-        self.assertEquals(channel.config_json()[Channel.CONFIG_MACROKIOSK_SENDER_ID], post_data['sender_id'])
-        self.assertEquals(channel.config_json()[Channel.CONFIG_MACROKIOSK_SERVICE_ID], post_data['service_id'])
-        self.assertEquals(channel.address, '250788123123')
-        self.assertEquals(channel.channel_type, 'MK')
+        self.assertEqual(channel.country, 'MY')
+        self.assertEqual(channel.config_json()['username'], post_data['username'])
+        self.assertEqual(channel.config_json()['password'], post_data['password'])
+        self.assertEqual(channel.config_json()[Channel.CONFIG_MACROKIOSK_SENDER_ID], post_data['sender_id'])
+        self.assertEqual(channel.config_json()[Channel.CONFIG_MACROKIOSK_SERVICE_ID], post_data['service_id'])
+        self.assertEqual(channel.address, '250788123123')
+        self.assertEqual(channel.channel_type, 'MK')
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.mk', args=[channel.uuid, 'receive']))
         self.assertContains(response, reverse('courier.mk', args=[channel.uuid, 'status']))

--- a/temba/channels/types/mblox/tests.py
+++ b/temba/channels/types/mblox/tests.py
@@ -31,17 +31,17 @@ class MbloxTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('RW', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('+250788123123', channel.address)
-        self.assertEquals('MB', channel.channel_type)
+        self.assertEqual('RW', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('+250788123123', channel.address)
+        self.assertEqual('MB', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.mb', args=[channel.uuid, 'receive']))
 
@@ -59,8 +59,8 @@ class MbloxTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('RW', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('20050', channel.address)
-        self.assertEquals('MB', channel.channel_type)
+        self.assertEqual('RW', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('20050', channel.address)
+        self.assertEqual('MB', channel.channel_type)

--- a/temba/channels/types/nexmo/tests.py
+++ b/temba/channels/types/nexmo/tests.py
@@ -158,7 +158,7 @@ class NexmoTypeTest(TembaTest):
                 response = self.client.post(update_url, updated)
                 channel = Channel.objects.get(pk=channel.id)
 
-                self.assertEquals('MTN', channel.address)
+                self.assertEqual('MTN', channel.address)
 
                 # add a canada number
                 nexmo_get.return_value = MockResponse(200, '{"count":1,"numbers":[{"features": ["SMS", "VOICE"], "type":"mobile-lvn","country":"CA","msisdn":"15797884540"}] }')
@@ -181,7 +181,7 @@ class NexmoTypeTest(TembaTest):
 
                 config_url = reverse('channels.channel_configuration', args=[channel.pk])
                 response = self.client.get(config_url)
-                self.assertEquals(200, response.status_code)
+                self.assertEqual(200, response.status_code)
 
                 self.assertContains(response, reverse('courier.nx', args=[channel.org.nexmo_uuid(), 'receive']))
                 self.assertContains(response, reverse('courier.nx', args=[channel.org.nexmo_uuid(), 'status']))

--- a/temba/channels/types/plivo/tests.py
+++ b/temba/channels/types/plivo/tests.py
@@ -66,10 +66,10 @@ class PlivoTypeTest(TembaTest):
                 # make sure it is actually connected
                 channel = Channel.objects.get(channel_type='PL', org=self.org)
                 self.assertEqual(channel.role, Channel.ROLE_SEND + Channel.ROLE_RECEIVE)
-                self.assertEquals(channel.config_json(), {Channel.CONFIG_PLIVO_AUTH_ID: 'auth-id',
-                                                          Channel.CONFIG_PLIVO_AUTH_TOKEN: 'auth-token',
-                                                          Channel.CONFIG_PLIVO_APP_ID: 'app-id'})
-                self.assertEquals(channel.address, "+16062681435")
+                self.assertEqual(channel.config_json(), {Channel.CONFIG_PLIVO_AUTH_ID: 'auth-id',
+                                                         Channel.CONFIG_PLIVO_AUTH_TOKEN: 'auth-token',
+                                                         Channel.CONFIG_PLIVO_APP_ID: 'app-id'})
+                self.assertEqual(channel.address, "+16062681435")
                 # no more credential in the session
                 self.assertFalse(Channel.CONFIG_PLIVO_AUTH_ID in self.client.session)
                 self.assertFalse(Channel.CONFIG_PLIVO_AUTH_TOKEN in self.client.session)
@@ -110,12 +110,12 @@ class PlivoTypeTest(TembaTest):
 
                         # make sure it is actually connected
                         channel = Channel.objects.get(channel_type='PL', org=self.org)
-                        self.assertEquals(channel.config_json(), {
+                        self.assertEqual(channel.config_json(), {
                             Channel.CONFIG_PLIVO_AUTH_ID: 'auth-id',
                             Channel.CONFIG_PLIVO_AUTH_TOKEN: 'auth-token',
                             Channel.CONFIG_PLIVO_APP_ID: 'app-id'
                         })
-                        self.assertEquals(channel.address, "+16062681440")
+                        self.assertEqual(channel.address, "+16062681440")
                         # no more credential in the session
                         self.assertFalse(Channel.CONFIG_PLIVO_AUTH_ID in self.client.session)
                         self.assertFalse(Channel.CONFIG_PLIVO_AUTH_TOKEN in self.client.session)

--- a/temba/channels/types/redrabbit/tests.py
+++ b/temba/channels/types/redrabbit/tests.py
@@ -31,17 +31,17 @@ class RedRabbitTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('JO', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('+250788123123', channel.address)
-        self.assertEquals('RR', channel.channel_type)
+        self.assertEqual('JO', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('+250788123123', channel.address)
+        self.assertEqual('RR', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         Channel.objects.all().delete()
 
@@ -57,8 +57,8 @@ class RedRabbitTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('JO', channel.country)
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('20050', channel.address)
-        self.assertEquals('RR', channel.channel_type)
+        self.assertEqual('JO', channel.country)
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('20050', channel.address)
+        self.assertEqual('RR', channel.channel_type)

--- a/temba/channels/types/shaqodoon/tests.py
+++ b/temba/channels/types/shaqodoon/tests.py
@@ -25,8 +25,8 @@ class ShaqodoonTypeTest(TembaTest):
         self.assertContains(response, url)
 
         response = self.client.get(url)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.context['view'].get_country({}), 'Somalia')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.context['view'].get_country({}), 'Somalia')
 
         # try to claim a channel
         response = self.client.get(url)
@@ -42,18 +42,18 @@ class ShaqodoonTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEquals('SO', channel.country)
+        self.assertEqual('SO', channel.country)
         self.assertTrue(channel.uuid)
-        self.assertEquals(post_data['number'], channel.address)
-        self.assertEquals(post_data['url'], channel.config_json()['send_url'])
-        self.assertEquals(post_data['username'], channel.config_json()['username'])
-        self.assertEquals(post_data['password'], channel.config_json()['password'])
-        self.assertEquals('SQ', channel.channel_type)
+        self.assertEqual(post_data['number'], channel.address)
+        self.assertEqual(post_data['url'], channel.config_json()['send_url'])
+        self.assertEqual(post_data['username'], channel.config_json()['username'])
+        self.assertEqual(post_data['password'], channel.config_json()['password'])
+        self.assertEqual('SQ', channel.channel_type)
 
         config_url = reverse('channels.channel_configuration', args=[channel.pk])
         self.assertRedirect(response, config_url)
 
         response = self.client.get(config_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertContains(response, reverse('courier.sq', args=[channel.uuid, 'receive']))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -152,11 +152,11 @@ class ContactCRUDLTest(_CRUDLTest):
 
         # can no longer access
         response = self.client.get(read_url)
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         # invalid uuid should return 404
         response = self.client.get(reverse('contacts.contact_read', args=['invalid-uuid']))
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     def testDelete(self):
         object = self.getTestObject()
@@ -277,25 +277,25 @@ class ContactGroupTest(TembaTest):
         # add contacts via the related field
         group.contacts.add(self.joe, self.frank)
 
-        self.assertEquals(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 2)
+        self.assertEqual(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 2)
 
         # add contacts via update_contacts
         group.update_contacts(self.user, [self.mary], add=True)
 
-        self.assertEquals(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 3)
+        self.assertEqual(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 3)
 
         # remove contacts via update_contacts
         group.update_contacts(self.user, [self.mary], add=False)
 
-        self.assertEquals(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 2)
+        self.assertEqual(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 2)
 
         # add test contact (will add to group but won't increment count)
         test_contact = Contact.get_test_contact(self.admin)
         group.update_contacts(self.user, [test_contact], add=True)
 
         group = ContactGroup.user_groups.get(pk=group.pk)
-        self.assertEquals(group.get_member_count(), 2)
-        self.assertEquals(set(group.contacts.all()), {self.joe, self.frank, test_contact})
+        self.assertEqual(group.get_member_count(), 2)
+        self.assertEqual(set(group.contacts.all()), {self.joe, self.frank, test_contact})
 
         # blocking a contact removes them from all user groups
         self.joe.block(self.user)
@@ -304,20 +304,20 @@ class ContactGroupTest(TembaTest):
             group.update_contacts(self.user, [self.joe], True)
 
         group = ContactGroup.user_groups.get(pk=group.pk)
-        self.assertEquals(group.get_member_count(), 1)
-        self.assertEquals(set(group.contacts.all()), {self.frank, test_contact})
+        self.assertEqual(group.get_member_count(), 1)
+        self.assertEqual(set(group.contacts.all()), {self.frank, test_contact})
 
         # unblocking won't re-add to any groups
         self.joe.unblock(self.user)
 
-        self.assertEquals(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 1)
+        self.assertEqual(ContactGroup.user_groups.get(pk=group.pk).get_member_count(), 1)
 
         # releasing also removes from all user groups
         self.frank.release(self.user)
 
         group = ContactGroup.user_groups.get(pk=group.pk)
-        self.assertEquals(group.get_member_count(), 0)
-        self.assertEquals(set(group.contacts.all()), {test_contact})
+        self.assertEqual(group.get_member_count(), 0)
+        self.assertEqual(set(group.contacts.all()), {test_contact})
 
     def test_system_group_counts(self):
         Contact.objects.all().delete()  # start with none
@@ -385,20 +385,20 @@ class ContactGroupTest(TembaTest):
         second_trigger.groups.add(group)
 
         response = self.client.post(delete_url, dict())
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
         response = self.client.post(delete_url, dict(), follow=True)
         self.assertTrue(ContactGroup.user_groups.get(pk=group.pk).is_active)
-        self.assertEquals(response.request['PATH_INFO'], reverse('contacts.contact_filter', args=[group.uuid]))
+        self.assertEqual(response.request['PATH_INFO'], reverse('contacts.contact_filter', args=[group.uuid]))
 
         # archive a trigger
         second_trigger.is_archived = True
         second_trigger.save()
 
         response = self.client.post(delete_url, dict())
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
         response = self.client.post(delete_url, dict(), follow=True)
         self.assertTrue(ContactGroup.user_groups.get(pk=group.pk).is_active)
-        self.assertEquals(response.request['PATH_INFO'], reverse('contacts.contact_filter', args=[group.uuid]))
+        self.assertEqual(response.request['PATH_INFO'], reverse('contacts.contact_filter', args=[group.uuid]))
 
         trigger.is_archived = True
         trigger.save()
@@ -474,7 +474,7 @@ class ContactGroupCRUDLTest(TembaTest):
         for i in range(ContactGroup.MAX_ORG_CONTACTGROUPS):
             ContactGroup.create_static(self.org, self.admin, 'group%d' % i)
 
-        self.assertEquals(ContactGroup.user_groups.all().count(), ContactGroup.MAX_ORG_CONTACTGROUPS)
+        self.assertEqual(ContactGroup.user_groups.all().count(), ContactGroup.MAX_ORG_CONTACTGROUPS)
         response = self.client.post(url, dict(name="People"))
         self.assertFormError(response, 'form', 'name', "You have reached 10 contact groups, "
                                                        "please remove some contact groups to be able "
@@ -618,25 +618,25 @@ class ContactTest(TembaTest):
 
         self.assertIsNone(snoop.urns.all().first().channel)
         snoop = Contact.get_or_create(self.org, self.user, channel=self.channel, urns=['tel:456'])
-        self.assertEquals(1, snoop.urns.all().count())
+        self.assertEqual(1, snoop.urns.all().count())
 
         # create contact with new urns one normalized and the other not
         jimmy = Contact.get_or_create(self.org, self.user, name="Jimmy", urns=['tel:+250788112233', 'tel:0788112233'])
-        self.assertEquals(1, jimmy.urns.all().count())
+        self.assertEqual(1, jimmy.urns.all().count())
 
     def test_get_test_contact(self):
         test_contact_admin = Contact.get_test_contact(self.admin)
         self.assertTrue(test_contact_admin.is_test)
-        self.assertEquals(test_contact_admin.created_by, self.admin)
+        self.assertEqual(test_contact_admin.created_by, self.admin)
 
         test_contact_user = Contact.get_test_contact(self.user)
         self.assertTrue(test_contact_user.is_test)
-        self.assertEquals(test_contact_user.created_by, self.user)
+        self.assertEqual(test_contact_user.created_by, self.user)
         self.assertFalse(test_contact_admin == test_contact_user)
 
         test_contact_user2 = Contact.get_test_contact(self.user)
         self.assertTrue(test_contact_user2.is_test)
-        self.assertEquals(test_contact_user2.created_by, self.user)
+        self.assertEqual(test_contact_user2.created_by, self.user)
         self.assertTrue(test_contact_user2 == test_contact_user)
 
         # assign this URN to another contact
@@ -1661,22 +1661,22 @@ class ContactTest(TembaTest):
                                                    message='A message to send')
 
         event.unit = 'D'
-        self.assertEquals("7 days after Planting Date", event_time(event))
+        self.assertEqual("7 days after Planting Date", event_time(event))
 
         event.unit = 'M'
-        self.assertEquals("7 minutes after Planting Date", event_time(event))
+        self.assertEqual("7 minutes after Planting Date", event_time(event))
 
         event.unit = 'H'
-        self.assertEquals("7 hours after Planting Date", event_time(event))
+        self.assertEqual("7 hours after Planting Date", event_time(event))
 
         event.offset = -1
-        self.assertEquals("1 hour before Planting Date", event_time(event))
+        self.assertEqual("1 hour before Planting Date", event_time(event))
 
         event.unit = 'D'
-        self.assertEquals("1 day before Planting Date", event_time(event))
+        self.assertEqual("1 day before Planting Date", event_time(event))
 
         event.unit = 'M'
-        self.assertEquals("1 minute before Planting Date", event_time(event))
+        self.assertEqual("1 minute before Planting Date", event_time(event))
 
     def test_activity_tags(self):
         self.create_campaign()
@@ -1805,13 +1805,13 @@ class ContactTest(TembaTest):
 
         # we have a field to add new urns
         response = self.fetch_protected(update_url, self.admin)
-        self.assertEquals(self.joe, response.context['object'])
+        self.assertEqual(self.joe, response.context['object'])
         self.assertContains(response, 'Add Connection')
 
         # no field to add new urns for anon org
         with AnonymousOrg(self.org):
             response = self.fetch_protected(update_url, self.admin)
-            self.assertEquals(self.joe, response.context['object'])
+            self.assertEqual(self.joe, response.context['object'])
             self.assertNotContains(response, 'Add Connection')
 
     def test_read(self):
@@ -1837,42 +1837,42 @@ class ContactTest(TembaTest):
         EventFire.update_campaign_events(self.campaign)
 
         # should have seven fires, one for each campaign event
-        self.assertEquals(7, EventFire.objects.all().count())
+        self.assertEqual(7, EventFire.objects.all().count())
 
         # visit a contact detail page as a user but not belonging to this organization
         self.login(self.user1)
         response = self.client.get(read_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # visit a contact detail page as a manager but not belonging to this organisation
         self.login(self.non_org_user)
         response = self.client.get(read_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # visit a contact detail page as a manager within the organization
         response = self.fetch_protected(read_url, self.admin)
-        self.assertEquals(self.joe, response.context['object'])
+        self.assertEqual(self.joe, response.context['object'])
 
         with patch('temba.orgs.models.Org.get_schemes') as mock_get_schemes:
             mock_get_schemes.return_value = []
 
             response = self.fetch_protected(read_url, self.admin)
-            self.assertEquals(self.joe, response.context['object'])
+            self.assertEqual(self.joe, response.context['object'])
             self.assertFalse(response.context['has_sendable_urn'])
 
             mock_get_schemes.return_value = ['tel']
 
             response = self.fetch_protected(read_url, self.admin)
-            self.assertEquals(self.joe, response.context['object'])
+            self.assertEqual(self.joe, response.context['object'])
             self.assertTrue(response.context['has_sendable_urn'])
 
         response = self.fetch_protected(read_url, self.admin)
-        self.assertEquals(self.joe, response.context['object'])
+        self.assertEqual(self.joe, response.context['object'])
         self.assertTrue(response.context['has_sendable_urn'])
         upcoming = response.context['upcoming_events']
 
         # should show the next seven events to fire in reverse order
-        self.assertEquals(7, len(upcoming))
+        self.assertEqual(7, len(upcoming))
 
         self.assertEqual(upcoming[4]['message'], "Sent 10 days after planting date")
         self.assertEqual(upcoming[5]['message'], "Sent 7 days after planting date")
@@ -1890,11 +1890,11 @@ class ContactTest(TembaTest):
         broadcast.save()
 
         response = self.fetch_protected(read_url, self.admin)
-        self.assertEquals(self.joe, response.context['object'])
+        self.assertEqual(self.joe, response.context['object'])
         upcoming = response.context['upcoming_events']
 
         # should show the next 2 events to fire and the scheduled broadcast in reverse order by schedule time
-        self.assertEquals(8, len(upcoming))
+        self.assertEqual(8, len(upcoming))
 
         self.assertEqual(upcoming[5]['message'], "Sent 7 days after planting date")
         self.assertEqual(upcoming[6]['message'], "Hello")
@@ -1907,7 +1907,7 @@ class ContactTest(TembaTest):
         contact_no_name = self.create_contact(name=None, number="678")
         read_url = reverse('contacts.contact_read', args=[contact_no_name.uuid])
         response = self.fetch_protected(read_url, self.superuser)
-        self.assertEquals(contact_no_name, response.context['object'])
+        self.assertEqual(contact_no_name, response.context['object'])
         self.client.logout()
 
         # login as a manager from out of this organization
@@ -1921,7 +1921,7 @@ class ContactTest(TembaTest):
         response = self.client.post(read_url, post_data, follow=True)
 
         # this manager cannot operate on this organization
-        self.assertEquals(len(self.joe.user_groups.all()), 2)
+        self.assertEqual(len(self.joe.user_groups.all()), 2)
         self.client.logout()
 
         # login as a manager of kLab
@@ -1933,7 +1933,7 @@ class ContactTest(TembaTest):
 
         # try removing it again, should fail
         response = self.client.post(read_url, post_data, follow=True)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # can't view contact in another org
         self.create_secondary_org()
@@ -1992,16 +1992,16 @@ class ContactTest(TembaTest):
 
         self.joe_and_frank = ContactGroup.user_groups.get(pk=self.joe_and_frank.pk)
 
-        self.assertEquals(self.joe.groups_as_text(), "Joe and Frank, Just Joe")
+        self.assertEqual(self.joe.groups_as_text(), "Joe and Frank, Just Joe")
         group_analytic_json = self.joe_and_frank.analytics_json()
-        self.assertEquals(group_analytic_json['id'], self.joe_and_frank.pk)
-        self.assertEquals(group_analytic_json['name'], "Joe and Frank")
-        self.assertEquals(2, group_analytic_json['count'])
+        self.assertEqual(group_analytic_json['id'], self.joe_and_frank.pk)
+        self.assertEqual(group_analytic_json['name'], "Joe and Frank")
+        self.assertEqual(2, group_analytic_json['count'])
 
         # try to list contacts as a user not in the organization
         self.login(self.user1)
         response = self.client.get(list_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # login as an org viewer
         self.login(self.user)
@@ -2011,14 +2011,14 @@ class ContactTest(TembaTest):
         self.assertContains(response, "Frank Smith")
         self.assertContains(response, "Billy Nophone")
         self.assertContains(response, "Joe and Frank")
-        self.assertEquals(response.context['actions'], ('label', 'block'))
+        self.assertEqual(response.context['actions'], ('label', 'block'))
 
         # make sure Joe's preferred URN is in the list
         self.assertContains(response, "blow80")
 
         # this just_joe group has one contact and joe_and_frank group has two contacts
-        self.assertEquals(len(self.just_joe.contacts.all()), 1)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 2)
+        self.assertEqual(len(self.just_joe.contacts.all()), 1)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 2)
 
         # viewer cannot remove Joe from the group
         post_data = dict()
@@ -2029,8 +2029,8 @@ class ContactTest(TembaTest):
 
         # no change
         self.client.post(list_url, post_data, follow=True)
-        self.assertEquals(len(self.just_joe.contacts.all()), 1)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 2)
+        self.assertEqual(len(self.just_joe.contacts.all()), 1)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 2)
 
         # viewer also can't block
         post_data['action'] = 'block'
@@ -2044,8 +2044,8 @@ class ContactTest(TembaTest):
         self.assertEqual(response.context['actions'], ('label', 'block'))
 
         # this just_joe group has one contact and joe_and_frank group has two contacts
-        self.assertEquals(len(self.just_joe.contacts.all()), 1)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 2)
+        self.assertEqual(len(self.just_joe.contacts.all()), 1)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 2)
 
         # add a new group
         group = self.create_group("Test", [self.joe])
@@ -2053,8 +2053,8 @@ class ContactTest(TembaTest):
         # view our test group
         filter_url = reverse('contacts.contact_filter', args=[group.uuid])
         response = self.client.get(filter_url)
-        self.assertEquals(1, len(response.context['object_list']))
-        self.assertEquals(self.joe, response.context['object_list'][0])
+        self.assertEqual(1, len(response.context['object_list']))
+        self.assertEqual(self.joe, response.context['object_list'][0])
 
         # should have the export link
         export_url = "%s?g=%s" % (reverse('contacts.contact_export'), group.uuid)
@@ -2072,7 +2072,7 @@ class ContactTest(TembaTest):
         self.assertRedirect(response, filter_url)
 
         group = ContactGroup.user_groups.get(pk=group.pk)
-        self.assertEquals("New Test", group.name)
+        self.assertEqual("New Test", group.name)
 
         # post to our delete url
         response = self.client.post(delete_url, dict())
@@ -2091,8 +2091,8 @@ class ContactTest(TembaTest):
 
         # check the Joe is only removed from just_joe only and is still in joe_and_frank
         self.client.post(list_url, post_data, follow=True)
-        self.assertEquals(len(self.just_joe.contacts.all()), 0)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 2)
+        self.assertEqual(len(self.just_joe.contacts.all()), 0)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 2)
 
         # Now add back Joe to the group
         post_data = dict()
@@ -2102,29 +2102,29 @@ class ContactTest(TembaTest):
         post_data['add'] = True
 
         self.client.post(list_url, post_data, follow=True)
-        self.assertEquals(len(self.just_joe.contacts.all()), 1)
-        self.assertEquals(self.just_joe.contacts.all()[0].pk, self.joe.pk)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 2)
+        self.assertEqual(len(self.just_joe.contacts.all()), 1)
+        self.assertEqual(self.just_joe.contacts.all()[0].pk, self.joe.pk)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 2)
 
         # test filtering by group
         joe_and_frank_filter_url = reverse('contacts.contact_filter', args=[self.joe_and_frank.uuid])
 
         # now test when the action with some data missing
-        self.assertEquals(self.joe.user_groups.filter(is_active=True).count(), 2)
+        self.assertEqual(self.joe.user_groups.filter(is_active=True).count(), 2)
 
         post_data = dict()
         post_data['action'] = 'label'
         post_data['objects'] = self.joe.id
         post_data['add'] = True
         self.client.post(joe_and_frank_filter_url, post_data)
-        self.assertEquals(self.joe.user_groups.filter(is_active=True).count(), 2)
+        self.assertEqual(self.joe.user_groups.filter(is_active=True).count(), 2)
 
         post_data = dict()
         post_data['action'] = 'unlabel'
         post_data['objects'] = self.joe.id
         post_data['add'] = True
         self.client.post(joe_and_frank_filter_url, post_data)
-        self.assertEquals(self.joe.user_groups.filter(is_active=True).count(), 2)
+        self.assertEqual(self.joe.user_groups.filter(is_active=True).count(), 2)
 
         # Now block Joe
         post_data = dict()
@@ -2133,13 +2133,13 @@ class ContactTest(TembaTest):
         self.client.post(list_url, post_data, follow=True)
 
         self.joe = Contact.objects.filter(pk=self.joe.pk)[0]
-        self.assertEquals(self.joe.is_blocked, True)
-        self.assertEquals(len(self.just_joe.contacts.all()), 0)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 1)
+        self.assertEqual(self.joe.is_blocked, True)
+        self.assertEqual(len(self.just_joe.contacts.all()), 0)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 1)
 
         # shouldn't be any contacts on the stopped page
         response = self.client.get(reverse('contacts.contact_stopped'))
-        self.assertEquals(0, len(response.context['object_list']))
+        self.assertEqual(0, len(response.context['object_list']))
 
         # mark frank as stopped
         self.frank.stop(self.user)
@@ -2147,15 +2147,15 @@ class ContactTest(TembaTest):
         stopped_url = reverse('contacts.contact_stopped')
 
         response = self.client.get(stopped_url)
-        self.assertEquals(1, len(response.context['object_list']))
-        self.assertEquals(1, response.context['object_list'].count())  # from ContactGroupCount
+        self.assertEqual(1, len(response.context['object_list']))
+        self.assertEqual(1, response.context['object_list'].count())  # from ContactGroupCount
 
         # receiving an incoming message removes us from stopped
         Msg.create_incoming(self.channel, str(self.frank.get_urn('tel')), "Incoming message")
 
         response = self.client.get(stopped_url)
-        self.assertEquals(0, len(response.context['object_list']))
-        self.assertEquals(0, response.context['object_list'].count())  # from ContactGroupCount
+        self.assertEqual(0, len(response.context['object_list']))
+        self.assertEqual(0, response.context['object_list'].count())  # from ContactGroupCount
 
         self.frank.refresh_from_db()
         self.assertFalse(self.frank.is_stopped)
@@ -2170,8 +2170,8 @@ class ContactTest(TembaTest):
         self.client.post(stopped_url, post_data, follow=True)
 
         response = self.client.get(stopped_url)
-        self.assertEquals(0, len(response.context['object_list']))
-        self.assertEquals(0, response.context['object_list'].count())  # from ContactGroupCount
+        self.assertEqual(0, len(response.context['object_list']))
+        self.assertEqual(0, response.context['object_list'].count())  # from ContactGroupCount
 
         self.frank.refresh_from_db()
         self.assertFalse(self.frank.is_stopped)
@@ -2198,9 +2198,9 @@ class ContactTest(TembaTest):
         response = self.client.get(list_url)
         self.assertContains(response, "Joe Blow")
         self.assertContains(response, "Frank Smith")
-        self.assertEquals(response.context['actions'], ('label', 'block'))
-        self.assertEquals(len(self.just_joe.contacts.all()), 0)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 1)
+        self.assertEqual(response.context['actions'], ('label', 'block'))
+        self.assertEqual(len(self.just_joe.contacts.all()), 0)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 1)
 
         # now let's test removing a contact from a group
         post_data = dict()
@@ -2209,7 +2209,7 @@ class ContactTest(TembaTest):
         post_data['objects'] = self.frank.id
         post_data['add'] = True
         self.client.post(joe_and_frank_filter_url, post_data, follow=True)
-        self.assertEquals(len(self.joe_and_frank.contacts.all()), 0)
+        self.assertEqual(len(self.joe_and_frank.contacts.all()), 0)
 
         # add an extra field to the org
         ContactField.get_or_create(self.org, self.user, 'state', label="Home state", value_type=Value.TYPE_STATE)
@@ -2255,7 +2255,7 @@ class ContactTest(TembaTest):
 
         # check that old URN is re-attached
         self.assertIsNone(ContactURN.objects.get(identity="tel:+250783835665").contact)
-        self.assertEquals(self.joe, ContactURN.objects.get(identity="tel:+250781111111").contact)
+        self.assertEqual(self.joe, ContactURN.objects.get(identity="tel:+250781111111").contact)
 
         # add another URN to joe
         ContactURN.create(self.org, self.joe, "tel:+250786666666")
@@ -2296,7 +2296,7 @@ class ContactTest(TembaTest):
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]), post_data, follow=True)
 
         self.joe = Contact.objects.get(pk=self.joe.pk)
-        self.assertEquals(self.joe.name, "Joe Bloggs")
+        self.assertEqual(self.joe.name, "Joe Bloggs")
 
         self.joe.unblock(self.user)
 
@@ -2306,7 +2306,7 @@ class ContactTest(TembaTest):
 
         urn = ContactURN.objects.filter(contact=self.joe, scheme='ext').first()
         self.assertIsNotNone(urn)
-        self.assertEquals('EXT123', urn.path)
+        self.assertEqual('EXT123', urn.path)
 
         # now try adding one that is invalid
         self.client.post(reverse('contacts.contact_update', args=[self.joe.id]),
@@ -2429,7 +2429,7 @@ class ContactTest(TembaTest):
         contact1 = self.create_contact(name=None, number="123456")
 
         contact1.set_first_name("Ludacris")
-        self.assertEquals(contact1.name, "Ludacris")
+        self.assertEqual(contact1.name, "Ludacris")
 
         first_modified_on = contact1.modified_on
         contact1.set_field(self.editor, 'occupation', 'Musician')
@@ -2439,23 +2439,23 @@ class ContactTest(TembaTest):
         self.assertEqual(contact1.modified_by, self.editor)
 
         contact2 = self.create_contact(name="Boy", number="12345")
-        self.assertEquals(contact2.get_display(), "Boy")
+        self.assertEqual(contact2.get_display(), "Boy")
 
         contact3 = self.create_contact(name=None, number="0788111222")
         self.channel.country = 'RW'
         self.channel.save()
 
         normalized = contact3.get_urn(TEL_SCHEME).ensure_number_normalization(self.channel)
-        self.assertEquals(normalized.path, "+250788111222")
+        self.assertEqual(normalized.path, "+250788111222")
 
         contact4 = self.create_contact(name=None, number="0788333444")
         normalized = contact4.get_urn(TEL_SCHEME).ensure_number_normalization(self.channel)
-        self.assertEquals(normalized.path, "+250788333444")
+        self.assertEqual(normalized.path, "+250788333444")
 
         # check normalization leads to matching
         contact5 = self.create_contact(name='Jimmy', number="+250788333555")
         contact6 = self.create_contact(name='James', number="0788333555")
-        self.assertEquals(contact5.pk, contact6.pk)
+        self.assertEqual(contact5.pk, contact6.pk)
 
         contact5.update_urns(self.user, ['twitter:jimmy_woot', 'tel:0788333666'])
 
@@ -2463,19 +2463,19 @@ class ContactTest(TembaTest):
         self.assertIsNone(ContactURN.objects.get(identity='tel:+250788333555').contact)
 
         # check new URNs were created and attached
-        self.assertEquals(contact5, ContactURN.objects.get(identity='tel:+250788333666').contact)
-        self.assertEquals(contact5, ContactURN.objects.get(identity='twitter:jimmy_woot').contact)
+        self.assertEqual(contact5, ContactURN.objects.get(identity='tel:+250788333666').contact)
+        self.assertEqual(contact5, ContactURN.objects.get(identity='twitter:jimmy_woot').contact)
 
         # check twitter URN takes priority if you don't specify scheme
         self.assertEqual('twitter:jimmy_woot', six.text_type(contact5.get_urn()))
-        self.assertEquals('twitter:jimmy_woot', six.text_type(contact5.get_urn(schemes=[TWITTER_SCHEME])))
-        self.assertEquals('tel:+250788333666', six.text_type(contact5.get_urn(schemes=[TEL_SCHEME])))
+        self.assertEqual('twitter:jimmy_woot', six.text_type(contact5.get_urn(schemes=[TWITTER_SCHEME])))
+        self.assertEqual('tel:+250788333666', six.text_type(contact5.get_urn(schemes=[TEL_SCHEME])))
         self.assertIsNone(contact5.get_urn(schemes=['email']))
         self.assertIsNone(contact5.get_urn(schemes=['facebook']))
 
         # check that we can steal other contact's URNs
         contact5.update_urns(self.user, ['tel:0788333444'])
-        self.assertEquals(contact5, ContactURN.objects.get(identity='tel:+250788333444').contact)
+        self.assertEqual(contact5, ContactURN.objects.get(identity='tel:+250788333444').contact)
         self.assertFalse(contact4.urns.all())
 
     def test_from_urn(self):
@@ -2561,13 +2561,13 @@ class ContactTest(TembaTest):
         self.assertIsNotNone(response.context['task'])
 
         if task_customize:
-            self.assertEquals(response.request['PATH_INFO'], reverse('contacts.contact_customize',
-                                                                     args=[response.context['task'].pk]))
+            self.assertEqual(response.request['PATH_INFO'], reverse('contacts.contact_customize',
+                                                                    args=[response.context['task'].pk]))
             if custom_fields_number:
-                self.assertEquals(len(response.context['form'].fields.keys()), custom_fields_number)
+                self.assertEqual(len(response.context['form'].fields.keys()), custom_fields_number)
 
         else:
-            self.assertEquals(response.context['results'], expected_results)
+            self.assertEqual(response.context['results'], expected_results)
 
             # no errors so hide the import form
             if not expected_results.get('error_messages', []):
@@ -2585,16 +2585,16 @@ class ContactTest(TembaTest):
         # first import brings in 3 contacts
         user = self.user
         records = self.do_import(user, 'sample_contacts.xls')
-        self.assertEquals(3, len(records))
+        self.assertEqual(3, len(records))
 
-        self.assertEquals(1, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, len(ContactGroup.user_groups.all()))
         group = ContactGroup.user_groups.all()[0]
-        self.assertEquals('Sample Contacts', group.name)
-        self.assertEquals(3, group.contacts.count())
+        self.assertEqual('Sample Contacts', group.name)
+        self.assertEqual(3, group.contacts.count())
 
-        self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-        self.assertEquals(1, Contact.objects.filter(name='Nic Pottier').count())
-        self.assertEquals(1, Contact.objects.filter(name='Jen Newcomer').count())
+        self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+        self.assertEqual(1, Contact.objects.filter(name='Nic Pottier').count())
+        self.assertEqual(1, Contact.objects.filter(name='Jen Newcomer').count())
 
         # eric opts out
         eric = Contact.objects.get(name='Eric Newcomer')
@@ -2604,11 +2604,11 @@ class ContactTest(TembaTest):
 
         # import again, should be no more records
         records = self.do_import(user, 'sample_contacts.xls')
-        self.assertEquals(3, len(records))
+        self.assertEqual(3, len(records))
 
         # But there should be another group
-        self.assertEquals(2, len(ContactGroup.user_groups.all()))
-        self.assertEquals(1, ContactGroup.user_groups.filter(name="Sample Contacts 2").count())
+        self.assertEqual(2, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, ContactGroup.user_groups.filter(name="Sample Contacts 2").count())
 
         # assert eric didn't get added to a group
         eric.refresh_from_db()
@@ -2621,46 +2621,46 @@ class ContactTest(TembaTest):
         records = self.do_import(user, 'sample_contacts_update.csv')
 
         # now there are three groups
-        self.assertEquals(3, len(ContactGroup.user_groups.all()))
-        self.assertEquals(1, ContactGroup.user_groups.filter(name="Sample Contacts Update").count())
+        self.assertEqual(3, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, ContactGroup.user_groups.filter(name="Sample Contacts Update").count())
 
-        self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-        self.assertEquals(1, Contact.objects.filter(name='Nic Pottier').count())
-        self.assertEquals(0, Contact.objects.filter(name='Jennifer Newcomer').count())
-        self.assertEquals(1, Contact.objects.filter(name='Jackson Newcomer').count())
-        self.assertEquals(1, Contact.objects.filter(name='Norbert Kwizera').count())
+        self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+        self.assertEqual(1, Contact.objects.filter(name='Nic Pottier').count())
+        self.assertEqual(0, Contact.objects.filter(name='Jennifer Newcomer').count())
+        self.assertEqual(1, Contact.objects.filter(name='Jackson Newcomer').count())
+        self.assertEqual(1, Contact.objects.filter(name='Norbert Kwizera').count())
 
         # Jackson took over Jen's number
-        self.assertEquals(Contact.objects.get(name='Jackson Newcomer').pk, jen_pk)
-        self.assertEquals(4, len(records))
+        self.assertEqual(Contact.objects.get(name='Jackson Newcomer').pk, jen_pk)
+        self.assertEqual(4, len(records))
 
         # Empty import file, shouldn't create a contact group
         self.do_import(user, 'empty.csv')
-        self.assertEquals(3, len(ContactGroup.user_groups.all()))
+        self.assertEqual(3, len(ContactGroup.user_groups.all()))
 
         # import twitter urns
         records = self.do_import(user, 'sample_contacts_twitter.xls')
-        self.assertEquals(3, len(records))
+        self.assertEqual(3, len(records))
 
         # now there are four groups
-        self.assertEquals(4, len(ContactGroup.user_groups.all()))
-        self.assertEquals(1, ContactGroup.user_groups.filter(name="Sample Contacts Twitter").count())
+        self.assertEqual(4, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, ContactGroup.user_groups.filter(name="Sample Contacts Twitter").count())
 
-        self.assertEquals(1, Contact.objects.filter(name='Rapidpro').count())
-        self.assertEquals(1, Contact.objects.filter(name='Textit').count())
-        self.assertEquals(1, Contact.objects.filter(name='Nyaruka').count())
+        self.assertEqual(1, Contact.objects.filter(name='Rapidpro').count())
+        self.assertEqual(1, Contact.objects.filter(name='Textit').count())
+        self.assertEqual(1, Contact.objects.filter(name='Nyaruka').count())
 
         # import twitter urns with phone
         records = self.do_import(user, 'sample_contacts_twitter_and_phone.xls')
-        self.assertEquals(3, len(records))
+        self.assertEqual(3, len(records))
 
         # now there are five groups
-        self.assertEquals(5, len(ContactGroup.user_groups.all()))
-        self.assertEquals(1, ContactGroup.user_groups.filter(name="Sample Contacts Twitter And Phone").count())
+        self.assertEqual(5, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, ContactGroup.user_groups.filter(name="Sample Contacts Twitter And Phone").count())
 
-        self.assertEquals(1, Contact.objects.filter(name='Rapidpro').count())
-        self.assertEquals(1, Contact.objects.filter(name='Textit').count())
-        self.assertEquals(1, Contact.objects.filter(name='Nyaruka').count())
+        self.assertEqual(1, Contact.objects.filter(name='Rapidpro').count())
+        self.assertEqual(1, Contact.objects.filter(name='Textit').count())
+        self.assertEqual(1, Contact.objects.filter(name='Nyaruka').count())
 
         import_url = reverse('contacts.contact_import')
 
@@ -2668,41 +2668,41 @@ class ContactTest(TembaTest):
         response = self.client.get(import_url)
         self.assertTrue(response.context['show_form'])
         self.assertFalse(response.context['task'])
-        self.assertEquals(response.context['group'], None)
+        self.assertEqual(response.context['group'], None)
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
 
         records = self.do_import(user, 'sample_contacts_UPPER.XLS')
-        self.assertEquals(3, len(records))
+        self.assertEqual(3, len(records))
 
-        self.assertEquals(1, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, len(ContactGroup.user_groups.all()))
         group = ContactGroup.user_groups.all()[0]
-        self.assertEquals(group.name, "Sample Contacts Upper")
-        self.assertEquals(3, group.contacts.count())
+        self.assertEqual(group.name, "Sample Contacts Upper")
+        self.assertEqual(3, group.contacts.count())
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
 
         records = self.do_import(user, 'sample_contacts_with_filename_very_long_that_it_will_not_validate.xls')
-        self.assertEquals(2, len(records))
+        self.assertEqual(2, len(records))
 
-        self.assertEquals(1, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, len(ContactGroup.user_groups.all()))
         group = ContactGroup.user_groups.all()[0]
-        self.assertEquals(group.name, "Sample Contacts With Filename Very Long That It Will N")
-        self.assertEquals(2, group.contacts.count())
+        self.assertEqual(group.name, "Sample Contacts With Filename Very Long That It Will N")
+        self.assertEqual(2, group.contacts.count())
 
         records = self.do_import(user, 'sample_contacts_with_filename_very_long_that_it_will_not_validate.xls')
-        self.assertEquals(2, len(records))
+        self.assertEqual(2, len(records))
 
-        self.assertEquals(2, len(ContactGroup.user_groups.all()))
+        self.assertEqual(2, len(ContactGroup.user_groups.all()))
         group = ContactGroup.user_groups.all()[0]
-        self.assertEquals(2, group.contacts.count())
+        self.assertEqual(2, group.contacts.count())
         group = ContactGroup.user_groups.all()[1]
-        self.assertEquals(2, group.contacts.count())
-        self.assertEquals(set(["Sample Contacts With Filename Very Long That It Will N",
-                               "Sample Contacts With Filename Very Long That It Will N 2"]),
-                          set(ContactGroup.user_groups.all().values_list('name', flat=True)))
+        self.assertEqual(2, group.contacts.count())
+        self.assertEqual(set(["Sample Contacts With Filename Very Long That It Will N",
+                              "Sample Contacts With Filename Very Long That It Will N 2"]),
+                         set(ContactGroup.user_groups.all().values_list('name', flat=True)))
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
@@ -2721,17 +2721,17 @@ class ContactTest(TembaTest):
             # import contact with uuid will force update if existing contact for the uuid
             self.assertContactImport('%s/test_imports/sample_contacts_uuid.xls' % settings.MEDIA_ROOT,
                                      dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
-            self.assertEquals(mock_lock.call_count, 3)
+            self.assertEqual(mock_lock.call_count, 3)
 
-        self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-        self.assertEquals(0, Contact.objects.filter(name='Bob').count())
-        self.assertEquals(0, Contact.objects.filter(name='Kobe').count())
+        self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+        self.assertEqual(0, Contact.objects.filter(name='Bob').count())
+        self.assertEqual(0, Contact.objects.filter(name='Kobe').count())
         eric = Contact.objects.filter(name='Eric Newcomer').first()
         michael = Contact.objects.filter(name='Michael').first()
         self.assertEqual(eric.pk, contact.pk)
         self.assertEqual(michael.pk, contact2.pk)
-        self.assertEquals('uuid-1111', eric.uuid)
-        self.assertEquals('uuid-4444', michael.uuid)
+        self.assertEqual('uuid-1111', eric.uuid)
+        self.assertEqual('uuid-4444', michael.uuid)
         self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
         # new urn added for eric
@@ -2760,21 +2760,21 @@ class ContactTest(TembaTest):
                                          dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
 
                 # we ignore urns so 1 less lock
-                self.assertEquals(mock_lock.call_count, 2)
+                self.assertEqual(mock_lock.call_count, 2)
 
-            self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-            self.assertEquals(0, Contact.objects.filter(name='Bob').count())
-            self.assertEquals(0, Contact.objects.filter(name='Kobe').count())
-            self.assertEquals('uuid-1111', Contact.objects.filter(name='Eric Newcomer').first().uuid)
-            self.assertEquals('uuid-4444', Contact.objects.filter(name='Michael').first().uuid)
+            self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+            self.assertEqual(0, Contact.objects.filter(name='Bob').count())
+            self.assertEqual(0, Contact.objects.filter(name='Kobe').count())
+            self.assertEqual('uuid-1111', Contact.objects.filter(name='Eric Newcomer').first().uuid)
+            self.assertEqual('uuid-4444', Contact.objects.filter(name='Michael').first().uuid)
             self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
             eric = Contact.objects.filter(name='Eric Newcomer').first()
             michael = Contact.objects.filter(name='Michael').first()
             self.assertEqual(eric.pk, contact.pk)
             self.assertEqual(michael.pk, contact2.pk)
-            self.assertEquals('uuid-1111', eric.uuid)
-            self.assertEquals('uuid-4444', michael.uuid)
+            self.assertEqual('uuid-1111', eric.uuid)
+            self.assertEqual('uuid-4444', michael.uuid)
             self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
             # new urn ignored for eric
@@ -2831,8 +2831,8 @@ class ContactTest(TembaTest):
         self.assertContactImport('%s/test_imports/sample_contacts_bad_unicode.xls' % settings.MEDIA_ROOT,
                                  dict(records=2, errors=0, creates=2, updates=0, error_messages=[]))
 
-        self.assertEquals(1, Contact.objects.filter(name='John Doe').count())
-        self.assertEquals(1, Contact.objects.filter(name='Mary Smith').count())
+        self.assertEqual(1, Contact.objects.filter(name='John Doe').count())
+        self.assertEqual(1, Contact.objects.filter(name='Mary Smith').count())
 
         contact = Contact.objects.filter(name='John Doe').first()
         contact2 = Contact.objects.filter(name='Mary Smith').first()
@@ -2847,21 +2847,21 @@ class ContactTest(TembaTest):
         self.assertContactImport('%s/test_imports/sample_contacts_twitter_and_phone.xls' % settings.MEDIA_ROOT,
                                  dict(records=3, errors=0, error_messages=[], creates=3, updates=0))
 
-        self.assertEquals(3, Contact.objects.all().count())
-        self.assertEquals(1, Contact.objects.filter(name='Rapidpro').count())
-        self.assertEquals(1, Contact.objects.filter(name='Textit').count())
-        self.assertEquals(1, Contact.objects.filter(name='Nyaruka').count())
+        self.assertEqual(3, Contact.objects.all().count())
+        self.assertEqual(1, Contact.objects.filter(name='Rapidpro').count())
+        self.assertEqual(1, Contact.objects.filter(name='Textit').count())
+        self.assertEqual(1, Contact.objects.filter(name='Nyaruka').count())
 
         # import file with row different urn on different existing contacts should ignore those lines
         self.assertContactImport('%s/test_imports/sample_contacts_twitter_and_phone_conflicts.xls' % settings.MEDIA_ROOT,
                                  dict(records=2, errors=0, creates=0, updates=2, error_messages=[]))
 
-        self.assertEquals(3, Contact.objects.all().count())
-        self.assertEquals(1, Contact.objects.filter(name='Rapidpro').count())
-        self.assertEquals(0, Contact.objects.filter(name='Textit').count())
-        self.assertEquals(0, Contact.objects.filter(name='Nyaruka').count())
-        self.assertEquals(1, Contact.objects.filter(name='Kigali').count())
-        self.assertEquals(1, Contact.objects.filter(name='Klab').count())
+        self.assertEqual(3, Contact.objects.all().count())
+        self.assertEqual(1, Contact.objects.filter(name='Rapidpro').count())
+        self.assertEqual(0, Contact.objects.filter(name='Textit').count())
+        self.assertEqual(0, Contact.objects.filter(name='Nyaruka').count())
+        self.assertEqual(1, Contact.objects.filter(name='Kigali').count())
+        self.assertEqual(1, Contact.objects.filter(name='Klab').count())
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
@@ -2893,17 +2893,17 @@ class ContactTest(TembaTest):
                                                                 "external, jiochat, fcm should be provided or a Contact UUID")]))
 
             # lock for creates only
-            self.assertEquals(mock_lock.call_count, 1)
+            self.assertEqual(mock_lock.call_count, 1)
 
-        self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-        self.assertEquals(0, Contact.objects.filter(name='Bob').count())
-        self.assertEquals(0, Contact.objects.filter(name='Kobe').count())
+        self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+        self.assertEqual(0, Contact.objects.filter(name='Bob').count())
+        self.assertEqual(0, Contact.objects.filter(name='Kobe').count())
         eric = Contact.objects.filter(name='Eric Newcomer').first()
         michael = Contact.objects.filter(name='Michael').first()
         self.assertEqual(eric.pk, contact.pk)
         self.assertEqual(michael.pk, contact2.pk)
-        self.assertEquals('uuid-1111', eric.uuid)
-        self.assertEquals('uuid-4444', michael.uuid)
+        self.assertEqual('uuid-1111', eric.uuid)
+        self.assertEqual('uuid-4444', michael.uuid)
         self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
         # new urn added for eric
@@ -2917,21 +2917,21 @@ class ContactTest(TembaTest):
                                          dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
 
                 # lock for creates only
-                self.assertEquals(mock_lock.call_count, 2)
+                self.assertEqual(mock_lock.call_count, 2)
 
-            self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-            self.assertEquals(0, Contact.objects.filter(name='Bob').count())
-            self.assertEquals(0, Contact.objects.filter(name='Kobe').count())
-            self.assertEquals('uuid-1111', Contact.objects.filter(name='Eric Newcomer').first().uuid)
-            self.assertEquals('uuid-4444', Contact.objects.filter(name='Michael').first().uuid)
+            self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+            self.assertEqual(0, Contact.objects.filter(name='Bob').count())
+            self.assertEqual(0, Contact.objects.filter(name='Kobe').count())
+            self.assertEqual('uuid-1111', Contact.objects.filter(name='Eric Newcomer').first().uuid)
+            self.assertEqual('uuid-4444', Contact.objects.filter(name='Michael').first().uuid)
             self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
             eric = Contact.objects.filter(name='Eric Newcomer').first()
             michael = Contact.objects.filter(name='Michael').first()
             self.assertEqual(eric.pk, contact.pk)
             self.assertEqual(michael.pk, contact2.pk)
-            self.assertEquals('uuid-1111', eric.uuid)
-            self.assertEquals('uuid-4444', michael.uuid)
+            self.assertEqual('uuid-1111', eric.uuid)
+            self.assertEqual('uuid-4444', michael.uuid)
             self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
             # new urn ignored for eric
@@ -2961,17 +2961,17 @@ class ContactTest(TembaTest):
                                                                 "external, jiochat, fcm should be provided or a Contact UUID")]))
 
             # only lock for create
-            self.assertEquals(mock_lock.call_count, 1)
+            self.assertEqual(mock_lock.call_count, 1)
 
-        self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-        self.assertEquals(0, Contact.objects.filter(name='Bob').count())
-        self.assertEquals(0, Contact.objects.filter(name='Kobe').count())
+        self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+        self.assertEqual(0, Contact.objects.filter(name='Bob').count())
+        self.assertEqual(0, Contact.objects.filter(name='Kobe').count())
         eric = Contact.objects.filter(name='Eric Newcomer').first()
         michael = Contact.objects.filter(name='Michael').first()
         self.assertEqual(eric.pk, contact.pk)
         self.assertEqual(michael.pk, contact2.pk)
-        self.assertEquals('uuid-1111', eric.uuid)
-        self.assertEquals('uuid-4444', michael.uuid)
+        self.assertEqual('uuid-1111', eric.uuid)
+        self.assertEqual('uuid-4444', michael.uuid)
         self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
         # new urn added for eric
@@ -2985,21 +2985,21 @@ class ContactTest(TembaTest):
                                          dict(records=4, errors=0, error_messages=[], creates=2, updates=2))
 
                 # only lock for creates
-                self.assertEquals(mock_lock.call_count, 2)
+                self.assertEqual(mock_lock.call_count, 2)
 
-            self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-            self.assertEquals(0, Contact.objects.filter(name='Bob').count())
-            self.assertEquals(0, Contact.objects.filter(name='Kobe').count())
-            self.assertEquals('uuid-1111', Contact.objects.filter(name='Eric Newcomer').first().uuid)
-            self.assertEquals('uuid-4444', Contact.objects.filter(name='Michael').first().uuid)
+            self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+            self.assertEqual(0, Contact.objects.filter(name='Bob').count())
+            self.assertEqual(0, Contact.objects.filter(name='Kobe').count())
+            self.assertEqual('uuid-1111', Contact.objects.filter(name='Eric Newcomer').first().uuid)
+            self.assertEqual('uuid-4444', Contact.objects.filter(name='Michael').first().uuid)
             self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
             eric = Contact.objects.filter(name='Eric Newcomer').first()
             michael = Contact.objects.filter(name='Michael').first()
             self.assertEqual(eric.pk, contact.pk)
             self.assertEqual(michael.pk, contact2.pk)
-            self.assertEquals('uuid-1111', eric.uuid)
-            self.assertEquals('uuid-4444', michael.uuid)
+            self.assertEqual('uuid-1111', eric.uuid)
+            self.assertEqual('uuid-4444', michael.uuid)
             self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
             # new urn ignored for eric
@@ -3025,10 +3025,10 @@ class ContactTest(TembaTest):
                                      dict(records=3, errors=0, error_messages=[], creates=1, updates=2))
 
             # one lock for the create
-            self.assertEquals(mock_lock.call_count, 1)
+            self.assertEqual(mock_lock.call_count, 1)
 
-        self.assertEquals(1, Contact.objects.filter(name='Bob').count())
-        self.assertEquals(1, Contact.objects.filter(name='Kobe').count())
+        self.assertEqual(1, Contact.objects.filter(name='Bob').count())
+        self.assertEqual(1, Contact.objects.filter(name='Kobe').count())
         self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
         with AnonymousOrg(self.org):
@@ -3038,10 +3038,10 @@ class ContactTest(TembaTest):
                                          dict(records=3, errors=0, error_messages=[], creates=1, updates=2))
 
                 # one lock for the create
-                self.assertEquals(mock_lock.call_count, 1)
+                self.assertEqual(mock_lock.call_count, 1)
 
-            self.assertEquals(1, Contact.objects.filter(name='Bob').count())
-            self.assertEquals(1, Contact.objects.filter(name='Kobe').count())
+            self.assertEqual(1, Contact.objects.filter(name='Bob').count())
+            self.assertEqual(1, Contact.objects.filter(name='Kobe').count())
             self.assertFalse(Contact.objects.filter(uuid='uuid-3333'))  # previously non-existent uuid ignored
 
         csv_file = open('%s/test_imports/sample_contacts_UPPER.XLS' % settings.MEDIA_ROOT, 'rb')
@@ -3053,16 +3053,16 @@ class ContactTest(TembaTest):
         ContactGroup.user_groups.all().delete()
 
         records = self.do_import(user, 'sample_contacts.xlsx')
-        self.assertEquals(3, len(records))
+        self.assertEqual(3, len(records))
 
-        self.assertEquals(1, len(ContactGroup.user_groups.all()))
+        self.assertEqual(1, len(ContactGroup.user_groups.all()))
         group = ContactGroup.user_groups.all()[0]
-        self.assertEquals('Sample Contacts', group.name)
-        self.assertEquals(3, group.contacts.count())
+        self.assertEqual('Sample Contacts', group.name)
+        self.assertEqual(3, group.contacts.count())
 
-        self.assertEquals(1, Contact.objects.filter(name='Eric Newcomer').count())
-        self.assertEquals(1, Contact.objects.filter(name='Nic Pottier').count())
-        self.assertEquals(1, Contact.objects.filter(name='Jen Newcomer').count())
+        self.assertEqual(1, Contact.objects.filter(name='Eric Newcomer').count())
+        self.assertEqual(1, Contact.objects.filter(name='Nic Pottier').count())
+        self.assertEqual(1, Contact.objects.filter(name='Jen Newcomer').count())
 
         Contact.objects.all().delete()
         ContactGroup.user_groups.all().delete()
@@ -3120,8 +3120,8 @@ class ContactTest(TembaTest):
         ContactGroup.user_groups.all().delete()
 
         # check that no contacts or groups were created by any of the previous invalid imports
-        self.assertEquals(Contact.objects.all().count(), 0)
-        self.assertEquals(ContactGroup.user_groups.all().count(), 0)
+        self.assertEqual(Contact.objects.all().count(), 0)
+        self.assertEqual(ContactGroup.user_groups.all().count(), 0)
 
         # existing field
         ContactField.get_or_create(self.org, self.admin, 'ride_or_drive', 'Vehicle')
@@ -3162,39 +3162,39 @@ class ContactTest(TembaTest):
         post_data['column_shoes_type'] = 'N'
 
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertEquals(response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3,
-                                                            updates=0))
-        self.assertEquals(Contact.objects.all().count(), 3)
-        self.assertEquals(ContactGroup.user_groups.all().count(), 1)
-        self.assertEquals(ContactGroup.user_groups.all()[0].name, 'Sample Contacts With Extra Fields')
+        self.assertEqual(response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3,
+                                                           updates=0))
+        self.assertEqual(Contact.objects.all().count(), 3)
+        self.assertEqual(ContactGroup.user_groups.all().count(), 1)
+        self.assertEqual(ContactGroup.user_groups.all()[0].name, 'Sample Contacts With Extra Fields')
 
         contact1 = Contact.objects.all().order_by('name')[0]
-        self.assertEquals(contact1.get_field_raw('location'), 'Rwanda')  # renamed from 'Country'
-        self.assertEquals(contact1.get_field_display('location'), 'Rwanda')  # renamed from 'Country'
+        self.assertEqual(contact1.get_field_raw('location'), 'Rwanda')  # renamed from 'Country'
+        self.assertEqual(contact1.get_field_display('location'), 'Rwanda')  # renamed from 'Country'
 
-        self.assertEquals(contact1.get_field_raw('ride_or_drive'), 'Moto')  # the existing field was looked up by label
-        self.assertEquals(contact1.get_field_raw('wears'), 'Bứnto')  # existing field was looked up by label & stripped
+        self.assertEqual(contact1.get_field_raw('ride_or_drive'), 'Moto')  # the existing field was looked up by label
+        self.assertEqual(contact1.get_field_raw('wears'), 'Bứnto')  # existing field was looked up by label & stripped
 
-        self.assertEquals(contact1.get_urn(schemes=[TWITTER_SCHEME]).path, 'ewok')
-        self.assertEquals(contact1.get_urn(schemes=[EXTERNAL_SCHEME]).path, 'abc-1111')
-        self.assertEquals(contact1.get_urn(schemes=[EMAIL_SCHEME]).path, 'eric@example.com')
+        self.assertEqual(contact1.get_urn(schemes=[TWITTER_SCHEME]).path, 'ewok')
+        self.assertEqual(contact1.get_urn(schemes=[EXTERNAL_SCHEME]).path, 'abc-1111')
+        self.assertEqual(contact1.get_urn(schemes=[EMAIL_SCHEME]).path, 'eric@example.com')
 
         # if we change the field type for 'location' to 'datetime' we shouldn't get a category
         ContactField.objects.filter(key='location').update(value_type=Value.TYPE_DATETIME)
         contact1 = Contact.objects.all().order_by('name')[0]
 
         # not a valid date, so should be None
-        self.assertEquals(contact1.get_field_display('location'), None)
+        self.assertEqual(contact1.get_field_display('location'), None)
 
         # return it back to a state field
         ContactField.objects.filter(key='location').update(value_type=Value.TYPE_STATE)
         contact1 = Contact.objects.all().order_by('name')[0]
 
         self.assertIsNone(contact1.get_field_raw('district'))  # wasn't included
-        self.assertEquals(contact1.get_field_raw('job_and_projects'), 'coach')  # renamed from 'Professional Status'
-        self.assertEquals(contact1.get_field_raw('postal_code'), '600.35')
-        self.assertEquals(contact1.get_field_raw('joined'), '31-12-2014 00:00')  # persisted value is localized to org
-        self.assertEquals(contact1.get_field_display('joined'), '31-12-2014 00:00')  # display value is also localized
+        self.assertEqual(contact1.get_field_raw('job_and_projects'), 'coach')  # renamed from 'Professional Status'
+        self.assertEqual(contact1.get_field_raw('postal_code'), '600.35')
+        self.assertEqual(contact1.get_field_raw('joined'), '31-12-2014 00:00')  # persisted value is localized to org
+        self.assertEqual(contact1.get_field_display('joined'), '31-12-2014 00:00')  # display value is also localized
 
         self.assertTrue(ContactField.objects.filter(org=self.org, label="Job and Projects"))
         self.assertTrue(ContactField.objects.filter(org=self.org, label="Location"))
@@ -3301,11 +3301,11 @@ class ContactTest(TembaTest):
         post_data['column_joined_type'] = 'D'
         post_data['column_joined_label'] = 'StartDate'
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertEquals(response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3,
-                                                            updates=0))
+        self.assertEqual(response.context['results'], dict(records=3, errors=0, error_messages=[], creates=3,
+                                                           updates=0))
 
         contact1 = Contact.objects.all().order_by('name')[0]
-        self.assertEquals(contact1.get_field_raw('startdate'), '31-12-2014 10:00')
+        self.assertEqual(contact1.get_field_raw('startdate'), '31-12-2014 10:00')
 
     def test_contact_import_handle_update_contact(self):
         self.login(self.admin)
@@ -3335,17 +3335,17 @@ class ContactTest(TembaTest):
         post_data['column_team_label'] = 'Team'
 
         response = self.client.post(customize_url, post_data, follow=True)
-        self.assertEquals(response.context['results'], dict(records=1, errors=0, error_messages=[], creates=0,
-                                                            updates=1))
+        self.assertEqual(response.context['results'], dict(records=1, errors=0, error_messages=[], creates=0,
+                                                           updates=1))
 
         contact1 = Contact.objects.filter(name='John Blow').first()
-        self.assertEquals(contact1.get_field_raw('planting_date'), '31-12-2020 10:00')
-        self.assertEquals(contact1.get_field_raw('team'), 'Ballers')
+        self.assertEqual(contact1.get_field_raw('planting_date'), '31-12-2020 10:00')
+        self.assertEqual(contact1.get_field_raw('team'), 'Ballers')
 
         event_fire = EventFire.objects.filter(event=self.message_event, contact=contact1,
                                               event__campaign__group__in=[ballers]).first()
         contact1_planting_date = contact1.get_field('planting_date').datetime_value.replace(second=0, microsecond=0)
-        self.assertEquals(event_fire.scheduled, contact1_planting_date + timedelta(days=7))
+        self.assertEqual(event_fire.scheduled, contact1_planting_date + timedelta(days=7))
 
     def test_contact_import_with_languages(self):
         self.create_contact(name="Eric", number="+250788382382")
@@ -3376,7 +3376,7 @@ class ContactTest(TembaTest):
         user = self.user
         c1 = self.create_contact(name=None, number='0788382382')
         c2 = self.create_contact(name=None, number='0788382382')
-        self.assertEquals(c1.pk, c2.pk)
+        self.assertEqual(c1.pk, c2.pk)
 
         field_dict = dict(phone='0788123123', created_by=user, modified_by=user, org=self.org, name='LaToya Jackson')
         c1 = Contact.create_instance(field_dict)
@@ -3384,13 +3384,13 @@ class ContactTest(TembaTest):
         field_dict = dict(phone='0788123123', created_by=user, modified_by=user, org=self.org, name='LaToya Jackson')
         field_dict['name'] = 'LaToya Jackson'
         c2 = Contact.create_instance(field_dict)
-        self.assertEquals(c1.pk, c2.pk)
+        self.assertEqual(c1.pk, c2.pk)
 
         c1.block(self.user)
         field_dict = dict(phone='0788123123', created_by=user, modified_by=user, org=self.org, name='LaToya Jackson')
         field_dict['name'] = 'LaToya Jackson'
         c2 = Contact.create_instance(field_dict)
-        self.assertEquals(c1.pk, c2.pk)
+        self.assertEqual(c1.pk, c2.pk)
         self.assertFalse(c2.is_blocked)
 
         import_params = dict(org_id=self.org.id, timezone=timezone.utc, extra_fields=[
@@ -3402,8 +3402,8 @@ class ContactTest(TembaTest):
         field_dict = Contact.prepare_fields(field_dict, import_params, user=user)
         self.assertNotIn('yourmom', field_dict)
         self.assertNotIn('nick name', field_dict)
-        self.assertEquals(field_dict['nick_name'], 'bob')
-        self.assertEquals(field_dict['org'], self.org)
+        self.assertEqual(field_dict['nick_name'], 'bob')
+        self.assertEqual(field_dict['org'], self.org)
 
         # missing important import params
         with self.assertRaises(Exception):
@@ -3450,21 +3450,21 @@ class ContactTest(TembaTest):
     def test_fields(self):
         # set a field on joe
         self.joe.set_field(self.user, 'abc_1234', 'Joe', label="Name")
-        self.assertEquals('Joe', self.joe.get_field_raw('abc_1234'))
+        self.assertEqual('Joe', self.joe.get_field_raw('abc_1234'))
 
         self.joe.set_field(self.user, 'abc_1234', None)
-        self.assertEquals(None, self.joe.get_field_raw('abc_1234'))
+        self.assertEqual(None, self.joe.get_field_raw('abc_1234'))
 
         # try storing an integer, should get turned into a string
         self.joe.set_field(self.user, 'abc_1234', 1)
-        self.assertEquals('1', self.joe.get_field_raw('abc_1234'))
+        self.assertEqual('1', self.joe.get_field_raw('abc_1234'))
 
         # we should have a field with the key
         ContactField.objects.get(key='abc_1234', label="Name", org=self.joe.org)
 
         # setting with a different label should update it
         self.joe.set_field(self.user, 'abc_1234', 'Joe', label="First Name")
-        self.assertEquals('Joe', self.joe.get_field_raw('abc_1234'))
+        self.assertEqual('Joe', self.joe.get_field_raw('abc_1234'))
         ContactField.objects.get(key='abc_1234', label="First Name", org=self.joe.org)
 
         modified_on = self.joe.modified_on
@@ -3537,13 +3537,13 @@ class ContactTest(TembaTest):
         joe.set_field(self.user, 'state', 'Kigali city')
         value = Value.objects.filter(contact=joe, contact_field=state_field).first()
         self.assertTrue(value.location_value)
-        self.assertEquals(value.location_value.name, "Kigali City")
+        self.assertEqual(value.location_value.name, "Kigali City")
 
         joe.set_field(self.user, 'district', 'Remera')
         value = Value.objects.filter(contact=joe, contact_field=district_field).first()
         self.assertTrue(value.location_value)
-        self.assertEquals(value.location_value.name, "Remera")
-        self.assertEquals(value.location_value.parent, kigali)
+        self.assertEqual(value.location_value.name, "Remera")
+        self.assertEqual(value.location_value.parent, kigali)
 
     def test_set_location_ward_fields(self):
 
@@ -3561,7 +3561,7 @@ class ContactTest(TembaTest):
         jemila.set_field(user1, 'district', 'bichi')
         jemila.set_field(user1, 'ward', 'bichi')
         value = Value.objects.filter(contact=jemila, contact_field=ward_field).first()
-        self.assertEquals(value.location_value, ward)
+        self.assertEqual(value.location_value, ward)
 
     def test_expressions_context(self):
         self.joe.urns.filter(scheme='twitter').delete()
@@ -3569,15 +3569,15 @@ class ContactTest(TembaTest):
 
         context = self.joe.build_expressions_context()
 
-        self.assertEquals("Joe", context['first_name'])
-        self.assertEquals("Joe Blow", context['name'])
-        self.assertEquals("Joe Blow", context['__default__'])
-        self.assertEquals("0781 111 111", context['tel'])
-        self.assertEquals("", context['groups'])
-        self.assertEquals(context['uuid'], self.joe.uuid)
-        self.assertEquals(self.joe.uuid, context['uuid'])
-        self.assertEquals("therealjoe", context['twitter'])
-        self.assertEquals("therealjoe", context['twitterid'])
+        self.assertEqual("Joe", context['first_name'])
+        self.assertEqual("Joe Blow", context['name'])
+        self.assertEqual("Joe Blow", context['__default__'])
+        self.assertEqual("0781 111 111", context['tel'])
+        self.assertEqual("", context['groups'])
+        self.assertEqual(context['uuid'], self.joe.uuid)
+        self.assertEqual(self.joe.uuid, context['uuid'])
+        self.assertEqual("therealjoe", context['twitter'])
+        self.assertEqual("therealjoe", context['twitterid'])
 
         # add him to a group
         self.create_group("Reporters", [self.joe])
@@ -3596,11 +3596,11 @@ class ContactTest(TembaTest):
 
         context = self.joe.build_expressions_context()
 
-        self.assertEquals("Joe", context['first_name'])
-        self.assertEquals("Joe Blow", context['name'])
-        self.assertEquals("Joe Blow", context['__default__'])
-        self.assertEquals("0781 111 111", context['tel'])
-        self.assertEquals("Reporters", context['groups'])
+        self.assertEqual("Joe", context['first_name'])
+        self.assertEqual("Joe Blow", context['name'])
+        self.assertEqual("Joe Blow", context['__default__'])
+        self.assertEqual("0781 111 111", context['tel'])
+        self.assertEqual("Reporters", context['groups'])
         self.assertNotIn('id', context)
 
         self.assertEqual("SeaHawks", context['team'])
@@ -3619,37 +3619,37 @@ class ContactTest(TembaTest):
 
         bob.update_urns(self.user, ['tel:456', 'tel:789'])
         urns = bob.urns.all().order_by('-priority')
-        self.assertEquals(2, len(urns))
-        self.assertEquals('456', urns[0].path)
-        self.assertEquals('789', urns[1].path)
-        self.assertEquals(99, urns[0].priority)
-        self.assertEquals(98, urns[1].priority)
+        self.assertEqual(2, len(urns))
+        self.assertEqual('456', urns[0].path)
+        self.assertEqual('789', urns[1].path)
+        self.assertEqual(99, urns[0].priority)
+        self.assertEqual(98, urns[1].priority)
 
         bob.update_urns(self.user, ['tel:789', 'tel:456'])
         urns = bob.urns.all().order_by('-priority')
-        self.assertEquals(2, len(urns))
-        self.assertEquals('789', urns[0].path)
-        self.assertEquals('456', urns[1].path)
+        self.assertEqual(2, len(urns))
+        self.assertEqual('789', urns[0].path)
+        self.assertEqual('456', urns[1].path)
 
         # add an email urn
         bob.update_urns(self.user, ['mailto:bob@marley.com', 'tel:789', 'tel:456'])
         urns = bob.urns.all().order_by('-priority')
-        self.assertEquals(3, len(urns))
-        self.assertEquals(99, urns[0].priority)
-        self.assertEquals(98, urns[1].priority)
-        self.assertEquals(97, urns[2].priority)
+        self.assertEqual(3, len(urns))
+        self.assertEqual(99, urns[0].priority)
+        self.assertEqual(98, urns[1].priority)
+        self.assertEqual(97, urns[2].priority)
 
         # it'll come back as the highest priority
-        self.assertEquals('bob@marley.com', urns[0].path)
+        self.assertEqual('bob@marley.com', urns[0].path)
 
         # but not the highest 'sendable' urn
         contact, urn = Msg.resolve_recipient(self.org, self.admin, bob, self.channel)
-        self.assertEquals(urn.path, '789')
+        self.assertEqual(urn.path, '789')
 
         # swap our phone numbers
         bob.update_urns(self.user, ['mailto:bob@marley.com', 'tel:456', 'tel:789'])
         contact, urn = Msg.resolve_recipient(self.org, self.admin, bob, self.channel)
-        self.assertEquals(urn.path, '456')
+        self.assertEqual(urn.path, '456')
 
     def test_update_handling(self):
         bob = self.create_contact("Bob", "111222")
@@ -3709,10 +3709,10 @@ class ContactTest(TembaTest):
             EventFire.update_campaign_events(joes_campaign)
 
             # check initial group members added correctly
-            self.assertEquals([self.frank, self.joe, self.mary], list(mtn_group.contacts.order_by('name')))
-            self.assertEquals([self.frank, self.joe], list(men_group.contacts.order_by('name')))
-            self.assertEquals([self.mary], list(women_group.contacts.order_by('name')))
-            self.assertEquals([self.joe], list(joes_group.contacts.order_by('name')))
+            self.assertEqual([self.frank, self.joe, self.mary], list(mtn_group.contacts.order_by('name')))
+            self.assertEqual([self.frank, self.joe], list(men_group.contacts.order_by('name')))
+            self.assertEqual([self.mary], list(women_group.contacts.order_by('name')))
+            self.assertEqual([self.joe], list(joes_group.contacts.order_by('name')))
 
             # try removing frank from dynamic group (shouldnt happen, ui doesnt allow this)
             with self.assertRaises(ValueError):
@@ -3722,27 +3722,27 @@ class ContactTest(TembaTest):
 
             # check event fire initialized correctly
             joe_fires = EventFire.objects.filter(event=joes_event)
-            self.assertEquals(1, joe_fires.count())
-            self.assertEquals(self.joe, joe_fires.first().contact)
+            self.assertEqual(1, joe_fires.count())
+            self.assertEqual(self.joe, joe_fires.first().contact)
 
             # Frank becomes Francine...
             self.frank.set_field(self.user, 'gender', "Female")
-            self.assertEquals([self.joe], list(men_group.contacts.order_by('name')))
-            self.assertEquals([self.frank, self.mary], list(women_group.contacts.order_by('name')))
+            self.assertEqual([self.joe], list(men_group.contacts.order_by('name')))
+            self.assertEqual([self.frank, self.mary], list(women_group.contacts.order_by('name')))
 
             # Mary's name changes
             self.mary.name = "Mary Joe"
             self.mary.save()
             self.mary.handle_update(attrs=('name',))
-            self.assertEquals([self.joe, self.mary], list(joes_group.contacts.order_by('name')))
+            self.assertEqual([self.joe, self.mary], list(joes_group.contacts.order_by('name')))
 
             # Mary should also have an event fire now
             joe_fires = EventFire.objects.filter(event=joes_event)
-            self.assertEquals(2, joe_fires.count())
+            self.assertEqual(2, joe_fires.count())
 
             # change Mary's URNs
             self.mary.update_urns(self.user, ['tel:54321', 'twitter:mary_mary'])
-            self.assertEquals([self.frank, self.joe], list(mtn_group.contacts.order_by('name')))
+            self.assertEqual([self.frank, self.joe], list(mtn_group.contacts.order_by('name')))
 
     def test_simulator_contact_views(self):
         simulator_contact = Contact.get_test_contact(self.admin)
@@ -3753,19 +3753,19 @@ class ContactTest(TembaTest):
 
         self.login(self.admin)
         response = self.client.get(reverse('contacts.contact_read', args=[simulator_contact.uuid]))
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         response = self.client.get(reverse('contacts.contact_update', args=[simulator_contact.pk]))
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         response = self.client.get(reverse('contacts.contact_list'))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertFalse(simulator_contact in response.context['object_list'])
         self.assertTrue(other_contact in response.context['object_list'])
         self.assertFalse("Simulator Contact" in response.content)
 
         response = self.client.get(reverse('contacts.contact_filter', args=[group.uuid]))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertFalse(simulator_contact in response.context['object_list'])
         self.assertTrue(other_contact in response.context['object_list'])
         self.assertFalse("Simulator Contact" in response.content)
@@ -3925,12 +3925,12 @@ class ContactFieldTest(TembaTest):
 
     def test_contact_templatetag(self):
         self.joe.set_field(self.user, 'First', 'Starter')
-        self.assertEquals(contact_field(self.joe, 'First'), 'Starter')
+        self.assertEqual(contact_field(self.joe, 'First'), 'Starter')
 
     def test_make_key(self):
-        self.assertEquals("first_name", ContactField.make_key("First Name"))
-        self.assertEquals("second_name", ContactField.make_key("Second   Name  "))
-        self.assertEquals("323_ffsn_slfs_ksflskfs_fk_anfaddgas", ContactField.make_key("  ^%$# %$$ $##323 ffsn slfs ksflskfs!!!! fk$%%%$$$anfaDDGAS ))))))))) "))
+        self.assertEqual("first_name", ContactField.make_key("First Name"))
+        self.assertEqual("second_name", ContactField.make_key("Second   Name  "))
+        self.assertEqual("323_ffsn_slfs_ksflskfs_fk_anfaddgas", ContactField.make_key("  ^%$# %$$ $##323 ffsn slfs ksflskfs!!!! fk$%%%$$$anfaDDGAS ))))))))) "))
 
     def test_is_valid_key(self):
         self.assertTrue(ContactField.is_valid_key("age"))
@@ -4078,11 +4078,11 @@ class ContactFieldTest(TembaTest):
         response = self.client.get(manage_fields_url)
 
         # redirect to login because of no access to org
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         self.login(self.admin)
         response = self.client.get(manage_fields_url)
-        self.assertEquals(len(response.context['form'].fields), 16)
+        self.assertEqual(len(response.context['form'].fields), 16)
 
         post_data = dict()
         for id, field in response.context['form'].fields.items():
@@ -4094,13 +4094,13 @@ class ContactFieldTest(TembaTest):
                 post_data[id] = field.initial
 
         response = self.client.post(manage_fields_url, post_data, follow=True)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # make sure we didn't have an error
         self.assertTrue('form' not in response.context)
 
         # should still have three contact fields
-        self.assertEquals(3, ContactField.objects.filter(org=self.org, is_active=True).count())
+        self.assertEqual(3, ContactField.objects.filter(org=self.org, is_active=True).count())
 
         # fields name should be unique case insensitively
         post_data['label_1'] = "Town"
@@ -4108,7 +4108,7 @@ class ContactFieldTest(TembaTest):
 
         response = self.client.post(manage_fields_url, post_data, follow=True)
         self.assertFormError(response, 'form', None, "Field names must be unique. 'Town' is duplicated")
-        self.assertEquals(3, ContactField.objects.filter(org=self.org, is_active=True).count())
+        self.assertEqual(3, ContactField.objects.filter(org=self.org, is_active=True).count())
         self.assertFalse(ContactField.objects.filter(org=self.org, label__in=["town", "Town"]))
 
         # now remove the first field, rename the second and change the type on the third
@@ -4118,7 +4118,7 @@ class ContactFieldTest(TembaTest):
         post_data['label_4'] = "New Field"
 
         response = self.client.post(manage_fields_url, post_data, follow=True)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # make sure we didn't have an error
         self.assertTrue('form' not in response.context)
@@ -4127,10 +4127,10 @@ class ContactFieldTest(TembaTest):
         self.assertIsNone(ContactField.objects.filter(org=self.org, key="first", is_active=True).first())
 
         # the second should be renamed
-        self.assertEquals("Number 2", ContactField.objects.filter(org=self.org, key="second", is_active=True).first().label)
+        self.assertEqual("Number 2", ContactField.objects.filter(org=self.org, key="second", is_active=True).first().label)
 
         # the third should have a different type
-        self.assertEquals('N', ContactField.objects.filter(org=self.org, key="third", is_active=True).first().value_type)
+        self.assertEqual('N', ContactField.objects.filter(org=self.org, key="third", is_active=True).first().value_type)
 
         # we should have a fourth field now
         self.assertTrue(ContactField.objects.filter(org=self.org, key='new_field', label="New Field", value_type='T'))
@@ -4154,7 +4154,7 @@ class ContactFieldTest(TembaTest):
         ContactField.objects.create(org=self.org, key='language', label='User Language',
                                     created_by=self.admin, modified_by=self.admin)
 
-        self.assertEquals(4, ContactField.objects.filter(org=self.org, is_active=True).count())
+        self.assertEqual(4, ContactField.objects.filter(org=self.org, is_active=True).count())
 
         response = self.client.get(manage_fields_url)
         post_data = dict()
@@ -4180,7 +4180,7 @@ class ContactFieldTest(TembaTest):
             ContactField.get_or_create(self.org, self.admin, key, label)
             ContactField.get_or_create(self.org2, self.admin, key, label)
 
-        self.assertEquals(Org.objects.all().count(), 2)
+        self.assertEqual(Org.objects.all().count(), 2)
 
         ContactField.objects.filter(org=self.org, key='key1').update(is_active=False)
 
@@ -4188,54 +4188,54 @@ class ContactFieldTest(TembaTest):
         response = self.client.get(contact_field_json_url)
 
         # redirect to login because of no access to org
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         self.login(self.admin)
         response = self.client.get(contact_field_json_url)
 
         response_json = response.json()
 
-        self.assertEquals(len(response_json), 45)
-        self.assertEquals(response_json[0]['label'], 'Full name')
-        self.assertEquals(response_json[0]['key'], 'name')
-        self.assertEquals(response_json[1]['label'], 'Phone number')
-        self.assertEquals(response_json[1]['key'], 'tel_e164')
-        self.assertEquals(response_json[2]['label'], 'Facebook identifier')
-        self.assertEquals(response_json[2]['key'], 'facebook')
-        self.assertEquals(response_json[3]['label'], 'Twitter handle')
-        self.assertEquals(response_json[3]['key'], 'twitter')
-        self.assertEquals(response_json[4]['label'], 'Twitter ID')
-        self.assertEquals(response_json[4]['key'], 'twitterid')
-        self.assertEquals(response_json[5]['label'], 'Viber identifier')
-        self.assertEquals(response_json[5]['key'], 'viber')
-        self.assertEquals(response_json[6]['label'], 'LINE identifier')
-        self.assertEquals(response_json[6]['key'], 'line')
-        self.assertEquals(response_json[7]['label'], 'Telegram identifier')
-        self.assertEquals(response_json[7]['key'], 'telegram')
-        self.assertEquals(response_json[8]['label'], 'Email address')
-        self.assertEquals(response_json[8]['key'], 'mailto')
-        self.assertEquals(response_json[9]['label'], 'External identifier')
-        self.assertEquals(response_json[9]['key'], 'ext')
-        self.assertEquals(response_json[10]['label'], 'Jiochat identifier')
-        self.assertEquals(response_json[10]['key'], 'jiochat')
-        self.assertEquals(response_json[11]['label'], 'Firebase Cloud Messaging identifier')
-        self.assertEquals(response_json[11]['key'], 'fcm')
-        self.assertEquals(response_json[12]['label'], 'Groups')
-        self.assertEquals(response_json[12]['key'], 'groups')
-        self.assertEquals(response_json[13]['label'], 'First')
-        self.assertEquals(response_json[13]['key'], 'first')
-        self.assertEquals(response_json[14]['label'], 'label0')
-        self.assertEquals(response_json[14]['key'], 'key0')
+        self.assertEqual(len(response_json), 45)
+        self.assertEqual(response_json[0]['label'], 'Full name')
+        self.assertEqual(response_json[0]['key'], 'name')
+        self.assertEqual(response_json[1]['label'], 'Phone number')
+        self.assertEqual(response_json[1]['key'], 'tel_e164')
+        self.assertEqual(response_json[2]['label'], 'Facebook identifier')
+        self.assertEqual(response_json[2]['key'], 'facebook')
+        self.assertEqual(response_json[3]['label'], 'Twitter handle')
+        self.assertEqual(response_json[3]['key'], 'twitter')
+        self.assertEqual(response_json[4]['label'], 'Twitter ID')
+        self.assertEqual(response_json[4]['key'], 'twitterid')
+        self.assertEqual(response_json[5]['label'], 'Viber identifier')
+        self.assertEqual(response_json[5]['key'], 'viber')
+        self.assertEqual(response_json[6]['label'], 'LINE identifier')
+        self.assertEqual(response_json[6]['key'], 'line')
+        self.assertEqual(response_json[7]['label'], 'Telegram identifier')
+        self.assertEqual(response_json[7]['key'], 'telegram')
+        self.assertEqual(response_json[8]['label'], 'Email address')
+        self.assertEqual(response_json[8]['key'], 'mailto')
+        self.assertEqual(response_json[9]['label'], 'External identifier')
+        self.assertEqual(response_json[9]['key'], 'ext')
+        self.assertEqual(response_json[10]['label'], 'Jiochat identifier')
+        self.assertEqual(response_json[10]['key'], 'jiochat')
+        self.assertEqual(response_json[11]['label'], 'Firebase Cloud Messaging identifier')
+        self.assertEqual(response_json[11]['key'], 'fcm')
+        self.assertEqual(response_json[12]['label'], 'Groups')
+        self.assertEqual(response_json[12]['key'], 'groups')
+        self.assertEqual(response_json[13]['label'], 'First')
+        self.assertEqual(response_json[13]['key'], 'first')
+        self.assertEqual(response_json[14]['label'], 'label0')
+        self.assertEqual(response_json[14]['key'], 'key0')
 
         ContactField.objects.filter(org=self.org, key='key0').update(label='AAAA')
 
         response = self.client.get(contact_field_json_url)
         response_json = response.json()
 
-        self.assertEquals(response_json[13]['label'], 'AAAA')
-        self.assertEquals(response_json[13]['key'], 'key0')
-        self.assertEquals(response_json[14]['label'], 'First')
-        self.assertEquals(response_json[14]['key'], 'first')
+        self.assertEqual(response_json[13]['label'], 'AAAA')
+        self.assertEqual(response_json[13]['key'], 'key0')
+        self.assertEqual(response_json[14]['label'], 'First')
+        self.assertEqual(response_json[14]['key'], 'first')
 
 
 class URNTest(TembaTest):

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -171,7 +171,7 @@ class FlowTest(TembaTest):
 
                 self.assertEqual(response.status_code, 200)
                 path = response.json().get('path', None)
-                self.assertEquals(path, expected_path)
+                self.assertEqual(path, expected_path)
 
         self.login(self.admin)
 
@@ -196,13 +196,13 @@ class FlowTest(TembaTest):
         revisions = self.flow.revisions.all().order_by('created_on')
 
         # now we should have two revisions
-        self.assertEquals(2, revisions.count())
-        self.assertEquals(1, revisions[0].revision)
-        self.assertEquals(2, revisions[1].revision)
+        self.assertEqual(2, revisions.count())
+        self.assertEqual(1, revisions[0].revision)
+        self.assertEqual(2, revisions[1].revision)
 
-        self.assertEquals(CURRENT_EXPORT_VERSION, revisions[0].spec_version)
-        self.assertEquals(CURRENT_EXPORT_VERSION, revisions[0].as_json()['version'])
-        self.assertEquals('base', revisions[0].get_definition_json()['base_language'])
+        self.assertEqual(CURRENT_EXPORT_VERSION, revisions[0].spec_version)
+        self.assertEqual(CURRENT_EXPORT_VERSION, revisions[0].as_json()['version'])
+        self.assertEqual('base', revisions[0].get_definition_json()['base_language'])
 
         # now make one revision invalid
         revision = revisions[1]
@@ -234,7 +234,7 @@ class FlowTest(TembaTest):
 
         # no valid revisions (but we didn't throw!)
         response = self.client.get(reverse('flows.flow_revisions', args=[self.flow.pk]))
-        self.assertEquals(0, len(response.json()))
+        self.assertEqual(0, len(response.json()))
 
     def test_get_localized_text(self):
 
@@ -284,8 +284,8 @@ class FlowTest(TembaTest):
         response = self.client.get(reverse('flows.flow_list'))
         self.assertContains(response, self.flow.name)
         self.assertContains(response, flow3.name)
-        self.assertEquals(2, response.context['folders'][0]['count'])
-        self.assertEquals(1, response.context['folders'][1]['count'])
+        self.assertEqual(2, response.context['folders'][0]['count'])
+        self.assertEqual(1, response.context['folders'][1]['count'])
 
         # archive it
         post_data = dict(action='archive', objects=self.flow.pk)
@@ -293,8 +293,8 @@ class FlowTest(TembaTest):
         response = self.client.get(reverse('flows.flow_list'))
         self.assertNotContains(response, self.flow.name)
         self.assertContains(response, flow3.name)
-        self.assertEquals(1, response.context['folders'][0]['count'])
-        self.assertEquals(2, response.context['folders'][1]['count'])
+        self.assertEqual(1, response.context['folders'][0]['count'])
+        self.assertEqual(2, response.context['folders'][1]['count'])
 
         response = self.client.get(reverse('flows.flow_archived'), post_data)
         self.assertContains(response, self.flow.name)
@@ -311,16 +311,16 @@ class FlowTest(TembaTest):
         response = self.client.get(reverse('flows.flow_list'), post_data)
         self.assertContains(response, self.flow.name)
         self.assertContains(response, flow3.name)
-        self.assertEquals(2, response.context['folders'][0]['count'])
-        self.assertEquals(1, response.context['folders'][1]['count'])
+        self.assertEqual(2, response.context['folders'][0]['count'])
+        self.assertEqual(1, response.context['folders'][1]['count'])
 
         # voice flows should be included in the count
         Flow.objects.filter(pk=self.flow.pk).update(flow_type=Flow.VOICE)
 
         response = self.client.get(reverse('flows.flow_list'))
         self.assertContains(response, self.flow.name)
-        self.assertEquals(2, response.context['folders'][0]['count'])
-        self.assertEquals(1, response.context['folders'][1]['count'])
+        self.assertEqual(2, response.context['folders'][0]['count'])
+        self.assertEqual(1, response.context['folders'][1]['count'])
 
         # single message flow (flom campaign) should not be included in counts and not even on this list
         Flow.objects.filter(pk=self.flow.pk).update(flow_type=Flow.MESSAGE)
@@ -328,16 +328,16 @@ class FlowTest(TembaTest):
         response = self.client.get(reverse('flows.flow_list'))
 
         self.assertNotContains(response, self.flow.name)
-        self.assertEquals(1, response.context['folders'][0]['count'])
-        self.assertEquals(1, response.context['folders'][1]['count'])
+        self.assertEqual(1, response.context['folders'][0]['count'])
+        self.assertEqual(1, response.context['folders'][1]['count'])
 
         # single message flow should not be even in the archived list
         Flow.objects.filter(pk=self.flow.pk).update(flow_type=Flow.MESSAGE, is_archived=True)
 
         response = self.client.get(reverse('flows.flow_archived'))
         self.assertNotContains(response, self.flow.name)
-        self.assertEquals(1, response.context['folders'][0]['count'])
-        self.assertEquals(1, response.context['folders'][1]['count'])  # only flow2
+        self.assertEqual(1, response.context['folders'][0]['count'])
+        self.assertEqual(1, response.context['folders'][1]['count'])  # only flow2
 
     def test_campaign_filter(self):
         self.login(self.admin)
@@ -504,7 +504,7 @@ class FlowTest(TembaTest):
 
         # test our message context
         context = self.flow.build_expressions_context(self.contact, None)
-        self.assertEquals(dict(__default__=''), context['flow'])
+        self.assertEqual(dict(__default__=''), context['flow'])
 
         # check flow activity endpoint response
         self.login(self.admin)
@@ -513,15 +513,15 @@ class FlowTest(TembaTest):
         test_message = self.create_msg(contact=test_contact, text='Hi')
 
         activity = json.loads(self.client.get(reverse('flows.flow_activity', args=[self.flow.pk])).content)
-        self.assertEquals(2, activity['visited']["d51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1"])
-        self.assertEquals(2, activity['activity']["bd531ace-911e-4722-8e53-6730d6122fe1"])
-        self.assertEquals(activity['messages'], [])
+        self.assertEqual(2, activity['visited']["d51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1"])
+        self.assertEqual(2, activity['activity']["bd531ace-911e-4722-8e53-6730d6122fe1"])
+        self.assertEqual(activity['messages'], [])
 
         # check activity with IVR test call
         IVRCall.create_incoming(self.channel, test_contact, test_contact.get_urn(), self.admin, 'CallSid')
         activity = json.loads(self.client.get(reverse('flows.flow_activity', args=[self.flow.pk])).content)
-        self.assertEquals(2, activity['visited']["d51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1"])
-        self.assertEquals(2, activity['activity']["bd531ace-911e-4722-8e53-6730d6122fe1"])
+        self.assertEqual(2, activity['visited']["d51ec25f-04e6-4349-a448-e7c4d93d4597:bd531ace-911e-4722-8e53-6730d6122fe1"])
+        self.assertEqual(2, activity['activity']["bd531ace-911e-4722-8e53-6730d6122fe1"])
         self.assertTrue(activity['messages'], [test_message.as_json()])
 
         # set the flow as inactive, shouldn't react to replies
@@ -551,8 +551,8 @@ class FlowTest(TembaTest):
 
         # our message should have gotten a reply
         reply = Msg.objects.get(response_to=incoming)
-        self.assertEquals(self.contact, reply.contact)
-        self.assertEquals("I love orange too! You said: orange which is category: Orange You are: 0788 382 382 SMS: orange Flow: color: orange", reply.text)
+        self.assertEqual(self.contact, reply.contact)
+        self.assertEqual("I love orange too! You said: orange which is category: Orange You are: 0788 382 382 SMS: orange Flow: color: orange", reply.text)
 
         # should be high priority as this is a reply
         self.assertTrue(reply.high_priority)
@@ -560,23 +560,23 @@ class FlowTest(TembaTest):
         # our previous state should be executed
         step = FlowStep.objects.get(run__contact=self.contact, pk=step.id)
         self.assertTrue(step.left_on)
-        self.assertEquals(step.messages.all()[0].msg_type, 'F')
+        self.assertEqual(step.messages.all()[0].msg_type, 'F')
 
         # it should contain what rule matched and what came next
-        self.assertEquals("1c75fd71-027b-40e8-a819-151a0f8140e6", step.rule_uuid)
-        self.assertEquals("Orange", step.rule_category)
-        self.assertEquals("orange", step.rule_value)
+        self.assertEqual("1c75fd71-027b-40e8-a819-151a0f8140e6", step.rule_uuid)
+        self.assertEqual("Orange", step.rule_category)
+        self.assertEqual("orange", step.rule_value)
         self.assertFalse(step.rule_decimal_value)
-        self.assertEquals("7d40faea-723b-473d-8999-59fb7d3c3ca2", step.next_uuid)
+        self.assertEqual("7d40faea-723b-473d-8999-59fb7d3c3ca2", step.next_uuid)
         self.assertTrue(incoming in step.messages.all())
 
         # we should also have a Value for this RuleSet
         value = Value.objects.get(run=step.run, ruleset__label="color")
-        self.assertEquals("1c75fd71-027b-40e8-a819-151a0f8140e6", value.rule_uuid)
-        self.assertEquals("Orange", value.category)
-        self.assertEquals("orange", value.string_value)
-        self.assertEquals(None, value.decimal_value)
-        self.assertEquals(None, value.datetime_value)
+        self.assertEqual("1c75fd71-027b-40e8-a819-151a0f8140e6", value.rule_uuid)
+        self.assertEqual("Orange", value.category)
+        self.assertEqual("orange", value.string_value)
+        self.assertEqual(None, value.decimal_value)
+        self.assertEqual(None, value.datetime_value)
 
         # check what our message context looks like now
         context = self.flow.build_expressions_context(self.contact, incoming)
@@ -591,10 +591,10 @@ class FlowTest(TembaTest):
         val_time = datetime_to_str(step.left_on, '%d-%m-%Y %H:%M', tz=self.org.timezone)
         self.assertEqual(val_time, context['flow']['color']['time'])
 
-        self.assertEquals(self.channel.get_address_display(e164=True), context['channel']['tel_e164'])
-        self.assertEquals(self.channel.get_address_display(), context['channel']['tel'])
-        self.assertEquals(self.channel.get_name(), context['channel']['name'])
-        self.assertEquals(self.channel.get_address_display(), context['channel']['__default__'])
+        self.assertEqual(self.channel.get_address_display(e164=True), context['channel']['tel_e164'])
+        self.assertEqual(self.channel.get_address_display(), context['channel']['tel'])
+        self.assertEqual(self.channel.get_name(), context['channel']['name'])
+        self.assertEqual(self.channel.get_address_display(), context['channel']['__default__'])
 
         # change our step instead be decimal
         step.rule_value = '10'
@@ -603,11 +603,11 @@ class FlowTest(TembaTest):
 
         # check our message context again
         context = self.flow.build_expressions_context(self.contact, incoming)
-        self.assertEquals('10', context['flow']['color']['value'])
-        self.assertEquals('Orange', context['flow']['color']['category'])
+        self.assertEqual('10', context['flow']['color']['value'])
+        self.assertEqual('Orange', context['flow']['color']['category'])
 
         # this is drawn from the message which didn't change
-        self.assertEquals('orange', context['flow']['color']['text'])
+        self.assertEqual('orange', context['flow']['color']['text'])
 
         # revert above change
         step.rule_value = 'orange'
@@ -617,10 +617,10 @@ class FlowTest(TembaTest):
         # finally we should have our final step which was our outgoing reply
         step = FlowStep.objects.filter(run__contact=self.contact).order_by('pk')[2]
 
-        self.assertEquals(FlowStep.TYPE_ACTION_SET, step.step_type)
-        self.assertEquals(self.contact, step.run.contact)
-        self.assertEquals(self.contact, step.contact)
-        self.assertEquals(self.flow, step.run.flow)
+        self.assertEqual(FlowStep.TYPE_ACTION_SET, step.step_type)
+        self.assertEqual(self.contact, step.run.contact)
+        self.assertEqual(self.contact, step.contact)
+        self.assertEqual(self.flow, step.run.flow)
         self.assertTrue(step.arrived_on)
 
         # we have left the flow
@@ -640,23 +640,23 @@ class FlowTest(TembaTest):
         results = self.flow.get_results()
 
         # should have two results
-        self.assertEquals(2, len(results))
+        self.assertEqual(2, len(results))
 
         # check the value
         found = False
         for result in results:
             if result['contact'] == self.contact:
                 found = True
-                self.assertEquals(1, len(result['values']))
+                self.assertEqual(1, len(result['values']))
 
         self.assertTrue(found)
 
         color = result['values'][0]
-        self.assertEquals('color', color['label'])
-        self.assertEquals('Orange', color['category']['base'])
-        self.assertEquals('orange', color['value'])
-        self.assertEquals("bd531ace-911e-4722-8e53-6730d6122fe1", color['node'])
-        self.assertEquals(incoming.text, color['text'])
+        self.assertEqual('color', color['label'])
+        self.assertEqual('Orange', color['category']['base'])
+        self.assertEqual('orange', color['value'])
+        self.assertEqual("bd531ace-911e-4722-8e53-6730d6122fe1", color['node'])
+        self.assertEqual(incoming.text, color['text'])
 
     def test_anon_export_results(self):
         self.org.is_anon = True
@@ -870,7 +870,7 @@ class FlowTest(TembaTest):
 
         # check can't export anonymously
         exported = self.client.get(reverse('flows.flow_export_results') + "?ids=%d" % self.flow.pk)
-        self.assertEquals(302, exported.status_code)
+        self.assertEqual(302, exported.status_code)
 
         self.login(self.admin)
 
@@ -1175,36 +1175,36 @@ class FlowTest(TembaTest):
 
         # make sure our metadata got saved
         metadata = json.loads(self.flow.metadata)
-        self.assertEquals("Ryan Lewis", metadata['author'])
+        self.assertEqual("Ryan Lewis", metadata['author'])
 
         # now create a copy
         copy = Flow.copy(self.flow, self.admin)
 
         metadata = json.loads(copy.metadata)
-        self.assertEquals("Ryan Lewis", metadata['author'])
+        self.assertEqual("Ryan Lewis", metadata['author'])
 
         # expiration should be copied too
-        self.assertEquals(60, copy.expires_after_minutes)
+        self.assertEqual(60, copy.expires_after_minutes)
 
         # should have a different id
         self.assertNotEqual(self.flow.pk, copy.pk)
 
         # Name should start with "Copy of"
-        self.assertEquals("Copy of Color Flow is a long name to use for something like thi", copy.name)
+        self.assertEqual("Copy of Color Flow is a long name to use for something like thi", copy.name)
 
         # metadata should come out in the json
         copy_json = copy.as_json()
-        self.assertEquals(dict(author="Ryan Lewis",
-                               name='Copy of Color Flow is a long name to use for something like thi',
-                               revision=1,
-                               expires=60,
-                               uuid=copy.uuid,
-                               saved_on=datetime_to_str(copy.saved_on)),
-                          copy_json['metadata'])
+        self.assertEqual(dict(author="Ryan Lewis",
+                              name='Copy of Color Flow is a long name to use for something like thi',
+                              revision=1,
+                              expires=60,
+                              uuid=copy.uuid,
+                              saved_on=datetime_to_str(copy.saved_on)),
+                         copy_json['metadata'])
 
         # should have the same number of actionsets and rulesets
-        self.assertEquals(copy.action_sets.all().count(), self.flow.action_sets.all().count())
-        self.assertEquals(copy.rule_sets.all().count(), self.flow.rule_sets.all().count())
+        self.assertEqual(copy.action_sets.all().count(), self.flow.action_sets.all().count())
+        self.assertEqual(copy.rule_sets.all().count(), self.flow.rule_sets.all().count())
 
     @override_settings(SEND_WEBHOOKS=True)
     def test_optimization_reply_action(self):
@@ -1230,12 +1230,12 @@ class FlowTest(TembaTest):
             self.assertTrue(Msg.objects.all())
             msg = Msg.objects.all()[0]
             self.assertFalse("@extra.coupon" in msg.text)
-            self.assertEquals(msg.text, "text to get NEXUS4")
-            self.assertEquals(PENDING, msg.status)
+            self.assertEqual(msg.text, "text to get NEXUS4")
+            self.assertEqual(PENDING, msg.status)
 
     def test_parsing(self):
         # our flow should have the appropriate RuleSet and ActionSet objects
-        self.assertEquals(4, ActionSet.objects.all().count())
+        self.assertEqual(4, ActionSet.objects.all().count())
 
         entry = ActionSet.objects.get(uuid="d51ec25f-04e6-4349-a448-e7c4d93d4597")
         actions = entry.get_actions()
@@ -1246,31 +1246,31 @@ class FlowTest(TembaTest):
 
         orange = ActionSet.objects.get(uuid="7d40faea-723b-473d-8999-59fb7d3c3ca2")
         actions = orange.get_actions()
-        self.assertEquals(1, len(actions))
-        self.assertEquals(ReplyAction(dict(base='I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow')).as_json(), actions[0].as_json())
+        self.assertEqual(1, len(actions))
+        self.assertEqual(ReplyAction(dict(base='I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow')).as_json(), actions[0].as_json())
 
-        self.assertEquals(1, RuleSet.objects.all().count())
+        self.assertEqual(1, RuleSet.objects.all().count())
         ruleset = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
-        self.assertEquals(entry.destination, ruleset.uuid)
+        self.assertEqual(entry.destination, ruleset.uuid)
         rules = ruleset.get_rules()
-        self.assertEquals(4, len(rules))
+        self.assertEqual(4, len(rules))
 
         # check ordering
-        self.assertEquals("7d40faea-723b-473d-8999-59fb7d3c3ca2", rules[0].destination)
-        self.assertEquals("1c75fd71-027b-40e8-a819-151a0f8140e6", rules[0].uuid)
-        self.assertEquals("c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", rules[1].destination)
-        self.assertEquals("40cc7c36-b7c8-4f05-ae82-25275607e5aa", rules[1].uuid)
-        self.assertEquals("1cb6d8da-3749-45b2-9382-3f756e3ca71f", rules[2].destination)
-        self.assertEquals("93998b50-6580-4574-8f60-74654df7d243", rules[2].uuid)
+        self.assertEqual("7d40faea-723b-473d-8999-59fb7d3c3ca2", rules[0].destination)
+        self.assertEqual("1c75fd71-027b-40e8-a819-151a0f8140e6", rules[0].uuid)
+        self.assertEqual("c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", rules[1].destination)
+        self.assertEqual("40cc7c36-b7c8-4f05-ae82-25275607e5aa", rules[1].uuid)
+        self.assertEqual("1cb6d8da-3749-45b2-9382-3f756e3ca71f", rules[2].destination)
+        self.assertEqual("93998b50-6580-4574-8f60-74654df7d243", rules[2].uuid)
 
         # check routing
-        self.assertEquals(ContainsTest(test=dict(base="orange")).as_json(), rules[0].test.as_json())
-        self.assertEquals(ContainsTest(test=dict(base="blue")).as_json(), rules[1].test.as_json())
-        self.assertEquals(TrueTest().as_json(), rules[2].test.as_json())
+        self.assertEqual(ContainsTest(test=dict(base="orange")).as_json(), rules[0].test.as_json())
+        self.assertEqual(ContainsTest(test=dict(base="blue")).as_json(), rules[1].test.as_json())
+        self.assertEqual(TrueTest().as_json(), rules[2].test.as_json())
 
         # and categories
-        self.assertEquals("Orange", rules[0].category['base'])
-        self.assertEquals("Blue", rules[1].category['base'])
+        self.assertEqual("Orange", rules[0].category['base'])
+        self.assertEqual("Blue", rules[1].category['base'])
 
         # back out as json
         json_dict = self.flow.as_json()
@@ -1293,7 +1293,7 @@ class FlowTest(TembaTest):
         # update
         self.flow.update(json_dict)
 
-        self.assertEquals(3, ActionSet.objects.all().count())
+        self.assertEqual(3, ActionSet.objects.all().count())
 
         entry = ActionSet.objects.get(uuid="d51ec25f-04e6-4349-a448-e7c4d93d4597")
         actions = entry.get_actions()
@@ -1304,22 +1304,22 @@ class FlowTest(TembaTest):
 
         orange = ActionSet.objects.get(uuid="7d40faea-723b-473d-8999-59fb7d3c3ca2")
         actions = orange.get_actions()
-        self.assertEquals(1, len(actions))
-        self.assertEquals(ReplyAction(dict(base='I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow')).as_json(), actions[0].as_json())
+        self.assertEqual(1, len(actions))
+        self.assertEqual(ReplyAction(dict(base='I love orange too! You said: @step.value which is category: @flow.color.category You are: @step.contact.tel SMS: @step Flow: @flow')).as_json(), actions[0].as_json())
 
-        self.assertEquals(1, RuleSet.objects.all().count())
+        self.assertEqual(1, RuleSet.objects.all().count())
         ruleset = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
-        self.assertEquals(entry.destination, ruleset.uuid)
+        self.assertEqual(entry.destination, ruleset.uuid)
         rules = ruleset.get_rules()
-        self.assertEquals(3, len(rules))
+        self.assertEqual(3, len(rules))
 
         # check ordering
-        self.assertEquals("7d40faea-723b-473d-8999-59fb7d3c3ca2", rules[0].destination)
-        self.assertEquals("c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", rules[1].destination)
+        self.assertEqual("7d40faea-723b-473d-8999-59fb7d3c3ca2", rules[0].destination)
+        self.assertEqual("c12f37e2-8e6c-4c81-ba6d-941bb3caf93f", rules[1].destination)
 
         # check routing
-        self.assertEquals(ContainsTest(test=dict(base="orange")).as_json(), rules[0].test.as_json())
-        self.assertEquals(ContainsTest(test=dict(base="blue")).as_json(), rules[1].test.as_json())
+        self.assertEqual(ContainsTest(test=dict(base="orange")).as_json(), rules[0].test.as_json())
+        self.assertEqual(ContainsTest(test=dict(base="blue")).as_json(), rules[1].test.as_json())
 
         # updating with a label name that is too long should truncate it
         json_dict['rule_sets'][0]['label'] = 'W' * 75
@@ -1328,8 +1328,8 @@ class FlowTest(TembaTest):
 
         # now check they are truncated to the max lengths
         ruleset = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
-        self.assertEquals(64, len(ruleset.label))
-        self.assertEquals(128, len(ruleset.operand))
+        self.assertEqual(64, len(ruleset.label))
+        self.assertEqual(128, len(ruleset.operand))
 
     def test_expanding(self):
         # add actions for adding to a group and messaging a contact, we'll test how these expand
@@ -1357,8 +1357,8 @@ class FlowTest(TembaTest):
         send = flow_json['action_sets'][3]['actions'][1]
 
         # should still see a reference to our group even (recreated)
-        self.assertEquals(1, len(add_group['groups']))
-        self.assertEquals(1, len(send['groups']))
+        self.assertEqual(1, len(add_group['groups']))
+        self.assertEqual(1, len(send['groups']))
 
     def assertTest(self, expected_test, expected_value, test, extra=None):
         runs = FlowRun.objects.filter(contact=self.contact)
@@ -1379,7 +1379,7 @@ class FlowTest(TembaTest):
             self.assertTrue(result[0])
         else:
             self.assertFalse(result[0])
-        self.assertEquals(expected_value, result[1])
+        self.assertEqual(expected_value, result[1])
 
         # return our run for later inspection
         return run
@@ -1664,7 +1664,7 @@ class FlowTest(TembaTest):
         self.assertTest(True, Decimal("4000"), test)
 
         rule = Rule('8bfc987a-796f-4de7-bce6-a10ed06f617b', None, None, None, test)
-        self.assertEquals("1000-5000", rule.get_category_name(None))
+        self.assertEqual("1000-5000", rule.get_category_name(None))
 
         test = StartsWithTest(test=dict(base="Green"))
         sms.text = "  green beans"
@@ -1732,24 +1732,24 @@ class FlowTest(TembaTest):
         sms.text = "Isaac Newton"
         run = self.assertTest(True, "Isaac Newton", test)
         extra = run.field_dict()
-        self.assertEquals("Isaac Newton", extra['0'])
-        self.assertEquals("Isaac", extra['1'])
-        self.assertEquals("Newton", extra['2'])
+        self.assertEqual("Isaac Newton", extra['0'])
+        self.assertEqual("Isaac", extra['1'])
+        self.assertEqual("Newton", extra['2'])
 
         # find that arabic unicode is handled right
         sms.text = "مرحبا العالم"
         run = self.assertTest(True, "مرحبا العالم", test)
         extra = run.field_dict()
-        self.assertEquals("مرحبا العالم", extra['0'])
-        self.assertEquals("مرحبا", extra['1'])
-        self.assertEquals("العالم", extra['2'])
+        self.assertEqual("مرحبا العالم", extra['0'])
+        self.assertEqual("مرحبا", extra['1'])
+        self.assertEqual("العالم", extra['2'])
 
         # no matching groups, should return whole string as match
         test = RegexTest(dict(base="\w+ \w+"))
         sms.text = "Isaac Newton"
         run = self.assertTest(True, "Isaac Newton", test)
         extra = run.field_dict()
-        self.assertEquals("Isaac Newton", extra['0'])
+        self.assertEqual("Isaac Newton", extra['0'])
 
         # no match, shouldn't return anything at all
         sms.text = "#$%^$#? !@#$"
@@ -1762,7 +1762,7 @@ class FlowTest(TembaTest):
         sms.text = "This is my Kazoo"
         run = self.assertTest(True, "Kazoo", test)
         extra = run.field_dict()
-        self.assertEquals("Kazoo", extra['0'])
+        self.assertEqual("Kazoo", extra['0'])
 
         # change to have anchors
         test = RegexTest(dict(base="^kazoo$"))
@@ -1775,7 +1775,7 @@ class FlowTest(TembaTest):
         sms.text = "Kazoo"
         run = self.assertTest(True, "Kazoo", test)
         extra = run.field_dict()
-        self.assertEquals("Kazoo", extra['0'])
+        self.assertEqual("Kazoo", extra['0'])
 
         # not empty
         sms.text = ""
@@ -1850,54 +1850,54 @@ class FlowTest(TembaTest):
 
         rules = Rule.from_json_array(org, js)
 
-        self.assertEquals("Normal Length", rules[0].category)
-        self.assertEquals(36, len(rules[1].category))
+        self.assertEqual("Normal Length", rules[0].category)
+        self.assertEqual(36, len(rules[1].category))
 
     def test_factories(self):
         org = self.org
 
         js = dict(type='true')
-        self.assertEquals(TrueTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, TrueTest().as_json())
+        self.assertEqual(TrueTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, TrueTest().as_json())
 
         js = dict(type='false')
-        self.assertEquals(FalseTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, FalseTest().as_json())
+        self.assertEqual(FalseTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, FalseTest().as_json())
 
         js = dict(type='and', tests=[dict(type='true')])
-        self.assertEquals(AndTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, AndTest([TrueTest()]).as_json())
+        self.assertEqual(AndTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, AndTest([TrueTest()]).as_json())
 
         js = dict(type='or', tests=[dict(type='true')])
-        self.assertEquals(OrTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, OrTest([TrueTest()]).as_json())
+        self.assertEqual(OrTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, OrTest([TrueTest()]).as_json())
 
         js = dict(type='contains', test="green")
-        self.assertEquals(ContainsTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, ContainsTest("green").as_json())
+        self.assertEqual(ContainsTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, ContainsTest("green").as_json())
 
         js = dict(type='lt', test="5")
-        self.assertEquals(LtTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, LtTest("5").as_json())
+        self.assertEqual(LtTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, LtTest("5").as_json())
 
         js = dict(type='gt', test="5")
-        self.assertEquals(GtTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, GtTest("5").as_json())
+        self.assertEqual(GtTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, GtTest("5").as_json())
 
         js = dict(type='gte', test="5")
-        self.assertEquals(GteTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, GteTest("5").as_json())
+        self.assertEqual(GteTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, GteTest("5").as_json())
 
         js = dict(type='eq', test="5")
-        self.assertEquals(EqTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, EqTest("5").as_json())
+        self.assertEqual(EqTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, EqTest("5").as_json())
 
         js = dict(type='between', min="5", max="10")
-        self.assertEquals(BetweenTest, Test.from_json(org, js).__class__)
-        self.assertEquals(js, BetweenTest("5", "10").as_json())
+        self.assertEqual(BetweenTest, Test.from_json(org, js).__class__)
+        self.assertEqual(js, BetweenTest("5", "10").as_json())
 
-        self.assertEquals(ReplyAction, Action.from_json(org, dict(type='reply', msg=dict(base="hello world"))).__class__)
-        self.assertEquals(SendAction, Action.from_json(org, dict(type='send', msg=dict(base="hello world"), contacts=[], groups=[], variables=[])).__class__)
+        self.assertEqual(ReplyAction, Action.from_json(org, dict(type='reply', msg=dict(base="hello world"))).__class__)
+        self.assertEqual(SendAction, Action.from_json(org, dict(type='send', msg=dict(base="hello world"), contacts=[], groups=[], variables=[])).__class__)
 
     def test_decimal_values(self):
         rules = RuleSet.objects.get(uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
@@ -1928,10 +1928,10 @@ class FlowTest(TembaTest):
         self.assertTrue(Flow.find_and_handle(sms)[0])
 
         step = FlowStep.objects.get(step_uuid="bd531ace-911e-4722-8e53-6730d6122fe1")
-        self.assertEquals("> 10", step.rule_category)
-        self.assertEquals("40cc7c36-b7c8-4f05-ae82-25275607e5aa", step.rule_uuid)
-        self.assertEquals("15", step.rule_value)
-        self.assertEquals(Decimal("15"), step.rule_decimal_value)
+        self.assertEqual("> 10", step.rule_category)
+        self.assertEqual("40cc7c36-b7c8-4f05-ae82-25275607e5aa", step.rule_uuid)
+        self.assertEqual("15", step.rule_value)
+        self.assertEqual(Decimal("15"), step.rule_decimal_value)
 
     def test_location_entry_test(self):
 
@@ -1957,45 +1957,45 @@ class FlowTest(TembaTest):
 
         # wrong admin level should return None if provided
         lga_tuple = HasDistrictTest('Kano').evaluate(run, sms, context, 'apapa')
-        self.assertEquals(lga_tuple[1], None)
+        self.assertEqual(lga_tuple[1], None)
 
         lga_tuple = HasDistrictTest('Lagos').evaluate(run, sms, context, 'apapa')
-        self.assertEquals(lga_tuple[1], apapa)
+        self.assertEqual(lga_tuple[1], apapa)
 
         # get lga with out higher admin level
         lga_tuple = HasDistrictTest().evaluate(run, sms, context, 'apapa')
-        self.assertEquals(lga_tuple[1], apapa)
+        self.assertEqual(lga_tuple[1], apapa)
 
         # get ward with out higher admin levels
         ward_tuple = HasWardTest().evaluate(run, sms, context, 'bichi')
-        self.assertEquals(ward_tuple[1], bichiward)
+        self.assertEqual(ward_tuple[1], bichiward)
 
         # get with hierarchy proved
         ward_tuple = HasWardTest('Kano', 'Bichi').evaluate(run, sms, context, 'bichi')
-        self.assertEquals(ward_tuple[1], bichiward)
+        self.assertEqual(ward_tuple[1], bichiward)
 
         # wrong admin level should return None if provided
         ward_tuple = HasWardTest('Kano', 'Ajingi').evaluate(run, sms, context, 'bichi')
         js = dict(state='Kano', district='Ajingi', type='ward')
-        self.assertEquals(HasWardTest('Kano', 'Ajingi').as_json(), js)
-        self.assertEquals(ward_tuple[1], None)
+        self.assertEqual(HasWardTest('Kano', 'Ajingi').as_json(), js)
+        self.assertEqual(ward_tuple[1], None)
 
         # get with hierarchy by aliases
         BoundaryAlias.objects.create(name='Pillars', boundary=kano, org=self.org,
                                      created_by=self.admin, modified_by=self.admin)
         ward_tuple = HasWardTest('Pillars', 'Bichi').evaluate(run, sms, context, 'bichi')
-        self.assertEquals(ward_tuple[1], bichiward)
+        self.assertEqual(ward_tuple[1], bichiward)
 
         # misconfigured flows should ignore the state and district if wards are unique by name
         ward_tuple = HasWardTest('Bichi', 'Kano').evaluate(run, sms, context, 'bichi')
-        self.assertEquals(ward_tuple[1], bichiward)
+        self.assertEqual(ward_tuple[1], bichiward)
 
         # misconfigured flows should not match if wards not unique
         AdminBoundary.objects.create(osm_id='3710379', name='Bichi', level=3, parent=apapa)
         ward_tuple = HasWardTest('Bichi', 'Kano').evaluate(run, sms, context, 'bichi')
-        self.assertEquals(ward_tuple[1], None)
+        self.assertEqual(ward_tuple[1], None)
 
-        self.assertEquals(HasWardTest, Test.from_json(self.org, js).__class__)
+        self.assertEqual(HasWardTest, Test.from_json(self.org, js).__class__)
 
     def test_flow_keyword_create(self):
         self.login(self.admin)
@@ -2075,9 +2075,9 @@ class FlowTest(TembaTest):
         self.assertEqual(response.status_code, 302)
 
         flow_with_keywords = Flow.objects.get(name="Flow With Keyword Triggers")
-        self.assertEquals(flow_with_keywords.triggers.count(), 3)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=False).count(), 3)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=False).exclude(groups=None).count(), 0)
+        self.assertEqual(flow_with_keywords.triggers.count(), 3)
+        self.assertEqual(flow_with_keywords.triggers.filter(is_archived=False).count(), 3)
+        self.assertEqual(flow_with_keywords.triggers.filter(is_archived=False).exclude(groups=None).count(), 0)
 
         # add triggers of other types
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
@@ -2095,7 +2095,7 @@ class FlowTest(TembaTest):
         Trigger.objects.create(created_by=self.admin, modified_by=self.admin, org=self.org,
                                trigger_type=Trigger.TYPE_SCHEDULE, flow=flow_with_keywords)
 
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=False).count(), 8)
+        self.assertEqual(flow_with_keywords.triggers.filter(is_archived=False).count(), 8)
 
         # update flow triggers
         post_data = dict()
@@ -2105,16 +2105,16 @@ class FlowTest(TembaTest):
         response = self.client.post(reverse('flows.flow_update', args=[flow.pk]), post_data, follow=True)
 
         flow_with_keywords = Flow.objects.get(name=post_data['name'])
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], reverse('flows.flow_list'))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], reverse('flows.flow_list'))
         self.assertTrue(flow_with_keywords in response.context['object_list'].all())
-        self.assertEquals(flow_with_keywords.triggers.count(), 9)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True).count(), 2)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True,
-                                                             trigger_type=Trigger.TYPE_KEYWORD).count(), 2)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=False).count(), 7)
-        self.assertEquals(flow_with_keywords.triggers.filter(is_archived=True,
-                                                             trigger_type=Trigger.TYPE_KEYWORD).count(), 2)
+        self.assertEqual(flow_with_keywords.triggers.count(), 9)
+        self.assertEqual(flow_with_keywords.triggers.filter(is_archived=True).count(), 2)
+        self.assertEqual(flow_with_keywords.triggers.filter(is_archived=True,
+                                                            trigger_type=Trigger.TYPE_KEYWORD).count(), 2)
+        self.assertEqual(flow_with_keywords.triggers.filter(is_archived=False).count(), 7)
+        self.assertEqual(flow_with_keywords.triggers.filter(is_archived=True,
+                                                            trigger_type=Trigger.TYPE_KEYWORD).count(), 2)
 
         # only keyword triggers got archived, other are stil active
         self.assertTrue(flow_with_keywords.triggers.filter(is_archived=False, trigger_type=Trigger.TYPE_FOLLOW))
@@ -2141,15 +2141,15 @@ class FlowTest(TembaTest):
 
         # list, should have only one flow (the one created in setUp)
         response = self.client.get(reverse('flows.flow_list'))
-        self.assertEquals(1, len(response.context['object_list']))
+        self.assertEqual(1, len(response.context['object_list']))
 
         # inactive list shouldn't have any flows
         response = self.client.get(reverse('flows.flow_archived'))
-        self.assertEquals(0, len(response.context['object_list']))
+        self.assertEqual(0, len(response.context['object_list']))
 
         # also shouldn't be able to view other flow
         response = self.client.get(reverse('flows.flow_editor', args=[other_flow.uuid]))
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # get our create page
         response = self.client.get(reverse('flows.flow_create'))
@@ -2269,13 +2269,13 @@ class FlowTest(TembaTest):
         post_data['expires_after_minutes'] = 60 * 12
         response = self.client.post(reverse('flows.flow_update', args=[flow3.pk]), post_data, follow=True)
         flow3 = Flow.objects.get(name=post_data['name'])
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], reverse('flows.flow_list'))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], reverse('flows.flow_list'))
         self.assertTrue(flow3 in response.context['object_list'].all())
-        self.assertEquals(flow3.triggers.count(), 5)
-        self.assertEquals(flow3.triggers.filter(is_archived=True).count(), 2)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).count(), 3)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 0)
+        self.assertEqual(flow3.triggers.count(), 5)
+        self.assertEqual(flow3.triggers.filter(is_archived=True).count(), 2)
+        self.assertEqual(flow3.triggers.filter(is_archived=False).count(), 3)
+        self.assertEqual(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 0)
 
         # update flow with unformatted keyword
         post_data['keyword_triggers'] = "it,changes,every thing"
@@ -2287,21 +2287,21 @@ class FlowTest(TembaTest):
         response = self.client.post(reverse('flows.flow_update', args=[flow3.pk]), post_data)
         self.assertTrue(response.context['form'].errors)
         response = self.client.get(reverse('flows.flow_update', args=[flow3.pk]))
-        self.assertEquals(response.context['form'].fields['keyword_triggers'].initial, "it,everything,changes")
-        self.assertEquals(flow3.triggers.filter(is_archived=False).count(), 3)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 0)
+        self.assertEqual(response.context['form'].fields['keyword_triggers'].initial, "it,everything,changes")
+        self.assertEqual(flow3.triggers.filter(is_archived=False).count(), 3)
+        self.assertEqual(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 0)
         trigger = Trigger.objects.get(keyword="everything", flow=flow3)
         group = self.create_group("first", [self.contact])
         trigger.groups.add(group)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).count(), 3)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 1)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).exclude(groups=None)[0].keyword, "everything")
+        self.assertEqual(flow3.triggers.filter(is_archived=False).count(), 3)
+        self.assertEqual(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 1)
+        self.assertEqual(flow3.triggers.filter(is_archived=False).exclude(groups=None)[0].keyword, "everything")
         response = self.client.get(reverse('flows.flow_update', args=[flow3.pk]))
-        self.assertEquals(response.context['form'].fields['keyword_triggers'].initial, "it,changes")
+        self.assertEqual(response.context['form'].fields['keyword_triggers'].initial, "it,changes")
         self.assertNotContains(response, "contact_creation")
-        self.assertEquals(flow3.triggers.filter(is_archived=False).count(), 3)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 1)
-        self.assertEquals(flow3.triggers.filter(is_archived=False).exclude(groups=None)[0].keyword, "everything")
+        self.assertEqual(flow3.triggers.filter(is_archived=False).count(), 3)
+        self.assertEqual(flow3.triggers.filter(is_archived=False).exclude(groups=None).count(), 1)
+        self.assertEqual(flow3.triggers.filter(is_archived=False).exclude(groups=None)[0].keyword, "everything")
 
         # make us a survey flow
         flow3.flow_type = Flow.SURVEY
@@ -2320,7 +2320,7 @@ class FlowTest(TembaTest):
 
         # can see results for a flow
         response = self.client.get(reverse('flows.flow_results', args=[self.flow.id]))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # check flow listing
         response = self.client.get(reverse('flows.flow_list'))
@@ -2356,7 +2356,7 @@ class FlowTest(TembaTest):
         json_dict['action_sets'][0]['destination'] = 'notthere'
 
         response = self.client.post(reverse('flows.flow_json', args=[self.flow.id]), json.dumps(json_dict), content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.flow.refresh_from_db()
         flow_json = self.flow.as_json()
@@ -2367,12 +2367,12 @@ class FlowTest(TembaTest):
 
         # should still have the original one, nothing changed
         response = self.client.get(reverse('flows.flow_json', args=[self.flow.id]))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         json_dict = response.json()
 
         # can't save against the other org's flow
         response = self.client.post(reverse('flows.flow_json', args=[other_flow.id]), json.dumps(json_dict), content_type="application/json")
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # can't save with invalid json
         with self.assertRaises(ValueError):
@@ -2388,7 +2388,7 @@ class FlowTest(TembaTest):
                                                    string_value="hey")
 
         response = self.client.get(simulate_url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         post_data = {'has_refresh': True}
 
@@ -2398,11 +2398,11 @@ class FlowTest(TembaTest):
         self.assertFalse(group in test_contact.all_groups.all())
         self.assertFalse(test_contact.values.all())
 
-        self.assertEquals(len(json_dict.keys()), 5)
-        self.assertEquals(len(json_dict['messages']), 3)
-        self.assertEquals('Test Contact has entered the &quot;Color Flow&quot; flow', json_dict['messages'][0]['text'])
-        self.assertEquals("This flow is more like a broadcast", json_dict['messages'][1]['text'])
-        self.assertEquals("Test Contact has exited this flow", json_dict['messages'][2]['text'])
+        self.assertEqual(len(json_dict.keys()), 5)
+        self.assertEqual(len(json_dict['messages']), 3)
+        self.assertEqual('Test Contact has entered the &quot;Color Flow&quot; flow', json_dict['messages'][0]['text'])
+        self.assertEqual("This flow is more like a broadcast", json_dict['messages'][1]['text'])
+        self.assertEqual("Test Contact has exited this flow", json_dict['messages'][2]['text'])
 
         group = self.create_group("fans", [test_contact])
         contact_field_value = Value.objects.create(contact=test_contact, contact_field=contact_field, org=self.org,
@@ -2412,7 +2412,7 @@ class FlowTest(TembaTest):
         post_data['has_refresh'] = False
 
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         json_dict = response.json()
 
         self.assertTrue(group in test_contact.all_groups.all())
@@ -2431,7 +2431,7 @@ class FlowTest(TembaTest):
         post_data['has_refresh'] = True
 
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         json_dict = response.json()
 
         self.assertEqual(len(json_dict.keys()), 5)
@@ -2473,7 +2473,7 @@ class FlowTest(TembaTest):
         # nothing should happen, contacts are already active in the flow
         count = Broadcast.objects.all().count()
         self.client.post(reverse('flows.flow_broadcast', args=[self.flow.id]), post_data, follow=True)
-        self.assertEquals(count, Broadcast.objects.all().count())
+        self.assertEqual(count, Broadcast.objects.all().count())
 
         FlowStart.objects.all().delete()
 
@@ -2481,14 +2481,14 @@ class FlowTest(TembaTest):
         post_data['include_active'] = 'on'
         count = Msg.objects.all().count()
         self.client.post(reverse('flows.flow_broadcast', args=[self.flow.id]), post_data, follow=True)
-        self.assertEquals(count + 1, Msg.objects.all().count())
+        self.assertEqual(count + 1, Msg.objects.all().count())
 
         # we should have a flow start
         start = FlowStart.objects.get(flow=self.flow)
 
         # should be in a completed state
-        self.assertEquals(FlowStart.STATUS_COMPLETE, start.status)
-        self.assertEquals(1, start.contact_count)
+        self.assertEqual(FlowStart.STATUS_COMPLETE, start.status)
+        self.assertEqual(1, start.contact_count)
 
         # do so again but don't restart the participants
         del post_data['restart_participants']
@@ -2497,9 +2497,9 @@ class FlowTest(TembaTest):
 
         # should have a new flow start
         new_start = FlowStart.objects.filter(flow=self.flow).order_by('-created_on').first()
-        self.assertNotEquals(start, new_start)
-        self.assertEquals(FlowStart.STATUS_COMPLETE, new_start.status)
-        self.assertEquals(0, new_start.contact_count)
+        self.assertNotEqual(start, new_start)
+        self.assertEqual(FlowStart.STATUS_COMPLETE, new_start.status)
+        self.assertEqual(0, new_start.contact_count)
 
         # mark that start as incomplete
         new_start.status = FlowStart.STATUS_STARTING
@@ -2522,17 +2522,17 @@ class FlowTest(TembaTest):
         response = self.client.post(reverse('flows.flow_create'), post_data, follow=True)
         msg_flow = Flow.objects.get(name=post_data['name'])
 
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], reverse('flows.flow_editor', args=[msg_flow.uuid]))
-        self.assertEquals(msg_flow.flow_type, 'F')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], reverse('flows.flow_editor', args=[msg_flow.uuid]))
+        self.assertEqual(msg_flow.flow_type, 'F')
 
         post_data = dict(name="Call flow", expires_after_minutes=5, flow_type='V')
         response = self.client.post(reverse('flows.flow_create'), post_data, follow=True)
         call_flow = Flow.objects.get(name=post_data['name'])
 
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], reverse('flows.flow_editor', args=[call_flow.uuid]))
-        self.assertEquals(call_flow.flow_type, 'V')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], reverse('flows.flow_editor', args=[call_flow.uuid]))
+        self.assertEqual(call_flow.flow_type, 'V')
 
         # test creating a  flow with base language
         # create the language for our org
@@ -2544,9 +2544,9 @@ class FlowTest(TembaTest):
         response = self.client.post(reverse('flows.flow_create'), post_data, follow=True)
         language_flow = Flow.objects.get(name=post_data['name'])
 
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(response.request['PATH_INFO'], reverse('flows.flow_editor', args=[language_flow.uuid]))
-        self.assertEquals(language_flow.base_language, language.iso_code)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.request['PATH_INFO'], reverse('flows.flow_editor', args=[language_flow.uuid]))
+        self.assertEqual(language_flow.base_language, language.iso_code)
 
     def test_views_viewers(self):
         # create a viewer
@@ -2578,7 +2578,7 @@ class FlowTest(TembaTest):
         # list, should have only one flow (the one created in setUp)
 
         response = self.client.get(flow_list_url)
-        self.assertEquals(1, len(response.context['object_list']))
+        self.assertEqual(1, len(response.context['object_list']))
         # no create links
         self.assertFalse(flow_create_url in response.content)
         self.assertFalse(flowlabel_create_url in response.content)
@@ -2597,7 +2597,7 @@ class FlowTest(TembaTest):
         post_data['add'] = True
 
         response = self.client.post(flow_list_url, post_data, follow=True)
-        self.assertEquals(1, response.context['object_list'].count())
+        self.assertEqual(1, response.context['object_list'].count())
         self.assertFalse(response.context['object_list'][0].labels.all())
 
         # can not archive
@@ -2605,55 +2605,55 @@ class FlowTest(TembaTest):
         post_data['action'] = 'archive'
         post_data['objects'] = self.flow.pk
         response = self.client.post(flow_list_url, post_data, follow=True)
-        self.assertEquals(1, response.context['object_list'].count())
-        self.assertEquals(response.context['object_list'][0].pk, self.flow.pk)
+        self.assertEqual(1, response.context['object_list'].count())
+        self.assertEqual(response.context['object_list'][0].pk, self.flow.pk)
         self.assertFalse(response.context['object_list'][0].is_archived)
 
         # inactive list shouldn't have any flows
         response = self.client.get(flow_archived_url)
-        self.assertEquals(0, len(response.context['object_list']))
+        self.assertEqual(0, len(response.context['object_list']))
 
         response = self.client.get(reverse('flows.flow_editor', args=[self.flow.uuid]))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertFalse(response.context['mutable'])
 
         # we can fetch the json for the flow
         response = self.client.get(reverse('flows.flow_json', args=[self.flow.pk]))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # but posting to it should redirect to a get
         response = self.client.post(reverse('flows.flow_json', args=[self.flow.pk]), post_data=response.content)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         self.flow.is_archived = True
         self.flow.save()
 
         response = self.client.get(flow_list_url)
-        self.assertEquals(0, len(response.context['object_list']))
+        self.assertEqual(0, len(response.context['object_list']))
 
         # can not restore
         post_data = dict()
         post_data['action'] = 'archive'
         post_data['objects'] = self.flow.pk
         response = self.client.post(flow_archived_url, post_data, follow=True)
-        self.assertEquals(1, response.context['object_list'].count())
-        self.assertEquals(response.context['object_list'][0].pk, self.flow.pk)
+        self.assertEqual(1, response.context['object_list'].count())
+        self.assertEqual(response.context['object_list'][0].pk, self.flow.pk)
         self.assertTrue(response.context['object_list'][0].is_archived)
 
         response = self.client.get(flow_archived_url)
-        self.assertEquals(1, len(response.context['object_list']))
+        self.assertEqual(1, len(response.context['object_list']))
 
         # cannot create a flow
         response = self.client.get(flow_create_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # cannot create a flowlabel
         response = self.client.get(flowlabel_create_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # also shouldn't be able to view other flow
         response = self.client.get(reverse('flows.flow_editor', args=[flow2.uuid]))
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
     def test_flow_update_error(self):
 
@@ -2665,8 +2665,8 @@ class FlowTest(TembaTest):
                                     json.dumps(json_dict),
                                     content_type="application/json")
 
-        self.assertEquals(400, response.status_code)
-        self.assertEquals('Invalid label name: @badlabel', response.json()['description'])
+        self.assertEqual(400, response.status_code)
+        self.assertEqual('Invalid label name: @badlabel', response.json()['description'])
 
     def test_flow_start_with_start_msg(self):
         sms = self.create_msg(direction=INCOMING, contact=self.contact, text="I am coming")
@@ -2675,7 +2675,7 @@ class FlowTest(TembaTest):
         self.assertTrue(FlowRun.objects.filter(contact=self.contact))
         run = FlowRun.objects.filter(contact=self.contact).first()
 
-        self.assertEquals(run.steps.all().count(), 2)
+        self.assertEqual(run.steps.all().count(), 2)
         actionset_step = run.steps.filter(step_type=FlowStep.TYPE_ACTION_SET).first()
         ruleset_step = run.steps.filter(step_type=FlowStep.TYPE_RULE_SET).first()
 
@@ -2683,13 +2683,13 @@ class FlowTest(TembaTest):
         self.assertFalse(ruleset_step.messages.all())
 
         # should have 2 messages on the actionset step
-        self.assertEquals(actionset_step.messages.all().count(), 2)
+        self.assertEqual(actionset_step.messages.all().count(), 2)
 
         # one is the start msg
         self.assertTrue(actionset_step.messages.filter(pk=sms.pk))
 
         # sms msg_type should be FLOW
-        self.assertEquals(Msg.objects.get(pk=sms.pk).msg_type, FLOW)
+        self.assertEqual(Msg.objects.get(pk=sms.pk).msg_type, FLOW)
 
     def test_multiple(self):
         self.flow.start([], [self.contact])
@@ -2702,16 +2702,16 @@ class FlowTest(TembaTest):
         self.flow2.start([], [self.contact])
 
         # each flow should have two events
-        self.assertEquals(2, FlowStep.objects.filter(run__flow=self.flow).count())
-        self.assertEquals(2, FlowStep.objects.filter(run__flow=self.flow2).count())
+        self.assertEqual(2, FlowStep.objects.filter(run__flow=self.flow).count())
+        self.assertEqual(2, FlowStep.objects.filter(run__flow=self.flow2).count())
 
         # send in a message
         incoming = self.create_msg(direction=INCOMING, contact=self.contact, text="Orange", created_on=timezone.now())
         self.assertTrue(Flow.find_and_handle(incoming)[0])
 
         # only the second flow should get it
-        self.assertEquals(2, FlowStep.objects.filter(run__flow=self.flow).count())
-        self.assertEquals(3, FlowStep.objects.filter(run__flow=self.flow2).count())
+        self.assertEqual(2, FlowStep.objects.filter(run__flow=self.flow).count())
+        self.assertEqual(3, FlowStep.objects.filter(run__flow=self.flow2).count())
 
         # start the flow again for our contact
         self.flow.start([], [self.contact], restart_participants=True)
@@ -2721,35 +2721,35 @@ class FlowTest(TembaTest):
         self.assertTrue(runs[0].is_active)
         self.assertFalse(runs[1].is_active)
 
-        self.assertEquals(2, runs[0].steps.all().count())
-        self.assertEquals(2, runs[1].steps.all().count())
+        self.assertEqual(2, runs[0].steps.all().count())
+        self.assertEqual(2, runs[1].steps.all().count())
 
         # send in a message, this should be handled by our first flow, which has a more recent run active
         incoming = self.create_msg(direction=INCOMING, contact=self.contact, text="blue")
         self.assertTrue(Flow.find_and_handle(incoming)[0])
 
-        self.assertEquals(3, runs[0].steps.all().count())
+        self.assertEqual(3, runs[0].steps.all().count())
 
         # if we exclude existing and try starting again, nothing happens
         self.flow.start([], [self.contact], restart_participants=False)
 
         # no new runs
-        self.assertEquals(2, self.flow.runs.all().count())
+        self.assertEqual(2, self.flow.runs.all().count())
 
         # get the results for the flow
         results = self.flow.get_results()
 
         # should only have one result
-        self.assertEquals(1, len(results))
+        self.assertEqual(1, len(results))
 
         # and only one value
-        self.assertEquals(1, len(results[0]['values']))
+        self.assertEqual(1, len(results[0]['values']))
 
         color = results[0]['values'][0]
-        self.assertEquals('color', color['label'])
-        self.assertEquals('Blue', color['category']['base'])
-        self.assertEquals('blue', color['value'])
-        self.assertEquals(incoming.text, color['text'])
+        self.assertEqual('color', color['label'])
+        self.assertEqual('Blue', color['category']['base'])
+        self.assertEqual('blue', color['value'])
+        self.assertEqual(incoming.text, color['text'])
 
     def test_ignore_keyword_triggers(self):
         self.flow.start([], [self.contact])
@@ -2856,19 +2856,19 @@ class ActionTest(TembaTest):
         action = ReplyAction(dict(base="We love green too!"))
         self.execute_action(action, run, msg)
         msg = Msg.objects.get(contact=self.contact, direction='O')
-        self.assertEquals("We love green too!", msg.text)
+        self.assertEqual("We love green too!", msg.text)
 
         Broadcast.objects.all().delete()
 
         action_json = action.as_json()
         action = ReplyAction.from_json(self.org, action_json)
-        self.assertEquals(dict(base="We love green too!"), action.msg)
+        self.assertEqual(dict(base="We love green too!"), action.msg)
 
         self.execute_action(action, run, msg)
 
         response = msg.responses.get()
-        self.assertEquals("We love green too!", response.text)
-        self.assertEquals(self.contact, response.contact)
+        self.assertEqual("We love green too!", response.text)
+        self.assertEqual(self.contact, response.contact)
 
     def test_send_all_action(self):
         contact = self.create_contact('Stephen', '+12078778899', twitter='stephen')
@@ -2898,7 +2898,7 @@ class ActionTest(TembaTest):
 
         action_json = action.as_json()
         action = ReplyAction.from_json(self.org, action_json)
-        self.assertEquals(dict(base="We love green too!"), action.msg)
+        self.assertEqual(dict(base="We love green too!"), action.msg)
         self.assertTrue(action.send_all)
 
         action_replies = self.execute_action(action, run, msg)
@@ -2918,8 +2918,8 @@ class ActionTest(TembaTest):
         action = ReplyAction(dict(base="We love green too!"), 'image/jpeg:path/to/media.jpg')
         self.execute_action(action, run, msg)
         reply_msg = Msg.objects.get(contact=self.contact, direction='O')
-        self.assertEquals("We love green too!", reply_msg.text)
-        self.assertEquals(reply_msg.attachments, ["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg')])
+        self.assertEqual("We love green too!", reply_msg.text)
+        self.assertEqual(reply_msg.attachments, ["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg')])
 
         Broadcast.objects.all().delete()
         Msg.objects.all().delete()
@@ -2927,15 +2927,15 @@ class ActionTest(TembaTest):
 
         action_json = action.as_json()
         action = ReplyAction.from_json(self.org, action_json)
-        self.assertEquals(dict(base="We love green too!"), action.msg)
-        self.assertEquals('image/jpeg:path/to/media.jpg', action.media)
+        self.assertEqual(dict(base="We love green too!"), action.msg)
+        self.assertEqual('image/jpeg:path/to/media.jpg', action.media)
 
         self.execute_action(action, run, msg)
 
         response = msg.responses.get()
-        self.assertEquals("We love green too!", response.text)
-        self.assertEquals(response.attachments, ["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg')])
-        self.assertEquals(self.contact, response.contact)
+        self.assertEqual("We love green too!", response.text)
+        self.assertEqual(response.attachments, ["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, 'path/to/media.jpg')])
+        self.assertEqual(self.contact, response.contact)
 
     def test_media_expression(self):
         msg = self.create_msg(direction=INCOMING, contact=self.contact, text="profile")
@@ -2950,12 +2950,12 @@ class ActionTest(TembaTest):
         # now execute it
         self.execute_action(action, run, msg)
         reply_msg = Msg.objects.get(contact=self.contact, direction='O')
-        self.assertEquals("Here is your profile pic.", reply_msg.text)
-        self.assertEquals(reply_msg.attachments, ["image:/photos/contacts/Eric.jpg"])
+        self.assertEqual("Here is your profile pic.", reply_msg.text)
+        self.assertEqual(reply_msg.attachments, ["image:/photos/contacts/Eric.jpg"])
 
         response = msg.responses.get()
-        self.assertEquals("Here is your profile pic.", response.text)
-        self.assertEquals(self.contact, response.contact)
+        self.assertEqual("Here is your profile pic.", response.text)
+        self.assertEqual(self.contact, response.contact)
 
     def test_ussd_action(self):
         self.channel.delete()
@@ -2976,7 +2976,7 @@ class ActionTest(TembaTest):
         execution = self.execute_action(action, run, msg)
 
         self.assertIsNone(action.msg)
-        self.assertEquals(execution, [])
+        self.assertEqual(execution, [])
 
         # add menu rules
         ussd_ruleset.set_rules_dict([Rule(str(uuid4()), dict(base="All Responses"), menu_uuid, 'R', TrueTest()).as_json(),
@@ -2993,9 +2993,9 @@ class ActionTest(TembaTest):
         execution = self.execute_action(action, run, msg)
 
         self.assertIsNotNone(action.msg)
-        self.assertEquals(action.msg, {u'base': u'test\n1: Test1\n2: Test2\n'})
+        self.assertEqual(action.msg, {u'base': u'test\n1: Test1\n2: Test2\n'})
         self.assertIsInstance(execution[0], Msg)
-        self.assertEquals(execution[0].text, u'test\n1: Test1\n2: Test2')
+        self.assertEqual(execution[0].text, u'test\n1: Test1\n2: Test2')
 
         Broadcast.objects.all().delete()
 
@@ -3048,11 +3048,11 @@ class ActionTest(TembaTest):
         self.assertNotIn('labelENG', action.msg['hun'])
         self.assertIn('label2ENG', action.msg['hun'])
 
-        self.assertEquals(action.msg['hun'], u'testHUN\n1: labelHUN\n2: label2ENG\n')
+        self.assertEqual(action.msg['hun'], u'testHUN\n1: labelHUN\n2: label2ENG\n')
 
         # the msg sent out is in english
         self.assertIsInstance(execution[0], Msg)
-        self.assertEquals(execution[0].text, u'testENG\n1: labelENG\n2: label2ENG')
+        self.assertEqual(execution[0].text, u'testENG\n1: labelENG\n2: label2ENG')
 
         # now set contact's language to something we don't have in our org languages
         self.contact.language = 'fre'
@@ -3064,7 +3064,7 @@ class ActionTest(TembaTest):
 
         # he will still get the english (base language)
         self.assertIsInstance(execution[0], Msg)
-        self.assertEquals(execution[0].text, u'testENG\n1: labelENG\n2: label2ENG')
+        self.assertEqual(execution[0].text, u'testENG\n1: labelENG\n2: label2ENG')
 
         # now set contact's language to hungarian
         self.contact.language = 'hun'
@@ -3076,7 +3076,7 @@ class ActionTest(TembaTest):
 
         # he will get the partly translated hungarian version
         self.assertIsInstance(execution[0], Msg)
-        self.assertEquals(execution[0].text, u'testHUN\n1: labelHUN\n2: label2ENG')
+        self.assertEqual(execution[0].text, u'testHUN\n1: labelHUN\n2: label2ENG')
 
         Broadcast.objects.all().delete()
 
@@ -3238,10 +3238,10 @@ class ActionTest(TembaTest):
 
         self.execute_action(action, run, msg)
 
-        self.assertEquals(len(mail.outbox), 1)
-        self.assertEquals(mail.outbox[0].subject, "Subject")
-        self.assertEquals(mail.outbox[0].body, "Body")
-        self.assertEquals(mail.outbox[0].recipients(), ["steve@apple.com"])
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Subject")
+        self.assertEqual(mail.outbox[0].body, "Body")
+        self.assertEqual(mail.outbox[0].recipients(), ["steve@apple.com"])
 
         try:
             EmailAction([], "Subject", "Body")
@@ -3259,10 +3259,10 @@ class ActionTest(TembaTest):
 
         self.execute_action(action, run, msg)
 
-        self.assertEquals(len(mail.outbox), 2)
-        self.assertEquals(mail.outbox[1].subject, "Eric added in subject")
-        self.assertEquals(mail.outbox[1].body, "Eric uses phone 0788 382 382")
-        self.assertEquals(mail.outbox[1].recipients(), ["eric@nyaruka.com"])  # invalid emails are ignored
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(mail.outbox[1].subject, "Eric added in subject")
+        self.assertEqual(mail.outbox[1].body, "Eric uses phone 0788 382 382")
+        self.assertEqual(mail.outbox[1].recipients(), ["eric@nyaruka.com"])  # invalid emails are ignored
 
         # check simulator reports invalid addresses
         test_contact = Contact.get_test_contact(self.user)
@@ -3280,21 +3280,21 @@ class ActionTest(TembaTest):
         test = EmailAction(["steve@apple.com"], "Allo \n allo\tmessage", "Email notification for allo allo")
         self.execute_action(test, run, msg)
 
-        self.assertEquals(len(mail.outbox), 3)
-        self.assertEquals(mail.outbox[2].subject, 'Allo allo message')
-        self.assertEquals(mail.outbox[2].body, 'Email notification for allo allo')
-        self.assertEquals(mail.outbox[2].recipients(), ["steve@apple.com"])
+        self.assertEqual(len(mail.outbox), 3)
+        self.assertEqual(mail.outbox[2].subject, 'Allo allo message')
+        self.assertEqual(mail.outbox[2].body, 'Email notification for allo allo')
+        self.assertEqual(mail.outbox[2].recipients(), ["steve@apple.com"])
 
         self.org.add_smtp_config('support@example.com', 'smtp.example.com', 'support@example.com', 'secret', '465', 'T', self.admin)
 
         action = EmailAction(["steve@apple.com"], "Subject", "Body")
         self.execute_action(action, run, msg)
 
-        self.assertEquals(len(mail.outbox), 4)
-        self.assertEquals(mail.outbox[3].from_email, 'support@example.com')
-        self.assertEquals(mail.outbox[3].subject, 'Subject')
-        self.assertEquals(mail.outbox[3].body, 'Body')
-        self.assertEquals(mail.outbox[3].recipients(), ["steve@apple.com"])
+        self.assertEqual(len(mail.outbox), 4)
+        self.assertEqual(mail.outbox[3].from_email, 'support@example.com')
+        self.assertEqual(mail.outbox[3].subject, 'Subject')
+        self.assertEqual(mail.outbox[3].body, 'Body')
+        self.assertEqual(mail.outbox[3].recipients(), ["steve@apple.com"])
 
     def test_save_to_contact_action(self):
         sms = self.create_msg(direction=INCOMING, contact=self.contact, text="batman")
@@ -3302,27 +3302,27 @@ class ActionTest(TembaTest):
         run = FlowRun.create(self.flow, self.contact.pk)
 
         field = ContactField.objects.get(org=self.org, key="superhero_name")
-        self.assertEquals("Superhero Name", field.label)
+        self.assertEqual("Superhero Name", field.label)
 
         self.execute_action(test, run, sms)
 
         # user should now have a nickname field with a value of batman
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals("batman", contact.get_field_raw('superhero_name'))
+        self.assertEqual("batman", contact.get_field_raw('superhero_name'))
 
         # test clearing our value
         test = SaveToContactAction.from_json(self.org, test.as_json())
         test.value = ""
         self.execute_action(test, run, sms)
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals(None, contact.get_field_raw('superhero_name'))
+        self.assertEqual(None, contact.get_field_raw('superhero_name'))
 
         # test setting our name
         test = SaveToContactAction.from_json(self.org, dict(type='save', label="Name", value='', field='name'))
         test.value = "Eric Newcomer"
         self.execute_action(test, run, sms)
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals("Eric Newcomer", contact.name)
+        self.assertEqual("Eric Newcomer", contact.name)
         run.contact = contact
 
         # test setting just the first name
@@ -3330,7 +3330,7 @@ class ActionTest(TembaTest):
         test.value = "Jen"
         self.execute_action(test, run, sms)
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals("Jen Newcomer", contact.name)
+        self.assertEqual("Jen Newcomer", contact.name)
 
         # throw exception for other reserved words except name and first_name
         for word in Contact.RESERVED_FIELDS:
@@ -3346,7 +3346,7 @@ class ActionTest(TembaTest):
         test.value = " Jackson "
         self.execute_action(test, run, sms)
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals("Jackson Newcomer", contact.name)
+        self.assertEqual("Jackson Newcomer", contact.name)
 
         # first name works with a single word
         run.contact = contact
@@ -3357,7 +3357,7 @@ class ActionTest(TembaTest):
         test.value = " Cole"
         self.execute_action(test, run, sms)
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals("Cole", contact.name)
+        self.assertEqual("Cole", contact.name)
 
         # test saving something really long to another field
         test = SaveToContactAction.from_json(self.org, dict(type='save', label="Last Message", value='', field='last_message'))
@@ -3366,7 +3366,7 @@ class ActionTest(TembaTest):
                      "fields and we want to enable that for them so that they can do what they want with the platform."
         self.execute_action(test, run, sms)
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals(test.value, contact.get_field('last_message').string_value)
+        self.assertEqual(test.value, contact.get_field('last_message').string_value)
 
         # test saving a contact's phone number
         test = SaveToContactAction.from_json(self.org, dict(type='save', label='Phone Number', field='tel_e164', value='@step'))
@@ -3377,7 +3377,7 @@ class ActionTest(TembaTest):
 
         # add another phone number to make sure it doesn't get removed too
         contact.urns.add(ContactURN.create(self.org, None, 'tel:+18005551212'))
-        self.assertEquals(3, contact.urns.all().count())
+        self.assertEqual(3, contact.urns.all().count())
 
         # create an inbound message on our original phone number
         sms = self.create_msg(direction=INCOMING, contact=self.contact,
@@ -3393,7 +3393,7 @@ class ActionTest(TembaTest):
 
         # instead it should update the tel urn for our contact
         contact = Contact.objects.get(id=self.contact.pk)
-        self.assertEquals(4, contact.urns.all().count())
+        self.assertEqual(4, contact.urns.all().count())
         self.assertIsNotNone(contact.urns.filter(path='+12065551212').first())
 
         # we should still have our twitter scheme
@@ -3417,28 +3417,28 @@ class ActionTest(TembaTest):
         ActionLog.objects.all().delete()
         action = SaveToContactAction.from_json(self.org, dict(type='save', label="mailto", value='foo@bar.com'))
         self.execute_action(action, run, None)
-        self.assertEquals(ActionLog.objects.get().text, "Added foo@bar.com as @contact.mailto - skipped in simulator")
+        self.assertEqual(ActionLog.objects.get().text, "Added foo@bar.com as @contact.mailto - skipped in simulator")
 
         # Invalid email
         ActionLog.objects.all().delete()
         action = SaveToContactAction.from_json(self.org, dict(type='save', label="mailto", value='foobar.com'))
         self.execute_action(action, run, None)
-        self.assertEquals(ActionLog.objects.get().text, "Contact not updated, invalid connection for contact (mailto:foobar.com)")
+        self.assertEqual(ActionLog.objects.get().text, "Contact not updated, invalid connection for contact (mailto:foobar.com)")
 
         # URN should be unchanged on the simulator contact
         test_contact = Contact.objects.get(id=test_contact.id)
-        self.assertEquals(test_contact_urn, test_contact.urns.all().first())
+        self.assertEqual(test_contact_urn, test_contact.urns.all().first())
 
         self.assertFalse(ContactField.objects.filter(org=self.org, label='Ecole'))
         SaveToContactAction.from_json(self.org, dict(type='save', label="[_NEW_]Ecole", value='@step'))
         field = ContactField.objects.get(org=self.org, key="ecole")
-        self.assertEquals("Ecole", field.label)
+        self.assertEqual("Ecole", field.label)
 
         # try saving some empty data into mailto
         ActionLog.objects.all().delete()
         action = SaveToContactAction.from_json(self.org, dict(type='save', label="mailto", value='@contact.mailto'))
         self.execute_action(action, run, None)
-        self.assertEquals(ActionLog.objects.get().text, "Contact not updated, missing connection for contact")
+        self.assertEqual(ActionLog.objects.get().text, "Contact not updated, missing connection for contact")
 
     def test_set_language_action(self):
         action = SetLanguageAction('kli', 'Klingon')
@@ -3453,7 +3453,7 @@ class ActionTest(TembaTest):
         # execute our action and check we are Klingon now, eeektorp shnockahltip.
         run = FlowRun.create(self.flow, self.contact.pk)
         self.execute_action(action, run, None)
-        self.assertEquals('kli', Contact.objects.get(pk=self.contact.pk).language)
+        self.assertEqual('kli', Contact.objects.get(pk=self.contact.pk).language)
 
         # try setting the language to something thats not three characters
         action_json['lang'] = 'base'
@@ -3611,9 +3611,9 @@ class ActionTest(TembaTest):
 
         # user should be in both groups now
         self.assertTrue(group1.contacts.filter(id=self.contact.pk))
-        self.assertEquals(1, group1.contacts.all().count())
+        self.assertEqual(1, group1.contacts.all().count())
         self.assertTrue(group2.contacts.filter(id=self.contact.pk))
-        self.assertEquals(1, group2.contacts.all().count())
+        self.assertEqual(1, group2.contacts.all().count())
 
         test = DeleteFromGroupAction([])
         action_json = test.as_json()
@@ -3623,9 +3623,9 @@ class ActionTest(TembaTest):
 
         # user should be gone from both groups now
         self.assertFalse(group1.contacts.filter(id=self.contact.pk))
-        self.assertEquals(0, group1.contacts.all().count())
+        self.assertEqual(0, group1.contacts.all().count())
         self.assertFalse(group2.contacts.filter(id=self.contact.pk))
-        self.assertEquals(0, group2.contacts.all().count())
+        self.assertEqual(0, group2.contacts.all().count())
 
     def test_set_channel_action(self):
         flow = self.flow
@@ -3738,8 +3738,8 @@ class ActionTest(TembaTest):
         self.execute_action(action, run, msg)
 
         self.assertEqual(set(Msg.objects.get(pk=msg.pk).labels.all()), {label1, label2})
-        self.assertEquals(Label.label_objects.get(pk=label1.pk).get_visible_count(), 1)
-        self.assertEquals(Label.label_objects.get(pk=label2.pk).get_visible_count(), 1)
+        self.assertEqual(Label.label_objects.get(pk=label1.pk).get_visible_count(), 1)
+        self.assertEqual(Label.label_objects.get(pk=label2.pk).get_visible_count(), 1)
 
     @override_settings(SEND_WEBHOOKS=True)
     @patch('django.utils.timezone.now')
@@ -3901,18 +3901,18 @@ class FlowRunTest(TembaTest):
         new_values = dict(Field1="value1", field_2="value2")
         run.update_fields(new_values)
 
-        self.assertEquals(run.field_dict(), new_values)
+        self.assertEqual(run.field_dict(), new_values)
 
         run.update_fields(dict(field2="new value2", field3="value3"))
         new_values['field2'] = "new value2"
         new_values['field3'] = "value3"
 
-        self.assertEquals(run.field_dict(), new_values)
+        self.assertEqual(run.field_dict(), new_values)
 
         run.update_fields(dict(field1=""))
         new_values['field1'] = ""
 
-        self.assertEquals(run.field_dict(), new_values)
+        self.assertEqual(run.field_dict(), new_values)
 
         # clear our fields
         run.fields = None
@@ -3957,25 +3957,25 @@ class FlowLabelTest(FlowFileTest):
         response = FlowLabel.create_unique("alongwordcomposedofmorethanthirtytwoletters",
                                            self.org,
                                            parent=None)
-        self.assertEquals(response.name, "alongwordcomposedofmorethanthirt")
+        self.assertEqual(response.name, "alongwordcomposedofmorethanthirt")
 
         # try to create another label which starts with the same 32 caracteres
         # the one we already have
         label = FlowLabel.create_unique("alongwordcomposedofmorethanthirtytwocaracteres",
                                         self.org, parent=None)
 
-        self.assertEquals(label.name, "alongwordcomposedofmorethanthi 2")
-        self.assertEquals(str(label), "alongwordcomposedofmorethanthi 2")
+        self.assertEqual(label.name, "alongwordcomposedofmorethanthi 2")
+        self.assertEqual(str(label), "alongwordcomposedofmorethanthi 2")
         label = FlowLabel.create_unique("child", self.org, parent=label)
-        self.assertEquals(str(label), "alongwordcomposedofmorethanthi 2 > child")
+        self.assertEqual(str(label), "alongwordcomposedofmorethanthi 2 > child")
 
         FlowLabel.create_unique("dog", self.org)
         FlowLabel.create_unique("dog", self.org)
         dog3 = FlowLabel.create_unique("dog", self.org)
-        self.assertEquals("dog 3", dog3.name)
+        self.assertEqual("dog 3", dog3.name)
 
         dog4 = FlowLabel.create_unique("dog ", self.org)
-        self.assertEquals("dog 4", dog4.name)
+        self.assertEqual("dog 4", dog4.name)
 
         # view the parent label, should see the child
         self.login(self.admin)
@@ -4014,28 +4014,28 @@ class FlowLabelTest(FlowFileTest):
 
         self.login(self.admin)
         response = self.client.post(create_url, post_data, follow=True)
-        self.assertEquals(FlowLabel.objects.all().count(), 1)
-        self.assertEquals(FlowLabel.objects.all()[0].parent, None)
+        self.assertEqual(FlowLabel.objects.all().count(), 1)
+        self.assertEqual(FlowLabel.objects.all()[0].parent, None)
 
         label_one = FlowLabel.objects.all()[0]
         post_data = dict(name="sub_label", parent=label_one.pk)
         response = self.client.post(create_url, post_data, follow=True)
 
-        self.assertEquals(FlowLabel.objects.all().count(), 2)
-        self.assertEquals(FlowLabel.objects.filter(parent=None).count(), 1)
+        self.assertEqual(FlowLabel.objects.all().count(), 2)
+        self.assertEqual(FlowLabel.objects.filter(parent=None).count(), 1)
 
         post_data = dict(name="sub_label ", parent=label_one.pk)
         response = self.client.post(create_url, post_data, follow=True)
         self.assertTrue('form' in response.context)
         self.assertTrue(response.context['form'].errors)
-        self.assertEquals('Name already used', response.context['form'].errors['name'][0])
+        self.assertEqual('Name already used', response.context['form'].errors['name'][0])
 
-        self.assertEquals(FlowLabel.objects.all().count(), 2)
-        self.assertEquals(FlowLabel.objects.filter(parent=None).count(), 1)
+        self.assertEqual(FlowLabel.objects.all().count(), 2)
+        self.assertEqual(FlowLabel.objects.filter(parent=None).count(), 1)
 
         post_data = dict(name="label from modal")
         response = self.client.post("%s?format=modal" % create_url, post_data, follow=True)
-        self.assertEquals(FlowLabel.objects.all().count(), 3)
+        self.assertEqual(FlowLabel.objects.all().count(), 3)
 
     def test_delete(self):
         label_one = FlowLabel.create_unique("label1", self.org)
@@ -4046,11 +4046,11 @@ class FlowLabelTest(FlowFileTest):
 
         self.login(self.other_user)
         response = self.client.get(delete_url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         self.login(self.admin)
         response = self.client.get(delete_url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_update(self):
         label_one = FlowLabel.create_unique("label1", self.org)
@@ -4142,10 +4142,10 @@ class WebhookTest(TembaTest):
 
                 # first do a GET
                 webhook.find_matching_rule(webhook_step, run, incoming)
-                self.assertEquals(dict(text="Get", blank=""), run.field_dict())
+                self.assertEqual(dict(text="Get", blank=""), run.field_dict())
 
                 # assert our phone number got encoded
-                self.assertEquals("http://ordercheck.com/check_order.php?phone=%2B250788383383", get.call_args[0][0])
+                self.assertEqual("http://ordercheck.com/check_order.php?phone=%2B250788383383", get.call_args[0][0])
 
                 # now do a POST
                 config = webhook.config_json()
@@ -4153,9 +4153,9 @@ class WebhookTest(TembaTest):
                 webhook.config = json.dumps(config)
                 webhook.save()
                 webhook.find_matching_rule(webhook_step, run, incoming)
-                self.assertEquals(dict(text="Post", blank=""), run.field_dict())
+                self.assertEqual(dict(text="Post", blank=""), run.field_dict())
 
-                self.assertEquals("http://ordercheck.com/check_order.php?phone=%2B250788383383", post.call_args[0][0])
+                self.assertEqual("http://ordercheck.com/check_order.php?phone=%2B250788383383", post.call_args[0][0])
 
         # remove @extra.blank from our text
         rules.operand = "@extra.text"
@@ -4174,33 +4174,33 @@ class WebhookTest(TembaTest):
             (match, value) = webhook.find_matching_rule(webhook_step, run, incoming)
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
 
-            self.assertEquals(valid_uuid, match.uuid)
-            self.assertEquals("Valid", value)
-            self.assertEquals(dict(text="Valid"), run.field_dict())
+            self.assertEqual(valid_uuid, match.uuid)
+            self.assertEqual("Valid", value)
+            self.assertEqual(dict(text="Valid"), run.field_dict())
 
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(200, '{ "text": "Valid", "order_number": "PX1001" }')
 
             (match, value) = webhook.find_matching_rule(webhook_step, run, incoming)
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
-            self.assertEquals(valid_uuid, match.uuid)
-            self.assertEquals("Valid", value)
-            self.assertEquals(dict(text="Valid", order_number="PX1001"), run.field_dict())
+            self.assertEqual(valid_uuid, match.uuid)
+            self.assertEqual("Valid", value)
+            self.assertEqual(dict(text="Valid", order_number="PX1001"), run.field_dict())
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
-            self.assertEquals(dict(text="Valid", order_number="PX1001"), message_context['extra'])
+            self.assertEqual(dict(text="Valid", order_number="PX1001"), message_context['extra'])
 
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(200, '{ "text": "Valid", "order_number": "PX1002" }')
 
             webhook.find_matching_rule(webhook_step, run, incoming)
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
-            self.assertEquals(valid_uuid, match.uuid)
-            self.assertEquals("Valid", value)
-            self.assertEquals(dict(text="Valid", order_number="PX1002"), run.field_dict())
+            self.assertEqual(valid_uuid, match.uuid)
+            self.assertEqual("Valid", value)
+            self.assertEqual(dict(text="Valid", order_number="PX1002"), run.field_dict())
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
-            self.assertEquals(dict(text="Valid", order_number="PX1002"), message_context['extra'])
+            self.assertEqual(dict(text="Valid", order_number="PX1002"), message_context['extra'])
 
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(200, '["zero", "one", "two"]')
@@ -4211,7 +4211,7 @@ class WebhookTest(TembaTest):
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
             self.assertIsNone(match)
             self.assertIsNone(value)
-            self.assertEquals("1001", incoming.text)
+            self.assertEqual("1001", incoming.text)
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
             self.assertEqual(message_context['extra'], {'0': 'zero', '1': 'one', '2': 'two'})
@@ -4225,7 +4225,7 @@ class WebhookTest(TembaTest):
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
             self.assertIsNone(match)
             self.assertIsNone(value)
-            self.assertEquals("1001", incoming.text)
+            self.assertEqual("1001", incoming.text)
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
             extra = message_context['extra']
@@ -4243,10 +4243,10 @@ class WebhookTest(TembaTest):
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
             self.assertIsNone(match)
             self.assertIsNone(value)
-            self.assertEquals("1001", incoming.text)
+            self.assertEqual("1001", incoming.text)
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
-            self.assertEquals({}, message_context['extra'])
+            self.assertEqual({}, message_context['extra'])
 
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(200, "12345")
@@ -4257,10 +4257,10 @@ class WebhookTest(TembaTest):
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
             self.assertIsNone(match)
             self.assertIsNone(value)
-            self.assertEquals("1001", incoming.text)
+            self.assertEqual("1001", incoming.text)
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
-            self.assertEquals({}, message_context['extra'])
+            self.assertEqual({}, message_context['extra'])
 
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(500, "Server Error")
@@ -4271,7 +4271,7 @@ class WebhookTest(TembaTest):
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
             self.assertIsNone(match)
             self.assertIsNone(value)
-            self.assertEquals("1001", incoming.text)
+            self.assertEqual("1001", incoming.text)
 
         with patch('requests.post') as mock:
             mock.return_value = MockResponse(400, '{ "text": "Valid", "error": "400", "message": "Missing field in request" }')
@@ -4280,12 +4280,12 @@ class WebhookTest(TembaTest):
 
             (match, value) = webhook.find_matching_rule(webhook_step, run, incoming)
             (match, value) = rules.find_matching_rule(rule_step, run, incoming)
-            self.assertEquals(valid_uuid, match.uuid)
-            self.assertEquals("Valid", value)
-            self.assertEquals(dict(text="Valid", error="400", message="Missing field in request"), run.field_dict())
+            self.assertEqual(valid_uuid, match.uuid)
+            self.assertEqual("Valid", value)
+            self.assertEqual(dict(text="Valid", error="400", message="Missing field in request"), run.field_dict())
 
             message_context = self.flow.build_expressions_context(self.contact, incoming)
-            self.assertEquals(dict(text="Valid", error="400", message="Missing field in request"), message_context['extra'])
+            self.assertEqual(dict(text="Valid", error="400", message="Missing field in request"), message_context['extra'])
 
     def test_resthook(self):
         self.contact = self.create_contact("Macklemore", "+12067799294")
@@ -4355,23 +4355,23 @@ class SimulationTest(FlowFileTest):
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
         json_dict = response.json()
 
-        self.assertEquals(len(json_dict.keys()), 6)
-        self.assertEquals(len(json_dict['messages']), 2)
-        self.assertEquals('Ben Haggerty has entered the &quot;Pick a Number&quot; flow', json_dict['messages'][0]['text'])
-        self.assertEquals("Pick a number between 1-10.", json_dict['messages'][1]['text'])
+        self.assertEqual(len(json_dict.keys()), 6)
+        self.assertEqual(len(json_dict['messages']), 2)
+        self.assertEqual('Ben Haggerty has entered the &quot;Pick a Number&quot; flow', json_dict['messages'][0]['text'])
+        self.assertEqual("Pick a number between 1-10.", json_dict['messages'][1]['text'])
 
         post_data['new_message'] = "3"
         post_data['has_refresh'] = False
 
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         json_dict = response.json()
 
-        self.assertEquals(len(json_dict['messages']), 6)
-        self.assertEquals("3", json_dict['messages'][2]['text'])
-        self.assertEquals("Saved &#39;3&#39; as @flow.number", json_dict['messages'][3]['text'])
-        self.assertEquals("You picked 3!", json_dict['messages'][4]['text'])
-        self.assertEquals('Ben Haggerty has exited this flow', json_dict['messages'][5]['text'])
+        self.assertEqual(len(json_dict['messages']), 6)
+        self.assertEqual("3", json_dict['messages'][2]['text'])
+        self.assertEqual("Saved &#39;3&#39; as @flow.number", json_dict['messages'][3]['text'])
+        self.assertEqual("You picked 3!", json_dict['messages'][4]['text'])
+        self.assertEqual('Ben Haggerty has exited this flow', json_dict['messages'][5]['text'])
 
     @patch('temba.ussd.models.USSDSession.handle_incoming')
     def test_ussd_simulation(self, handle_incoming):
@@ -4387,7 +4387,7 @@ class SimulationTest(FlowFileTest):
         self.login(self.admin)
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # session should have started now
         self.assertTrue(handle_incoming.called)
@@ -4397,7 +4397,7 @@ class SimulationTest(FlowFileTest):
 
         self.channel.delete()
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     @patch('temba.ussd.models.USSDSession.handle_incoming')
     def test_ussd_simulation_interrupt(self, handle_incoming):
@@ -4413,7 +4413,7 @@ class SimulationTest(FlowFileTest):
         self.login(self.admin)
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # session should have started now
         self.assertTrue(handle_incoming.called)
@@ -4436,10 +4436,10 @@ class SimulationTest(FlowFileTest):
         self.login(self.admin)
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         connection = USSDSession.objects.get()
-        self.assertEquals(connection.status, USSDSession.COMPLETED)
+        self.assertEqual(connection.status, USSDSession.COMPLETED)
 
     def test_ussd_simulation_without_channel_doesnt_run(self):
         Channel.objects.all().delete()
@@ -4452,7 +4452,7 @@ class SimulationTest(FlowFileTest):
 
         self.login(self.admin)
         response = self.client.post(simulate_url, json.dumps(post_data), content_type="application/json")
-        self.assertEquals(response.status_code, 400)
+        self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['status'], 'error')
 
         self.assertEqual(flow.runs.count(), 0)
@@ -4480,7 +4480,7 @@ class FlowsTest(FlowFileTest):
         flow = self.get_flow('sms_form')
 
         def assert_response(message, response):
-            self.assertEquals(response, self.send_message(flow, message, restart_participants=True))
+            self.assertEqual(response, self.send_message(flow, message, restart_participants=True))
 
         # invalid age
         assert_response("101 M Seattle", "Sorry, 101 doesn't look like a valid age, please try again.")
@@ -4524,11 +4524,11 @@ class FlowsTest(FlowFileTest):
 
         # saving should work
         response = flow.update(flow_json, self.admin)
-        self.assertEquals(response.get('status'), 'success')
+        self.assertEqual(response.get('status'), 'success')
 
         # but if we save from in the past after our save it should fail
         response = flow.update(flow_json, self.admin)
-        self.assertEquals(response.get('status'), 'unsaved')
+        self.assertEqual(response.get('status'), 'unsaved')
 
     def test_flow_results(self):
         favorites = self.get_flow('favorites')
@@ -4753,9 +4753,9 @@ class FlowsTest(FlowFileTest):
         flow = self.get_flow('columns_order')
 
         export_columns = flow.get_columns()
-        self.assertEquals(export_columns[0], RuleSet.objects.filter(flow=flow, label='Beer').first())
-        self.assertEquals(export_columns[1], RuleSet.objects.filter(flow=flow, label='Name').first())
-        self.assertEquals(export_columns[2], RuleSet.objects.filter(flow=flow, label='Color').first())
+        self.assertEqual(export_columns[0], RuleSet.objects.filter(flow=flow, label='Beer').first())
+        self.assertEqual(export_columns[1], RuleSet.objects.filter(flow=flow, label='Name').first())
+        self.assertEqual(export_columns[2], RuleSet.objects.filter(flow=flow, label='Color').first())
 
     def test_recent_messages(self):
         flow = self.get_flow('favorites')
@@ -4899,9 +4899,9 @@ class FlowsTest(FlowFileTest):
 
         # should all be expired
         (active, visited) = flow.get_activity()
-        self.assertEquals(FlowRun.objects.filter(is_active=True).count(), 0)
-        self.assertEquals(FlowRun.objects.filter(is_active=False, exit_type='E').exclude(exited_on=None).count(), 6)
-        self.assertEquals(len(active), 0)
+        self.assertEqual(FlowRun.objects.filter(is_active=True).count(), 0)
+        self.assertEqual(FlowRun.objects.filter(is_active=False, exit_type='E').exclude(exited_on=None).count(), 6)
+        self.assertEqual(len(active), 0)
 
         # assert our flowrun counts
         self.assertEqual(FlowRunCount.get_totals(flow), {'A': 0, 'C': 0, 'E': 6, 'I': 0})
@@ -4966,10 +4966,10 @@ class FlowsTest(FlowFileTest):
         self.send_message(flow, 'chartreuse')
         (active, visited) = flow.get_activity()
 
-        self.assertEquals(1, len(active))
-        self.assertEquals(1, active[color.uuid])
-        self.assertEquals(1, visited[other_rule_to_msg])
-        self.assertEquals(1, visited[msg_to_color_step])
+        self.assertEqual(1, len(active))
+        self.assertEqual(1, active[color.uuid])
+        self.assertEqual(1, visited[other_rule_to_msg])
+        self.assertEqual(1, visited[msg_to_color_step])
         self.assertEqual(flow.get_run_stats(),
                          {'total': 1, 'active': 1, 'completed': 0, 'expired': 0, 'interrupted': 0, 'completion': 0})
 
@@ -4977,17 +4977,17 @@ class FlowsTest(FlowFileTest):
         # the active stats will look the same, but there should be one more journey on the path
         self.send_message(flow, 'mauve')
         (active, visited) = flow.get_activity()
-        self.assertEquals(1, len(active))
-        self.assertEquals(1, active[color.uuid])
-        self.assertEquals(2, visited[other_rule_to_msg])
-        self.assertEquals(2, visited[msg_to_color_step])
+        self.assertEqual(1, len(active))
+        self.assertEqual(1, active[color.uuid])
+        self.assertEqual(2, visited[other_rule_to_msg])
+        self.assertEqual(2, visited[msg_to_color_step])
 
         # this time a color we know takes us elsewhere, activity will move
         # to another node, but still just one entry
         self.send_message(flow, 'blue')
         (active, visited) = flow.get_activity()
-        self.assertEquals(1, len(active))
-        self.assertEquals(1, active[beer.uuid])
+        self.assertEqual(1, len(active))
+        self.assertEqual(1, active[beer.uuid])
 
         # check recent messages
         recent = FlowPathRecentMessage.get_recent([color_question.uuid], [color.uuid])
@@ -5006,25 +5006,25 @@ class FlowsTest(FlowFileTest):
         ryan = self.create_contact('Ryan Lewis', '+12065550725')
         self.send_message(flow, 'burnt sienna', contact=ryan)
         (active, visited) = flow.get_activity()
-        self.assertEquals(2, len(active))
-        self.assertEquals(1, active[color.uuid])
-        self.assertEquals(1, active[beer.uuid])
-        self.assertEquals(3, visited[other_rule_to_msg])
-        self.assertEquals(3, visited[msg_to_color_step])
+        self.assertEqual(2, len(active))
+        self.assertEqual(1, active[color.uuid])
+        self.assertEqual(1, active[beer.uuid])
+        self.assertEqual(3, visited[other_rule_to_msg])
+        self.assertEqual(3, visited[msg_to_color_step])
         self.assertEqual(flow.get_run_stats(),
                          {'total': 2, 'active': 2, 'completed': 0, 'expired': 0, 'interrupted': 0, 'completion': 0})
 
         # now let's have them land in the same place
         self.send_message(flow, 'blue', contact=ryan)
         (active, visited) = flow.get_activity()
-        self.assertEquals(1, len(active))
-        self.assertEquals(2, active[beer.uuid])
+        self.assertEqual(1, len(active))
+        self.assertEqual(2, active[beer.uuid])
 
         # now move our first contact forward to the end, both out of the flow now
         self.send_message(flow, 'Turbo King')
         self.send_message(flow, 'Ben Haggerty')
         (active, visited) = flow.get_activity()
-        self.assertEquals(1, len(active))
+        self.assertEqual(1, len(active))
 
         # half of our flows are now complete
         self.assertEqual(flow.get_run_stats(),
@@ -5033,39 +5033,39 @@ class FlowsTest(FlowFileTest):
         # we are going to expire, but we want runs across two different flows
         # to make sure that our optimization for expiration is working properly
         cga_flow = self.get_flow('color_gender_age')
-        self.assertEquals("What is your gender?", self.send_message(cga_flow, "Red"))
-        self.assertEquals(1, len(cga_flow.get_activity()[0]))
+        self.assertEqual("What is your gender?", self.send_message(cga_flow, "Red"))
+        self.assertEqual(1, len(cga_flow.get_activity()[0]))
 
         # expire the first contact's runs
         FlowRun.bulk_exit(FlowRun.objects.filter(contact=self.contact), FlowRun.EXIT_TYPE_EXPIRED)
 
         # no active runs for our contact
-        self.assertEquals(0, FlowRun.objects.filter(contact=self.contact, is_active=True).count())
+        self.assertEqual(0, FlowRun.objects.filter(contact=self.contact, is_active=True).count())
 
         # both of our flows should have reduced active contacts
-        self.assertEquals(0, len(cga_flow.get_activity()[0]))
+        self.assertEqual(0, len(cga_flow.get_activity()[0]))
 
         # now we should only have one node with active runs, but the paths stay
         # the same since those are historical
         (active, visited) = flow.get_activity()
-        self.assertEquals(1, len(active))
-        self.assertEquals(3, visited[other_rule_to_msg])
+        self.assertEqual(1, len(active))
+        self.assertEqual(3, visited[other_rule_to_msg])
 
         # no completed runs but one expired run
         self.assertEqual(flow.get_run_stats(),
                          {'total': 2, 'active': 1, 'completed': 0, 'expired': 1, 'interrupted': 0, 'completion': 0})
 
         # check that we have the right number of steps and runs
-        self.assertEquals(17, FlowStep.objects.filter(run__flow=flow).count())
-        self.assertEquals(2, FlowRun.objects.filter(flow=flow).count())
+        self.assertEqual(17, FlowStep.objects.filter(run__flow=flow).count())
+        self.assertEqual(2, FlowRun.objects.filter(flow=flow).count())
 
         # now let's delete our contact, we'll still have one active node, but
         # our visit path counts will go down by two since he went there twice
         self.contact.release(self.user)
         (active, visited) = flow.get_activity()
-        self.assertEquals(1, len(active))
-        self.assertEquals(1, visited[msg_to_color_step])
-        self.assertEquals(1, visited[other_rule_to_msg])
+        self.assertEqual(1, len(active))
+        self.assertEqual(1, visited[msg_to_color_step])
+        self.assertEqual(1, visited[other_rule_to_msg])
 
         # he was also accounting for our completion rate, back to nothing
         self.assertEqual(flow.get_run_stats(),
@@ -5075,7 +5075,7 @@ class FlowsTest(FlowFileTest):
         self.send_message(flow, 'Turbo King', contact=ryan)
         self.send_message(flow, 'Ryan Lewis', contact=ryan)
         (active, visited) = flow.get_activity()
-        self.assertEquals(0, len(active))
+        self.assertEqual(0, len(active))
         self.assertEqual(flow.get_run_stats(),
                          {'total': 1, 'active': 0, 'completed': 1, 'expired': 0, 'interrupted': 0, 'completion': 100})
 
@@ -5095,9 +5095,9 @@ class FlowsTest(FlowFileTest):
 
         # our flow stats should be unchanged
         (active, visited) = flow.get_activity()
-        self.assertEquals(0, len(active))
-        self.assertEquals(1, visited[msg_to_color_step])
-        self.assertEquals(1, visited[other_rule_to_msg])
+        self.assertEqual(0, len(active))
+        self.assertEqual(1, visited[msg_to_color_step])
+        self.assertEqual(1, visited[other_rule_to_msg])
         self.assertEqual(flow.get_run_stats(),
                          {'total': 1, 'active': 0, 'completed': 1, 'expired': 0, 'interrupted': 0, 'completion': 100})
 
@@ -5108,37 +5108,37 @@ class FlowsTest(FlowFileTest):
         # try the same thing after squashing
         squash_flowpathcounts()
         visited = flow.get_activity()[1]
-        self.assertEquals(1, visited[msg_to_color_step])
-        self.assertEquals(1, visited[other_rule_to_msg])
+        self.assertEqual(1, visited[msg_to_color_step])
+        self.assertEqual(1, visited[other_rule_to_msg])
 
         # but hammer should have created some simulation activity
         (active, visited) = flow.get_activity(simulation=True)
-        self.assertEquals(0, len(active))
-        self.assertEquals(2, visited[msg_to_color_step])
-        self.assertEquals(2, visited[other_rule_to_msg])
+        self.assertEqual(0, len(active))
+        self.assertEqual(2, visited[msg_to_color_step])
+        self.assertEqual(2, visited[other_rule_to_msg])
 
         # delete our last contact to make sure activity is gone without first expiring, zeros abound
         ryan.release(self.admin)
         (active, visited) = flow.get_activity()
-        self.assertEquals(0, len(active))
-        self.assertEquals(0, visited[msg_to_color_step])
-        self.assertEquals(0, visited[other_rule_to_msg])
+        self.assertEqual(0, len(active))
+        self.assertEqual(0, visited[msg_to_color_step])
+        self.assertEqual(0, visited[other_rule_to_msg])
 
         self.assertEqual(flow.get_run_stats(),
                          {'total': 0, 'active': 0, 'completed': 0, 'expired': 0, 'interrupted': 0, 'completion': 0})
 
         # runs and steps all gone too
-        self.assertEquals(0, FlowStep.objects.filter(run__flow=flow, contact__is_test=False).count())
-        self.assertEquals(0, FlowRun.objects.filter(flow=flow, contact__is_test=False).count())
+        self.assertEqual(0, FlowStep.objects.filter(run__flow=flow, contact__is_test=False).count())
+        self.assertEqual(0, FlowRun.objects.filter(flow=flow, contact__is_test=False).count())
 
         # test that expirations remove activity when triggered from the cron in the same way
         tupac = self.create_contact('Tupac Shakur', '+12065550725')
         self.send_message(flow, 'azul', contact=tupac)
         (active, visited) = flow.get_activity()
-        self.assertEquals(1, len(active))
-        self.assertEquals(1, active[color.uuid])
-        self.assertEquals(1, visited[other_rule_to_msg])
-        self.assertEquals(1, visited[msg_to_color_step])
+        self.assertEqual(1, len(active))
+        self.assertEqual(1, active[color.uuid])
+        self.assertEqual(1, visited[other_rule_to_msg])
+        self.assertEqual(1, visited[msg_to_color_step])
         self.assertEqual(flow.get_run_stats(),
                          {'total': 1, 'active': 1, 'completed': 0, 'expired': 0, 'interrupted': 0, 'completion': 0})
 
@@ -5151,7 +5151,7 @@ class FlowsTest(FlowFileTest):
         from .tasks import check_flows_task
         check_flows_task()
         (active, visited) = flow.get_activity()
-        self.assertEquals(0, len(active))
+        self.assertEqual(0, len(active))
         self.assertEqual(flow.get_run_stats(),
                          {'total': 1, 'active': 0, 'completed': 0, 'expired': 1, 'interrupted': 0, 'completion': 0})
 
@@ -5248,18 +5248,18 @@ class FlowsTest(FlowFileTest):
         start = ActionSet.objects.get(flow=flow, y=0)
 
         # assert our destination
-        self.assertEquals(FlowStep.TYPE_RULE_SET, start.destination_type)
+        self.assertEqual(FlowStep.TYPE_RULE_SET, start.destination_type)
 
         # and that ruleset points to an actionset
         ruleset = RuleSet.objects.get(uuid=start.destination)
         rule = ruleset.get_rules()[0]
-        self.assertEquals(FlowStep.TYPE_ACTION_SET, rule.destination_type)
+        self.assertEqual(FlowStep.TYPE_ACTION_SET, rule.destination_type)
 
         # point our rule to a ruleset
         passive = RuleSet.objects.get(flow=flow, label='passive')
         self.update_destination(flow, rule.uuid, passive.uuid)
         ruleset = RuleSet.objects.get(uuid=start.destination)
-        self.assertEquals(FlowStep.TYPE_RULE_SET, ruleset.get_rules()[0].destination_type)
+        self.assertEqual(FlowStep.TYPE_RULE_SET, ruleset.get_rules()[0].destination_type)
 
     def test_orphaned_action_to_action(self):
         """
@@ -5268,7 +5268,7 @@ class FlowsTest(FlowFileTest):
 
         # run a flow that ends on an action
         flow = self.get_flow('pick_a_number')
-        self.assertEquals("You picked 3!", self.send_message(flow, "3"))
+        self.assertEqual("You picked 3!", self.send_message(flow, "3"))
 
         pick_a_number = ActionSet.objects.get(flow=flow, y=0)
         you_picked = ActionSet.objects.get(flow=flow, y=228)
@@ -5288,7 +5288,7 @@ class FlowsTest(FlowFileTest):
         """
         flow = self.get_flow('pick_a_number')
 
-        self.assertEquals("You picked 6!", self.send_message(flow, "6"))
+        self.assertEqual("You picked 6!", self.send_message(flow, "6"))
 
         you_picked = ActionSet.objects.get(flow=flow, y=228)
         number = RuleSet.objects.get(flow=flow, label='number')
@@ -5305,7 +5305,7 @@ class FlowsTest(FlowFileTest):
 
         you_picked = ActionSet.objects.get(flow=flow, y=228)
         passive_ruleset = RuleSet.objects.get(flow=flow, label='passive')
-        self.assertEquals("You picked 6!", self.send_message(flow, "6"))
+        self.assertEqual("You picked 6!", self.send_message(flow, "6"))
 
         flow = self.update_destination(flow, you_picked.uuid, passive_ruleset.uuid)
         self.send_message(flow, "9", assert_reply=False, assert_handle=False)
@@ -5386,12 +5386,12 @@ class FlowsTest(FlowFileTest):
 
     def test_decimal_substitution(self):
         flow = self.get_flow('pick_a_number')
-        self.assertEquals("You picked 3!", self.send_message(flow, "3"))
+        self.assertEqual("You picked 3!", self.send_message(flow, "3"))
 
     def test_rules_first(self):
         flow = self.get_flow('rules_first')
-        self.assertEquals(Flow.RULES_ENTRY, flow.entry_type)
-        self.assertEquals("You've got to be kitten me", self.send_message(flow, "cats"))
+        self.assertEqual(Flow.RULES_ENTRY, flow.entry_type)
+        self.assertEqual("You've got to be kitten me", self.send_message(flow, "cats"))
 
     def test_numeric_rule_allows_variables(self):
         flow = self.get_flow('numeric_rule_allows_variables')
@@ -5399,7 +5399,7 @@ class FlowsTest(FlowFileTest):
         zinedine = self.create_contact('Zinedine', '+123456')
         zinedine.set_field(self.user, 'age', 25)
 
-        self.assertEquals('Good count', self.send_message(flow, "35", contact=zinedine))
+        self.assertEqual('Good count', self.send_message(flow, "35", contact=zinedine))
 
     def test_non_blocking_rule_first(self):
 
@@ -5408,7 +5408,7 @@ class FlowsTest(FlowFileTest):
         eminem = self.create_contact('Eminem', '+12345')
         flow.start(groups=[], contacts=[eminem])
         msg = Msg.objects.filter(direction='O', contact=eminem).first()
-        self.assertEquals('Hi there Eminem', msg.text)
+        self.assertEqual('Hi there Eminem', msg.text)
 
         # put a webhook on the rule first and make sure it executes
         ruleset = RuleSet.objects.get(uuid=flow.entry_uuid)
@@ -5418,7 +5418,7 @@ class FlowsTest(FlowFileTest):
         tupac = self.create_contact('Tupac', '+15432')
         flow.start(groups=[], contacts=[tupac])
         msg = Msg.objects.filter(direction='O', contact=tupac).first()
-        self.assertEquals('Hi there Tupac', msg.text)
+        self.assertEqual('Hi there Tupac', msg.text)
 
     def test_webhook_rule_first(self):
 
@@ -5428,7 +5428,7 @@ class FlowsTest(FlowFileTest):
 
         # a message should have been sent
         msg = Msg.objects.filter(direction='O', contact=tupac).first()
-        self.assertEquals('Testing this out', msg.text)
+        self.assertEqual('Testing this out', msg.text)
 
     def test_group_uuid_mapping(self):
         flow = self.get_flow('group_split')
@@ -5498,11 +5498,11 @@ class FlowsTest(FlowFileTest):
         flow = self.get_flow('media_first_action')
 
         runs = flow.start_msg_flow([self.contact.id])
-        self.assertEquals(1, len(runs))
-        self.assertEquals(1, self.contact.msgs.all().count())
-        self.assertEquals('Hey', self.contact.msgs.all()[0].text)
-        self.assertEquals(["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, "attachments/2/53/steps/87d34837-491c-4541-98a1-fa75b52ebccc.jpg")],
-                          self.contact.msgs.all()[0].attachments)
+        self.assertEqual(1, len(runs))
+        self.assertEqual(1, self.contact.msgs.all().count())
+        self.assertEqual('Hey', self.contact.msgs.all()[0].text)
+        self.assertEqual(["image/jpeg:https://%s/%s" % (settings.AWS_BUCKET_DOMAIN, "attachments/2/53/steps/87d34837-491c-4541-98a1-fa75b52ebccc.jpg")],
+                         self.contact.msgs.all()[0].attachments)
 
     def test_substitution(self):
         flow = self.get_flow('substitution')
@@ -5511,13 +5511,13 @@ class FlowsTest(FlowFileTest):
         self.contact.save()
 
         runs = flow.start_msg_flow([self.contact.id])
-        self.assertEquals(1, len(runs))
-        self.assertEquals(1, self.contact.msgs.all().count())
-        self.assertEquals('Hi Ben Haggerty, what is your phone number?', self.contact.msgs.all()[0].text)
+        self.assertEqual(1, len(runs))
+        self.assertEqual(1, self.contact.msgs.all().count())
+        self.assertEqual('Hi Ben Haggerty, what is your phone number?', self.contact.msgs.all()[0].text)
 
-        self.assertEquals("Thanks, you typed +250788123123", self.send_message(flow, "0788123123"))
+        self.assertEqual("Thanks, you typed +250788123123", self.send_message(flow, "0788123123"))
         sms = Msg.objects.get(org=flow.org, contact__urns__path="+250788123123")
-        self.assertEquals("Hi from Ben Haggerty! Your phone is 0788 123 123.", sms.text)
+        self.assertEqual("Hi from Ben Haggerty! Your phone is 0788 123 123.", sms.text)
 
     def test_group_send(self):
         # create an inactive group with the same name, to test that this doesn't blow up our import
@@ -5535,13 +5535,13 @@ class FlowsTest(FlowFileTest):
         mother_flow = self.get_flow('mama_mother_registration')
         registration_flow = self.get_flow('mama_registration', dict(NEW_MOTHER_FLOW_ID=mother_flow.pk))
 
-        self.assertEquals("Enter the expected delivery date.", self.send_message(registration_flow, "Judy Pottier"))
-        self.assertEquals("Great, thanks for registering the new mother", self.send_message(registration_flow, "31.1.2015"))
+        self.assertEqual("Enter the expected delivery date.", self.send_message(registration_flow, "Judy Pottier"))
+        self.assertEqual("Great, thanks for registering the new mother", self.send_message(registration_flow, "31.1.2015"))
 
         mother = Contact.objects.get(org=self.org, name="Judy Pottier")
         self.assertTrue(mother.get_field_raw('edd').startswith('31-01-2015'))
-        self.assertEquals(mother.get_field_raw('chw_phone'), self.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(mother.get_field_raw('chw_name'), self.contact.name)
+        self.assertEqual(mother.get_field_raw('chw_phone'), self.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(mother.get_field_raw('chw_name'), self.contact.name)
 
     def test_group_rule_first(self):
         rule_flow = self.get_flow('group_rule_first')
@@ -5564,25 +5564,25 @@ class FlowsTest(FlowFileTest):
 
         self.assertEqual(mother_flow.runs.count(), 0)
 
-        self.assertEquals("What is her expected delivery date?", self.send_message(registration_flow, "Judy Pottier"))
-        self.assertEquals("What is her phone number?", self.send_message(registration_flow, "31.1.2014"))
-        self.assertEquals("Great, you've registered the new mother!", self.send_message(registration_flow, "0788 383 383"))
+        self.assertEqual("What is her expected delivery date?", self.send_message(registration_flow, "Judy Pottier"))
+        self.assertEqual("What is her phone number?", self.send_message(registration_flow, "31.1.2014"))
+        self.assertEqual("Great, you've registered the new mother!", self.send_message(registration_flow, "0788 383 383"))
 
         # we start both the new mother by @flow.phone and the current contact by its uuid @contact.uuid
         self.assertEqual(mother_flow.runs.count(), 2)
 
         mother = Contact.from_urn(self.org, "tel:+250788383383")
-        self.assertEquals("Judy Pottier", mother.name)
+        self.assertEqual("Judy Pottier", mother.name)
         self.assertTrue(mother.get_field_raw('expected_delivery_date').startswith('31-01-2014'))
-        self.assertEquals("+12065552020", mother.get_field_raw('chw'))
+        self.assertEqual("+12065552020", mother.get_field_raw('chw'))
         self.assertTrue(mother.user_groups.filter(name="Expecting Mothers"))
 
         pain_flow = self.get_flow('pain_flow')
-        self.assertEquals("Your CHW will be in contact soon!", self.send_message(pain_flow, "yes", contact=mother))
+        self.assertEqual("Your CHW will be in contact soon!", self.send_message(pain_flow, "yes", contact=mother))
 
         chw = self.contact
         sms = Msg.objects.filter(contact=chw).order_by('-created_on')[0]
-        self.assertEquals("Please follow up with Judy Pottier, she has reported she is in pain.", sms.text)
+        self.assertEqual("Please follow up with Judy Pottier, she has reported she is in pain.", sms.text)
 
     def test_flow_delete(self):
         from temba.campaigns.models import Campaign, CampaignEvent
@@ -5601,7 +5601,7 @@ class FlowsTest(FlowFileTest):
                                          created_by=self.admin, modified_by=self.admin)
 
         # run the flow
-        self.assertEquals("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "RED"))
+        self.assertEqual("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "RED"))
 
         # try to remove the flow, not logged in, no dice
         response = self.client.post(reverse('flows.flow_delete', args=[flow.pk]))
@@ -5655,7 +5655,7 @@ class FlowsTest(FlowFileTest):
         for contact in contacts:
             self.assertTrue(FlowRun.objects.filter(flow=parent, contact=contact))
             self.assertTrue(FlowRun.objects.filter(flow=child, contact=contact))
-            self.assertEquals("Greg", Contact.objects.get(pk=contact.pk).name)
+            self.assertEqual("Greg", Contact.objects.get(pk=contact.pk).name)
 
         # 10 child flow runs should be active waiting for input
         self.assertEqual(FlowRun.objects.filter(flow=child, is_active=True).count(), 10)
@@ -5677,15 +5677,15 @@ class FlowsTest(FlowFileTest):
         flow = Flow.objects.get(name='Multi Language Flow')
 
         # even tho we don't have a language, our flow has enough info to function
-        self.assertEquals('eng', flow.base_language)
+        self.assertEqual('eng', flow.base_language)
 
         # now try executing this flow on our org, should use the flow base language
-        self.assertEquals('Hello friend! What is your favorite color?',
-                          self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
+        self.assertEqual('Hello friend! What is your favorite color?',
+                         self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
 
         replies = self.send_message(flow, 'blue')
-        self.assertEquals('Thank you! I like blue.', replies[0])
-        self.assertEquals('This message was not translated.', replies[1])
+        self.assertEqual('Thank you! I like blue.', replies[0])
+        self.assertEqual('This message was not translated.', replies[1])
 
         # now add a primary language to our org
         self.org.primary_language = spanish
@@ -5694,16 +5694,16 @@ class FlowsTest(FlowFileTest):
         flow = Flow.objects.get(pk=flow.pk)
 
         # with our org in spanish, we should get the spanish version
-        self.assertEquals('\xa1Hola amigo! \xbfCu\xe1l es tu color favorito?',
-                          self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
+        self.assertEqual('\xa1Hola amigo! \xbfCu\xe1l es tu color favorito?',
+                         self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
 
         self.org.primary_language = None
         self.org.save()
         flow = Flow.objects.get(pk=flow.pk)
 
         # no longer spanish on our org
-        self.assertEquals('Hello friend! What is your favorite color?',
-                          self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
+        self.assertEqual('Hello friend! What is your favorite color?',
+                         self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
 
         # back to spanish
         self.org.primary_language = spanish
@@ -5713,8 +5713,8 @@ class FlowsTest(FlowFileTest):
         # but set our contact's language explicitly should keep us at english
         self.contact.language = 'eng'
         self.contact.save()
-        self.assertEquals('Hello friend! What is your favorite color?',
-                          self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
+        self.assertEqual('Hello friend! What is your favorite color?',
+                         self.send_message(flow, 'start flow', restart_participants=True, initiate_flow=True))
 
     def test_different_expiration(self):
         flow = self.get_flow('favorites')
@@ -5734,7 +5734,7 @@ class FlowsTest(FlowFileTest):
         self.assertFalse(first_run.is_active)
 
         # expires on shouldn't have changed on it though
-        self.assertEquals(first_expires, first_run.expires_on)
+        self.assertEqual(first_expires, first_run.expires_on)
 
         # new run should have a different expires on
         new_run = flow.runs.all().order_by('-expires_on').first()
@@ -5742,11 +5742,11 @@ class FlowsTest(FlowFileTest):
 
     def test_flow_expiration_updates(self):
         flow = self.get_flow('favorites')
-        self.assertEquals("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "RED"))
+        self.assertEqual("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "RED"))
 
         # get our current expiration
         run = flow.runs.get()
-        self.assertEquals(flow.org, run.org)
+        self.assertEqual(flow.org, run.org)
 
         starting_expiration = run.expires_on
         starting_modified = run.modified_on
@@ -5754,8 +5754,8 @@ class FlowsTest(FlowFileTest):
         time.sleep(1)
 
         # now fire another messages
-        self.assertEquals("Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?",
-                          self.send_message(flow, "turbo"))
+        self.assertEqual("Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?",
+                         self.send_message(flow, "turbo"))
 
         # our new expiration should be later
         run.refresh_from_db()
@@ -5771,9 +5771,9 @@ class FlowsTest(FlowFileTest):
 
     def test_flow_expiration(self):
         flow = self.get_flow('favorites')
-        self.assertEquals("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "RED"))
-        self.assertEquals("Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?", self.send_message(flow, "turbo"))
-        self.assertEquals(1, flow.runs.count())
+        self.assertEqual("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "RED"))
+        self.assertEqual("Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?", self.send_message(flow, "turbo"))
+        self.assertEqual(1, flow.runs.count())
 
         # pretend our step happened 10 minutes ago
         step = FlowStep.objects.filter(run=flow.runs.all()[0], left_on=None)[0]
@@ -5792,9 +5792,9 @@ class FlowsTest(FlowFileTest):
         self.assertFalse(run.is_active)
 
         # we will be starting a new run now, since the other expired
-        self.assertEquals("I don't know that color. Try again.",
-                          self.send_message(flow, "Michael Jordan", restart_participants=True))
-        self.assertEquals(2, flow.runs.count())
+        self.assertEqual("I don't know that color. Try again.",
+                         self.send_message(flow, "Michael Jordan", restart_participants=True))
+        self.assertEqual(2, flow.runs.count())
 
         previous_expiration = run.expires_on
         run.update_expiration(None)
@@ -5803,7 +5803,7 @@ class FlowsTest(FlowFileTest):
     def test_parsing(self):
         # test a preprocess url
         flow = self.get_flow('preprocess')
-        self.assertEquals('http://preprocessor.com/endpoint.php', flow.rule_sets.all().order_by('y')[0].config_json()[RuleSet.CONFIG_WEBHOOK])
+        self.assertEqual('http://preprocessor.com/endpoint.php', flow.rule_sets.all().order_by('y')[0].config_json()[RuleSet.CONFIG_WEBHOOK])
 
     def test_flow_loops(self):
         # this tests two flows that start each other
@@ -5852,7 +5852,7 @@ class FlowsTest(FlowFileTest):
         CampaignEvent.create_flow_event(self.org, self.admin, campaign, relative_to=field,
                                         offset=10, unit='W', flow=favorites)
 
-        self.assertEquals("Added to campaign.", self.send_message(parent, "start", initiate_flow=True))
+        self.assertEqual("Added to campaign.", self.send_message(parent, "start", initiate_flow=True))
 
         # should have one event scheduled for this contact
         self.assertTrue(EventFire.objects.filter(contact=self.contact))
@@ -6128,17 +6128,17 @@ class FlowsTest(FlowFileTest):
         # start our flow without a message (simulating it being fired by a trigger or the simulator)
         # this will evaluate requires_step() to make sure it handles localized flows
         runs = flow.start_msg_flow([self.contact.id])
-        self.assertEquals(1, len(runs))
-        self.assertEquals(1, self.contact.msgs.all().count())
-        self.assertEquals('You are not in the enrolled group.', self.contact.msgs.all()[0].text)
+        self.assertEqual(1, len(runs))
+        self.assertEqual(1, self.contact.msgs.all().count())
+        self.assertEqual('You are not in the enrolled group.', self.contact.msgs.all()[0].text)
 
         enrolled_group = ContactGroup.create_static(self.org, self.user, "Enrolled")
         enrolled_group.update_contacts(self.user, [self.contact], True)
 
         runs_started = flow.start_msg_flow([self.contact.id])
-        self.assertEquals(1, len(runs_started))
-        self.assertEquals(2, self.contact.msgs.all().count())
-        self.assertEquals('You are in the enrolled group.', self.contact.msgs.all().order_by('-pk')[0].text)
+        self.assertEqual(1, len(runs_started))
+        self.assertEqual(2, self.contact.msgs.all().count())
+        self.assertEqual('You are in the enrolled group.', self.contact.msgs.all().order_by('-pk')[0].text)
 
     def test_translations(self):
 
@@ -6152,7 +6152,7 @@ class FlowsTest(FlowFileTest):
         self.org.save()
 
         # everything should work as normal with our flow
-        self.assertEquals("What is your favorite color?", self.send_message(favorites, "favorites", initiate_flow=True))
+        self.assertEqual("What is your favorite color?", self.send_message(favorites, "favorites", initiate_flow=True))
         json_dict = favorites.as_json()
         reply = json_dict['action_sets'][0]['actions'][0]
 
@@ -6163,13 +6163,13 @@ class FlowsTest(FlowFileTest):
         # now our replies are language dicts
         json_dict = favorites.as_json()
         reply = json_dict['action_sets'][1]['actions'][0]
-        self.assertEquals('Good choice, I like @flow.color.category too! What is your favorite beer?', reply['msg']['base'])
+        self.assertEqual('Good choice, I like @flow.color.category too! What is your favorite beer?', reply['msg']['base'])
 
         # now interact with the flow and make sure we get an appropriate response
         FlowRun.objects.all().delete()
 
-        self.assertEquals("What is your favorite color?", self.send_message(favorites, "favorites", initiate_flow=True))
-        self.assertEquals("Good choice, I like Red too! What is your favorite beer?", self.send_message(favorites, "RED"))
+        self.assertEqual("What is your favorite color?", self.send_message(favorites, "favorites", initiate_flow=True))
+        self.assertEqual("Good choice, I like Red too! What is your favorite beer?", self.send_message(favorites, "RED"))
 
         # now let's add a second language
         Language.create(self.org, favorites.created_by, "Klingon", 'kli')
@@ -6184,20 +6184,20 @@ class FlowsTest(FlowFileTest):
         json_dict['action_sets'][1]['actions'][0] = reply
 
         # save the changes
-        self.assertEquals('success', favorites.update(json_dict, self.admin)['status'])
+        self.assertEqual('success', favorites.update(json_dict, self.admin)['status'])
 
         # should get org primary language (english) since our contact has no preferred language
         FlowRun.objects.all().delete()
-        self.assertEquals("What is your favorite color?", self.send_message(favorites, "favorite", initiate_flow=True))
-        self.assertEquals("Good choice, I like Red too! What is your favorite beer?", self.send_message(favorites, "RED"))
+        self.assertEqual("What is your favorite color?", self.send_message(favorites, "favorite", initiate_flow=True))
+        self.assertEqual("Good choice, I like Red too! What is your favorite beer?", self.send_message(favorites, "RED"))
 
         # now set our contact's preferred language to klingon
         FlowRun.objects.all().delete()
         self.contact.language = 'kli'
         self.contact.save()
 
-        self.assertEquals("Kikshtik derklop?", self.send_message(favorites, "favorite", initiate_flow=True))
-        self.assertEquals("Katishklick Shnik Red Errrrrrrrklop", self.send_message(favorites, "RED"))
+        self.assertEqual("Kikshtik derklop?", self.send_message(favorites, "favorite", initiate_flow=True))
+        self.assertEqual("Katishklick Shnik Red Errrrrrrrklop", self.send_message(favorites, "RED"))
 
         # we support localized rules and categories as well
         json_dict = favorites.as_json()
@@ -6206,10 +6206,10 @@ class FlowsTest(FlowFileTest):
         rule['test']['test']['kli'] = 'klerk'
         rule['category']['kli'] = 'Klerkistikloperopikshtop'
         json_dict['rule_sets'][0]['rules'][0] = rule
-        self.assertEquals('success', favorites.update(json_dict, self.admin)['status'])
+        self.assertEqual('success', favorites.update(json_dict, self.admin)['status'])
 
         FlowRun.objects.all().delete()
-        self.assertEquals("Katishklick Shnik Klerkistikloperopikshtop Errrrrrrrklop", self.send_message(favorites, "klerk"))
+        self.assertEqual("Katishklick Shnik Klerkistikloperopikshtop Errrrrrrrklop", self.send_message(favorites, "klerk"))
 
         # test the send action as well
         json_dict = favorites.as_json()
@@ -6219,12 +6219,12 @@ class FlowsTest(FlowFileTest):
         action['groups'] = []
         action['variables'] = []
         json_dict['action_sets'][1]['actions'][0] = action
-        self.assertEquals('success', favorites.update(json_dict, self.admin)['status'])
+        self.assertEqual('success', favorites.update(json_dict, self.admin)['status'])
 
         FlowRun.objects.all().delete()
         self.send_message(favorites, "klerk", assert_reply=False)
         sms = Msg.objects.filter(contact=self.contact).order_by('-pk')[0]
-        self.assertEquals("Katishklick Shnik Klerkistikloperopikshtop Errrrrrrrklop", sms.text)
+        self.assertEqual("Katishklick Shnik Klerkistikloperopikshtop Errrrrrrrklop", sms.text)
 
         # test dirty json
         json_dict = favorites.as_json()
@@ -6238,22 +6238,22 @@ class FlowsTest(FlowFileTest):
         rule['category']['updated'] = True
 
         response = favorites.update(json_dict)
-        self.assertEquals('success', response['status'])
+        self.assertEqual('success', response['status'])
 
         favorites = Flow.objects.get(pk=favorites.pk)
         json_dict = favorites.as_json()
-        action = self.assertEquals('Bleck', json_dict['action_sets'][0]['actions'][0]['msg']['kli'])
+        action = self.assertEqual('Bleck', json_dict['action_sets'][0]['actions'][0]['msg']['kli'])
 
         # test that simulation takes language into account
         self.login(self.admin)
         simulate_url = reverse('flows.flow_simulate', args=[favorites.pk])
         response = json.loads(self.client.post(simulate_url, json.dumps(dict(has_refresh=True)), content_type="application/json").content)
-        self.assertEquals('What is your favorite color?', response['messages'][1]['text'])
+        self.assertEqual('What is your favorite color?', response['messages'][1]['text'])
 
         # now lets toggle the UI to Klingon and try the same thing
         simulate_url = "%s?lang=kli" % reverse('flows.flow_simulate', args=[favorites.pk])
         response = json.loads(self.client.post(simulate_url, json.dumps(dict(has_refresh=True)), content_type="application/json").content)
-        self.assertEquals('Bleck', response['messages'][1]['text'])
+        self.assertEqual('Bleck', response['messages'][1]['text'])
 
     def test_interrupted_state(self):
         self.channel.delete()
@@ -6324,9 +6324,9 @@ class FlowsTest(FlowFileTest):
             mock_trigger_event.return_value = airtime_event
 
             runs = flow.start_msg_flow([self.contact.id])
-            self.assertEquals(1, len(runs))
-            self.assertEquals(1, self.contact.msgs.all().count())
-            self.assertEquals('Message complete', self.contact.msgs.all()[0].text)
+            self.assertEqual(1, len(runs))
+            self.assertEqual(1, self.contact.msgs.all().count())
+            self.assertEqual('Message complete', self.contact.msgs.all()[0].text)
 
             airtime_event.status = AirtimeTransfer.FAILED
             airtime_event.save()
@@ -6334,9 +6334,9 @@ class FlowsTest(FlowFileTest):
             mock_trigger_event.return_value = airtime_event
 
             runs = flow.start_msg_flow([self.contact.id])
-            self.assertEquals(1, len(runs))
-            self.assertEquals(2, self.contact.msgs.all().count())
-            self.assertEquals('Message failed', self.contact.msgs.all()[0].text)
+            self.assertEqual(1, len(runs))
+            self.assertEqual(2, self.contact.msgs.all().count())
+            self.assertEqual('Message failed', self.contact.msgs.all()[0].text)
 
     @patch('temba.airtime.models.AirtimeTransfer.post_transferto_api_response')
     def test_airtime_trigger_event(self, mock_post_transferto):
@@ -6352,11 +6352,11 @@ class FlowsTest(FlowFileTest):
 
         flow = self.get_flow('airtime')
         runs = flow.start_msg_flow([self.contact.id])
-        self.assertEquals(1, len(runs))
-        self.assertEquals(1, self.contact.msgs.all().count())
-        self.assertEquals('Message complete', self.contact.msgs.all()[0].text)
+        self.assertEqual(1, len(runs))
+        self.assertEqual(1, self.contact.msgs.all().count())
+        self.assertEqual('Message complete', self.contact.msgs.all()[0].text)
 
-        self.assertEquals(1, AirtimeTransfer.objects.all().count())
+        self.assertEqual(1, AirtimeTransfer.objects.all().count())
         airtime = AirtimeTransfer.objects.all().first()
         self.assertEqual(airtime.status, AirtimeTransfer.SUCCESS)
         self.assertEqual(airtime.contact, self.contact)
@@ -6371,11 +6371,11 @@ class FlowsTest(FlowFileTest):
                                             MockResponse(200, "error_code=0\r\nerror_txt=\r\n")]
 
         runs = flow.start_msg_flow([self.contact.id])
-        self.assertEquals(1, len(runs))
-        self.assertEquals(2, self.contact.msgs.all().count())
-        self.assertEquals('Message failed', self.contact.msgs.all()[0].text)
+        self.assertEqual(1, len(runs))
+        self.assertEqual(2, self.contact.msgs.all().count())
+        self.assertEqual('Message failed', self.contact.msgs.all()[0].text)
 
-        self.assertEquals(2, AirtimeTransfer.objects.all().count())
+        self.assertEqual(2, AirtimeTransfer.objects.all().count())
         airtime = AirtimeTransfer.objects.all().last()
         self.assertEqual(airtime.status, AirtimeTransfer.FAILED)
         self.assertEqual(airtime.message, "Error transferring airtime: Failed by invalid amount "
@@ -6393,21 +6393,21 @@ class FlowsTest(FlowFileTest):
         test_contact = Contact.get_test_contact(self.admin)
 
         runs = flow.start_msg_flow([test_contact.id])
-        self.assertEquals(1, len(runs))
+        self.assertEqual(1, len(runs))
 
         # no saved airtime event in DB
-        self.assertEquals(2, AirtimeTransfer.objects.all().count())
+        self.assertEqual(2, AirtimeTransfer.objects.all().count())
         self.assertEqual(mock_post_transferto.call_count, 0)
 
         contact2 = self.create_contact(name='Bismack Biyombo', number='+250788123123', twitter='biyombo')
         self.assertEqual(contact2.get_urn().path, 'biyombo')
 
         runs = flow.start_msg_flow([contact2.id])
-        self.assertEquals(1, len(runs))
-        self.assertEquals(1, contact2.msgs.all().count())
-        self.assertEquals('Message complete', contact2.msgs.all()[0].text)
+        self.assertEqual(1, len(runs))
+        self.assertEqual(1, contact2.msgs.all().count())
+        self.assertEqual('Message complete', contact2.msgs.all()[0].text)
 
-        self.assertEquals(3, AirtimeTransfer.objects.all().count())
+        self.assertEqual(3, AirtimeTransfer.objects.all().count())
         airtime = AirtimeTransfer.objects.all().last()
         self.assertEqual(airtime.status, AirtimeTransfer.SUCCESS)
         self.assertEqual(airtime.recipient, '+250788123123')
@@ -6424,11 +6424,11 @@ class FlowsTest(FlowFileTest):
                                             MockResponse(200, "error_code=0\r\nerror_txt=\r\n")]
 
         runs = flow.start_msg_flow([self.contact.id])
-        self.assertEquals(1, len(runs))
-        self.assertEquals(3, self.contact.msgs.all().count())
-        self.assertEquals('Message failed', self.contact.msgs.all()[0].text)
+        self.assertEqual(1, len(runs))
+        self.assertEqual(3, self.contact.msgs.all().count())
+        self.assertEqual('Message failed', self.contact.msgs.all()[0].text)
 
-        self.assertEquals(4, AirtimeTransfer.objects.all().count())
+        self.assertEqual(4, AirtimeTransfer.objects.all().count())
         airtime = AirtimeTransfer.objects.all().last()
         self.assertEqual(airtime.status, AirtimeTransfer.FAILED)
         self.assertEqual(airtime.contact, self.contact)
@@ -6555,12 +6555,12 @@ class FlowMigrationTest(FlowFileTest):
 
         # and that the format looks correct
         flow_json = flow.as_json()
-        self.assertEquals(flow_json['metadata']['name'], 'Call Me Maybe')
-        self.assertEquals(flow_json['metadata']['revision'], 2)
-        self.assertEquals(flow_json['metadata']['expires'], 720)
-        self.assertEquals(flow_json['base_language'], 'base')
-        self.assertEquals(5, len(flow_json['action_sets']))
-        self.assertEquals(1, len(flow_json['rule_sets']))
+        self.assertEqual(flow_json['metadata']['name'], 'Call Me Maybe')
+        self.assertEqual(flow_json['metadata']['revision'], 2)
+        self.assertEqual(flow_json['metadata']['expires'], 720)
+        self.assertEqual(flow_json['base_language'], 'base')
+        self.assertEqual(5, len(flow_json['action_sets']))
+        self.assertEqual(1, len(flow_json['rule_sets']))
 
     @override_settings(SEND_WEBHOOKS=True)
     def test_migrate_to_10(self):
@@ -6638,8 +6638,8 @@ class FlowMigrationTest(FlowFileTest):
 
         # check that contacts migrated properly
         send_action = flow_json['action_sets'][0]['actions'][1]
-        self.assertEquals(1, len(send_action['contacts']))
-        self.assertEquals(1, len(send_action['groups']))
+        self.assertEqual(1, len(send_action['contacts']))
+        self.assertEqual(1, len(send_action['groups']))
 
         for contact in send_action['contacts']:
             self.assertIn('uuid', contact)
@@ -6731,18 +6731,18 @@ class FlowMigrationTest(FlowFileTest):
         flow_json = migrate_to_version_6(flow_json)
 
         self.assertIsNotNone(flow_json.get('definition'))
-        self.assertEquals('Call me maybe', flow_json.get('name'))
-        self.assertEquals(100, flow_json.get('id'))
-        self.assertEquals('V', flow_json.get('flow_type'))
+        self.assertEqual('Call me maybe', flow_json.get('name'))
+        self.assertEqual(100, flow_json.get('id'))
+        self.assertEqual('V', flow_json.get('flow_type'))
 
         flow_json = migrate_to_version_7(flow_json)
         self.assertIsNone(flow_json.get('definition', None))
         self.assertIsNotNone(flow_json.get('metadata', None))
 
         metadata = flow_json.get('metadata')
-        self.assertEquals('Call me maybe', metadata['name'])
-        self.assertEquals(100, metadata['id'])
-        self.assertEquals('V', flow_json.get('flow_type'))
+        self.assertEqual('Call me maybe', metadata['name'])
+        self.assertEqual(100, metadata['id'])
+        self.assertEqual('V', flow_json.get('flow_type'))
 
     def test_migrate_to_6(self):
 
@@ -6752,8 +6752,8 @@ class FlowMigrationTest(FlowFileTest):
 
         # no language set
         self.assertIsNone(definition.get('base_language', None))
-        self.assertEquals('Yes', definition['rule_sets'][0]['rules'][0]['category'])
-        self.assertEquals('Press one, two, or three. Thanks.', definition['action_sets'][0]['actions'][0]['msg'])
+        self.assertEqual('Yes', definition['rule_sets'][0]['rules'][0]['category'])
+        self.assertEqual('Press one, two, or three. Thanks.', definition['action_sets'][0]['actions'][0]['msg'])
 
         # add a recording to make sure that gets migrated properly too
         definition['action_sets'][0]['actions'][0]['recording'] = '/recording.mp3'
@@ -6763,10 +6763,10 @@ class FlowMigrationTest(FlowFileTest):
         definition = voice_json.get('definition')
 
         # now we should have a language
-        self.assertEquals('base', definition.get('base_language', None))
-        self.assertEquals('Yes', definition['rule_sets'][0]['rules'][0]['category']['base'])
-        self.assertEquals('Press one, two, or three. Thanks.', definition['action_sets'][0]['actions'][0]['msg']['base'])
-        self.assertEquals('/recording.mp3', definition['action_sets'][0]['actions'][0]['recording']['base'])
+        self.assertEqual('base', definition.get('base_language', None))
+        self.assertEqual('Yes', definition['rule_sets'][0]['rules'][0]['category']['base'])
+        self.assertEqual('Press one, two, or three. Thanks.', definition['action_sets'][0]['actions'][0]['msg']['base'])
+        self.assertEqual('/recording.mp3', definition['action_sets'][0]['actions'][0]['recording']['base'])
 
         # now try one that doesn't have a recording set
         voice_json = self.get_flow_json('call_me_maybe')
@@ -6797,9 +6797,9 @@ class FlowMigrationTest(FlowFileTest):
         self.assertIsNotNone(wait_ruleset)
         self.assertIsNotNone(rules)
 
-        self.assertEquals(1, len(rules))
-        self.assertEquals('All Responses', rules[0]['category']['eng'])
-        self.assertEquals('Otro', rules[0]['category']['spa'])
+        self.assertEqual(1, len(rules))
+        self.assertEqual('All Responses', rules[0]['category']['eng'])
+        self.assertEqual('Otro', rules[0]['category']['spa'])
 
     @override_settings(SEND_WEBHOOKS=True)
     def test_migrate_to_5(self):
@@ -6811,7 +6811,7 @@ class FlowMigrationTest(FlowFileTest):
         # we should be sitting at the ruleset waiting for a message
         step = FlowStep.objects.get(run__flow=flow, step_type='R')
         ruleset = RuleSet.objects.get(uuid=step.step_uuid)
-        self.assertEquals('wait_message', ruleset.ruleset_type)
+        self.assertEqual('wait_message', ruleset.ruleset_type)
 
         # fake a version 4 flow
         RuleSet.objects.filter(flow=flow).update(response_type='C', ruleset_type=None)
@@ -6835,37 +6835,37 @@ class FlowMigrationTest(FlowFileTest):
 
         # we should be sitting at a wait node
         ruleset = RuleSet.objects.get(uuid=step.step_uuid)
-        self.assertEquals('wait_message', ruleset.ruleset_type)
-        self.assertEquals('@step.value', ruleset.operand)
+        self.assertEqual('wait_message', ruleset.ruleset_type)
+        self.assertEqual('@step.value', ruleset.operand)
 
         # we should be pointing to a newly created webhook rule
         webhook = RuleSet.objects.get(flow=flow, uuid=ruleset.get_rules()[0].destination)
-        self.assertEquals('webhook', webhook.ruleset_type)
-        self.assertEquals('http://localhost:49999/echo?content=%7B%20%22status%22%3A%20%22valid%22%20%7D', webhook.config_json()[RuleSet.CONFIG_WEBHOOK])
-        self.assertEquals('POST', webhook.config_json()[RuleSet.CONFIG_WEBHOOK_ACTION])
-        self.assertEquals('@step.value', webhook.operand)
-        self.assertEquals('Color Webhook', webhook.label)
+        self.assertEqual('webhook', webhook.ruleset_type)
+        self.assertEqual('http://localhost:49999/echo?content=%7B%20%22status%22%3A%20%22valid%22%20%7D', webhook.config_json()[RuleSet.CONFIG_WEBHOOK])
+        self.assertEqual('POST', webhook.config_json()[RuleSet.CONFIG_WEBHOOK_ACTION])
+        self.assertEqual('@step.value', webhook.operand)
+        self.assertEqual('Color Webhook', webhook.label)
 
         # which should in turn point to a new expression split on @extra.value
         expression = RuleSet.objects.get(flow=flow, uuid=webhook.get_rules()[0].destination)
-        self.assertEquals('expression', expression.ruleset_type)
-        self.assertEquals('@extra.value', expression.operand)
+        self.assertEqual('expression', expression.ruleset_type)
+        self.assertEqual('@extra.value', expression.operand)
 
         # takes us to the next question
         beer_question = ActionSet.objects.get(flow=flow, uuid=expression.get_rules()[0].destination)
 
         # which should pause for the response
         wait_beer = RuleSet.objects.get(flow=flow, uuid=beer_question.destination)
-        self.assertEquals('wait_message', wait_beer.ruleset_type)
-        self.assertEquals('@step.value', wait_beer.operand)
-        self.assertEquals(1, len(wait_beer.get_rules()))
-        self.assertEquals('All Responses', wait_beer.get_rules()[0].category[flow.base_language])
+        self.assertEqual('wait_message', wait_beer.ruleset_type)
+        self.assertEqual('@step.value', wait_beer.operand)
+        self.assertEqual(1, len(wait_beer.get_rules()))
+        self.assertEqual('All Responses', wait_beer.get_rules()[0].category[flow.base_language])
 
         # and then split on the expression for various beer choices
         beer_expression = RuleSet.objects.get(flow=flow, uuid=wait_beer.get_rules()[0].destination)
-        self.assertEquals('expression', beer_expression.ruleset_type)
-        self.assertEquals('@(LOWER(step.value))', beer_expression.operand)
-        self.assertEquals(5, len(beer_expression.get_rules()))
+        self.assertEqual('expression', beer_expression.ruleset_type)
+        self.assertEqual('@(LOWER(step.value))', beer_expression.operand)
+        self.assertEqual(5, len(beer_expression.get_rules()))
 
         # set our expression to operate on the last inbound message
         expression.operand = '@step.value'
@@ -6880,14 +6880,14 @@ class FlowMigrationTest(FlowFileTest):
         first_response.save()
 
         reply = self.send_message(flow, 'red')
-        self.assertEquals('I like Red too! What is your favorite beer? { "status": "valid" }', reply)
+        self.assertEqual('I like Red too! What is your favorite beer? { "status": "valid" }', reply)
 
         reply = self.send_message(flow, 'Turbo King')
-        self.assertEquals('Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?', reply)
+        self.assertEqual('Mmmmm... delicious Turbo King. If only they made red Turbo King! Lastly, what is your name?', reply)
 
     def test_migrate_sample_flows(self):
         self.org.create_sample_flows('https://app.rapidpro.io')
-        self.assertEquals(3, self.org.flows.filter(name__icontains='Sample Flow').count())
+        self.assertEqual(3, self.org.flows.filter(name__icontains='Sample Flow').count())
 
         # make sure it is localized
         poll = self.org.flows.filter(name='Sample Flow - Simple Poll').first()
@@ -6908,21 +6908,21 @@ class DuplicateValueTest(FlowFileTest):
 
     def test_duplicate_value_test(self):
         flow = self.get_flow('favorites')
-        self.assertEquals("I don't know that color. Try again.", self.send_message(flow, "carpet"))
+        self.assertEqual("I don't know that color. Try again.", self.send_message(flow, "carpet"))
 
         # get the run for our contact
         run = FlowRun.objects.get(contact=self.contact, flow=flow)
 
         # we should have one value for this run, "Other"
         value = Value.objects.get(run=run)
-        self.assertEquals("Other", value.category)
+        self.assertEqual("Other", value.category)
 
         # retry with "red" as an aswer
-        self.assertEquals("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "red"))
+        self.assertEqual("Good choice, I like Red too! What is your favorite beer?", self.send_message(flow, "red"))
 
         # we should now still have only one value, but the category should be Red now
         value = Value.objects.get(run=run)
-        self.assertEquals("Red", value.category)
+        self.assertEqual("Red", value.category)
 
 
 class ChannelSplitTest(FlowFileTest):
@@ -6981,13 +6981,13 @@ class WebhookLoopTest(FlowFileTest):
     def test_webhook_loop(self):
         flow = self.get_flow('webhook_loop')
 
-        self.assertEquals("first message", self.send_message(flow, "first", initiate_flow=True))
+        self.assertEqual("first message", self.send_message(flow, "first", initiate_flow=True))
 
         flow_def = flow.as_json()
         flow_def['action_sets'][0]['actions'][0]['webhook'] = self.mockedServerURL('{ "text": "second message" }')
         flow.update(flow_def)
 
-        self.assertEquals("second message", self.send_message(flow, "second"))
+        self.assertEqual("second message", self.send_message(flow, "second"))
 
 
 class MissedCallChannelTest(FlowFileTest):
@@ -7016,14 +7016,14 @@ class MissedCallChannelTest(FlowFileTest):
 
         # should have sent a message to the user
         msg = Msg.objects.get(contact=call.contact, channel=self.channel)
-        self.assertEquals(msg.text, "Matched +250785551212")
+        self.assertEqual(msg.text, "Matched +250785551212")
 
         # try the same thing with a contact trigger (same as missed calls via twilio)
         Trigger.catch_triggers(msg.contact, Trigger.TYPE_MISSED_CALL, msg.channel)
 
-        self.assertEquals(2, Msg.objects.filter(contact=call.contact, channel=self.channel).count())
+        self.assertEqual(2, Msg.objects.filter(contact=call.contact, channel=self.channel).count())
         last = Msg.objects.filter(contact=call.contact, channel=self.channel).order_by('-pk').first()
-        self.assertEquals(last.text, "Matched +250785551212")
+        self.assertEqual(last.text, "Matched +250785551212")
 
 
 class GhostActionNodeTest(FlowFileTest):
@@ -7047,8 +7047,8 @@ class GhostActionNodeTest(FlowFileTest):
         Flow.find_and_handle(msg)
 
         # we should have gotten a response from our child flow
-        self.assertEquals("I like butter too.",
-                          Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
+        self.assertEqual("I like butter too.",
+                         Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
 
 
 class TriggerStartTest(FlowFileTest):
@@ -7137,13 +7137,13 @@ class FlowBatchTest(FlowFileTest):
         flow.start([], contacts)
 
         # ensure 11 flow runs were created
-        self.assertEquals(11, FlowRun.objects.all().count())
+        self.assertEqual(11, FlowRun.objects.all().count())
 
         # ensure 20 outgoing messages were created (2 for each successful run)
-        self.assertEquals(20, Msg.objects.all().exclude(contact=stopped).count())
+        self.assertEqual(20, Msg.objects.all().exclude(contact=stopped).count())
 
         # but only one broadcast
-        self.assertEquals(1, Broadcast.objects.all().count())
+        self.assertEqual(1, Broadcast.objects.all().count())
         broadcast = Broadcast.objects.get()
 
         # ensure that our flowsteps all have the broadcast set on them
@@ -7538,8 +7538,8 @@ class TimeoutTest(FlowFileTest):
         self.assertEqual(run.exit_type, FlowRun.EXIT_TYPE_COMPLETED)
 
         # and we should have sent our message
-        self.assertEquals("Thanks, Wilson",
-                          Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
+        self.assertEqual("Thanks, Wilson",
+                         Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
 
     def test_timeout(self):
         from temba.flows.tasks import check_flow_timeouts_task
@@ -7553,8 +7553,8 @@ class TimeoutTest(FlowFileTest):
         Flow.find_and_handle(msg)
 
         # we should have sent a response
-        self.assertEquals("Great. Good to meet you Wilson",
-                          Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
+        self.assertEqual("Great. Good to meet you Wilson",
+                         Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
 
         # assert we have exited our flow
         run = FlowRun.objects.get()
@@ -7602,8 +7602,8 @@ class TimeoutTest(FlowFileTest):
         self.assertEqual(run.exit_type, FlowRun.EXIT_TYPE_COMPLETED)
 
         # and we should have sent our message
-        self.assertEquals("Don't worry about it , we'll catch up next week.",
-                          Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
+        self.assertEqual("Don't worry about it , we'll catch up next week.",
+                         Msg.objects.filter(direction=OUTGOING).order_by('-created_on').first().text)
 
 
 class MigrationUtilsTest(TembaTest):
@@ -7767,8 +7767,8 @@ class ParentChildOrderingTest(FlowFileTest):
 
             # get the msgs for our contact
             msgs = Msg.objects.filter(contact=self.contact).order_by('sent_on')
-            self.assertEquals(msgs[0].text, "Parent 1")
-            self.assertEquals(msgs[1].text, "Child Msg")
+            self.assertEqual(msgs[0].text, "Parent 1")
+            self.assertEqual(msgs[1].text, "Child Msg")
 
             self.assertEqual(mock_send_msg.call_count, 1)
 
@@ -7787,15 +7787,15 @@ class AndroidChildStatus(FlowFileTest):
 
         # get the msgs for our contact
         msgs = Msg.objects.filter(contact=self.contact, status=PENDING, direction=OUTGOING).order_by('created_on')
-        self.assertEquals(msgs[0].text, "Child Msg 1")
+        self.assertEqual(msgs[0].text, "Child Msg 1")
 
         # respond
         msg = self.create_msg(contact=self.contact, direction='I', text="Response")
         Flow.find_and_handle(msg)
 
         msgs = Msg.objects.filter(contact=self.contact, status=PENDING, direction=OUTGOING).order_by('created_on')
-        self.assertEquals(msgs[0].text, "Child Msg 1")
-        self.assertEquals(msgs[1].text, "Child Msg 2")
+        self.assertEqual(msgs[0].text, "Child Msg 1")
+        self.assertEqual(msgs[1].text, "Child Msg 2")
 
 
 class FlowChannelSelectionTest(FlowFileTest):
@@ -7867,5 +7867,5 @@ class FlowTriggerTest(TembaTest):
         group_trigger.fire()
 
         # nothing should have changed
-        self.assertEquals(2, FlowRun.objects.filter(flow=flow, contact=contact).count())
-        self.assertEquals(1, FlowStart.objects.all().count())
+        self.assertEqual(2, FlowRun.objects.filter(flow=flow, contact=contact).count())
+        self.assertEqual(1, FlowStart.objects.all().count())

--- a/temba/ivr/tests.py
+++ b/temba/ivr/tests.py
@@ -58,10 +58,10 @@ class IVRTests(FlowFileTest):
         flow.start([], [contact])
 
         call = IVRCall.objects.get()
-        self.assertEquals(IVRCall.PENDING, call.status)
+        self.assertEqual(IVRCall.PENDING, call.status)
 
         # call should be on a Twilio channel since that's all we have
-        self.assertEquals(Channel.TYPE_TWILIO, call.channel.channel_type)
+        self.assertEqual(Channel.TYPE_TWILIO, call.channel.channel_type)
 
         # connect Nexmo instead
         self.org.connect_nexmo('123', '456', self.admin)
@@ -78,8 +78,8 @@ class IVRTests(FlowFileTest):
         flow.start([], [contact], restart_participants=True)
 
         call = IVRCall.objects.all().last()
-        self.assertEquals(IVRCall.PENDING, call.status)
-        self.assertEquals(Channel.TYPE_TWILIO, call.channel.channel_type)
+        self.assertEqual(IVRCall.PENDING, call.status)
+        self.assertEqual(Channel.TYPE_TWILIO, call.channel.channel_type)
 
         # switch back to Nexmo being the preferred channel
         contact.set_preferred_channel(nexmo)
@@ -92,8 +92,8 @@ class IVRTests(FlowFileTest):
         flow.start([], [contact], restart_participants=True)
 
         call = IVRCall.objects.all().last()
-        self.assertEquals(IVRCall.PENDING, call.status)
-        self.assertEquals('NX', call.channel.channel_type)
+        self.assertEqual(IVRCall.PENDING, call.status)
+        self.assertEqual('NX', call.channel.channel_type)
 
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
@@ -121,8 +121,8 @@ class IVRTests(FlowFileTest):
         flow.start([], [test_contact])
 
         log = ActionLog.objects.all().order_by('-pk').first()
-        self.assertEquals(log.text, 'Call ended. Could not authenticate with your Twilio account. '
-                                    'Check your token and try again.')
+        self.assertEqual(log.text, 'Call ended. Could not authenticate with your Twilio account. '
+                                   'Check your token and try again.')
 
     @patch('twilio.util.RequestValidator', MockRequestValidator)
     def test_call_logging(self):
@@ -169,7 +169,7 @@ class IVRTests(FlowFileTest):
 
                 self.assertEqual(mock.call_count, 0)
                 call = IVRCall.objects.get()
-                self.assertEquals(IVRCall.FAILED, call.status)
+                self.assertEqual(IVRCall.FAILED, call.status)
 
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
@@ -243,7 +243,7 @@ class IVRTests(FlowFileTest):
 
         # we should have captured the recording, and ended the call
         call = IVRCall.objects.get(pk=call.pk)
-        self.assertEquals(IVRCall.COMPLETED, call.status)
+        self.assertEqual(IVRCall.COMPLETED, call.status)
 
         # twilio will also send us a final completion message with the call duration (status of completed again)
         self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]),
@@ -255,12 +255,12 @@ class IVRTests(FlowFileTest):
         self.assertEqual(channel_log.description, "Updated call status")
 
         call = IVRCall.objects.get(pk=call.pk)
-        self.assertEquals(IVRCall.COMPLETED, call.status)
-        self.assertEquals(15, call.duration)
+        self.assertEqual(IVRCall.COMPLETED, call.status)
+        self.assertEqual(15, call.duration)
 
         messages = Msg.objects.filter(msg_type=IVR).order_by('pk')
-        self.assertEquals(4, messages.count())
-        self.assertEquals(4, self.org.get_credits_used())
+        self.assertEqual(4, messages.count())
+        self.assertEqual(4, self.org.get_credits_used())
 
         # we should have played a recording from the contact back to them
         outbound_msg = messages[1]
@@ -281,15 +281,15 @@ class IVRTests(FlowFileTest):
 
         from temba.flows.models import FlowStep
         steps = FlowStep.objects.all()
-        self.assertEquals(4, steps.count())
+        self.assertEqual(4, steps.count())
 
         # each of our steps should have exactly one message
         for step in steps:
-            self.assertEquals(1, step.messages.all().count(), msg="Step '%s' does not have exactly one message" % step)
+            self.assertEqual(1, step.messages.all().count(), msg="Step '%s' does not have exactly one message" % step)
 
         # each message should have exactly one step
         for msg in messages:
-            self.assertEquals(1, msg.steps.all().count(), msg="Message '%s' is not attached to exactly one step" % msg.text)
+            self.assertEqual(1, msg.steps.all().count(), msg="Message '%s' is not attached to exactly one step" % msg.text)
 
     @patch('jwt.encode')
     @patch('nexmo.Client.create_application')
@@ -389,12 +389,12 @@ class IVRTests(FlowFileTest):
 
         # we should have captured the recording, and ended the call
         call = IVRCall.objects.get(pk=call.pk)
-        self.assertEquals(IVRCall.COMPLETED, call.status)
-        self.assertEquals(15, call.duration)
+        self.assertEqual(IVRCall.COMPLETED, call.status)
+        self.assertEqual(15, call.duration)
 
         messages = Msg.objects.filter(msg_type=IVR).order_by('pk')
-        self.assertEquals(4, messages.count())
-        self.assertEquals(4, self.org.get_credits_used())
+        self.assertEqual(4, messages.count())
+        self.assertEqual(4, self.org.get_credits_used())
 
         # we should have played a recording from the contact back to them
         outbound_msg = messages[1]
@@ -415,15 +415,15 @@ class IVRTests(FlowFileTest):
 
         from temba.flows.models import FlowStep
         steps = FlowStep.objects.all()
-        self.assertEquals(4, steps.count())
+        self.assertEqual(4, steps.count())
 
         # each of our steps should have exactly one message
         for step in steps:
-            self.assertEquals(1, step.messages.all().count(), msg="Step '%s' does not have exactly one message" % step)
+            self.assertEqual(1, step.messages.all().count(), msg="Step '%s' does not have exactly one message" % step)
 
         # each message should have exactly one step
         for msg in messages:
-            self.assertEquals(1, msg.steps.all().count(), msg="Message '%s' is not attached to exactly one step" % msg.text)
+            self.assertEqual(1, msg.steps.all().count(), msg="Message '%s' is not attached to exactly one step" % msg.text)
 
         # create a valid call first
         flow.start([], [contact], restart_participants=True)
@@ -529,7 +529,7 @@ class IVRTests(FlowFileTest):
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
         self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)
 
-        self.assertEquals(2, FlowStep.objects.all().count())
+        self.assertEqual(2, FlowStep.objects.all().count())
 
         # press 1
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), dict(Digits=1))
@@ -570,7 +570,7 @@ class IVRTests(FlowFileTest):
         post_data = dict(CallSid='CallSid', CallStatus='completed', CallDuration=30)
         self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)
         call.refresh_from_db()
-        self.assertEquals(IVRCall.COMPLETED, call.status)
+        self.assertEqual(IVRCall.COMPLETED, call.status)
 
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
@@ -620,17 +620,17 @@ class IVRTests(FlowFileTest):
         eminem = self.create_contact('Eminem', '+12345')
         flow.start(groups=[], contacts=[eminem])
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
-        self.assertNotEquals(call, None)
+        self.assertNotEqual(call, None)
 
         # after a call is picked up, twilio will call back to our server
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
         self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)
 
         # should have two steps so far, right up to the recording
-        self.assertEquals(2, FlowStep.objects.all().count())
+        self.assertEqual(2, FlowStep.objects.all().count())
 
         # no outbound yet
-        self.assertEquals(None, Msg.objects.filter(direction='O', contact=eminem).first())
+        self.assertEqual(None, Msg.objects.filter(direction='O', contact=eminem).first())
 
         # now pretend we got a recording
         from temba.tests import MockResponse
@@ -645,7 +645,7 @@ class IVRTests(FlowFileTest):
                                   RecordingUrl='http://api.twilio.com/ASID/Recordings/SID', RecordingSid='FAKESID'))
 
         # now we should have an outbound message
-        self.assertEquals('Hi there Eminem', Msg.objects.filter(direction='O', contact=eminem).first().text)
+        self.assertEqual('Hi there Eminem', Msg.objects.filter(direction='O', contact=eminem).first().text)
 
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)
@@ -914,7 +914,7 @@ class IVRTests(FlowFileTest):
 
         # make sure our flow is there as expected
         flow = Flow.objects.filter(name='Call me maybe').first()
-        self.assertEquals('callme', flow.triggers.filter(trigger_type='K').first().keyword)
+        self.assertEqual('callme', flow.triggers.filter(trigger_type='K').first().keyword)
 
         user_settings = self.admin.get_settings()
         user_settings.tel = '+18005551212'
@@ -927,7 +927,7 @@ class IVRTests(FlowFileTest):
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
 
         # should be using the usersettings number in test mode
-        self.assertEquals('Placing test call to +1 800-555-1212', ActionLog.objects.all().first().text)
+        self.assertEqual('Placing test call to +1 800-555-1212', ActionLog.objects.all().first().text)
 
         # our twilio callback on pickup
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
@@ -969,17 +969,17 @@ class IVRTests(FlowFileTest):
         # we should have an outbound ivr call now
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
 
-        self.assertEquals(timedelta(seconds=0), call.get_duration())
+        self.assertEqual(timedelta(seconds=0), call.get_duration())
         self.assertIsNotNone(call)
-        self.assertEquals('CallSid', call.external_id)
+        self.assertEqual('CallSid', call.external_id)
 
         # after a call is picked up, twilio will call back to our server
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), post_data)
 
         self.assertContains(response, '<Say>Would you like me to call you? Press one for yes, two for no, or three for maybe.</Say>')
-        self.assertEquals(1, Msg.objects.filter(msg_type=IVR).count())
-        self.assertEquals(1, self.org.get_credits_used())
+        self.assertEqual(1, Msg.objects.filter(msg_type=IVR).count())
+        self.assertEqual(1, self.org.get_credits_used())
 
         # make sure a message from the person on the call goes to the
         # inbox since our flow doesn't handle text messages
@@ -988,13 +988,13 @@ class IVRTests(FlowFileTest):
 
         # updated our status and duration accordingly
         call = IVRCall.objects.get(pk=call.pk)
-        self.assertEquals(20, call.duration)
-        self.assertEquals(IVRCall.IN_PROGRESS, call.status)
+        self.assertEqual(20, call.duration)
+        self.assertEqual(IVRCall.IN_PROGRESS, call.status)
 
         # don't press any numbers, but # instead
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]) + "?empty=1", dict())
         self.assertContains(response, '<Say>Press one, two, or three. Thanks.</Say>')
-        self.assertEquals(3, self.org.get_credits_used())
+        self.assertEqual(3, self.org.get_credits_used())
 
         # press the number 4 (unexpected)
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), dict(Digits=4))
@@ -1004,25 +1004,25 @@ class IVRTests(FlowFileTest):
         self.assertEqual('H', msg.status)
 
         self.assertContains(response, '<Say>Press one, two, or three. Thanks.</Say>')
-        self.assertEquals(5, self.org.get_credits_used())
+        self.assertEqual(5, self.org.get_credits_used())
 
         # two more messages, one inbound and it's response
-        self.assertEquals(4, Msg.objects.filter(msg_type=IVR).count())
+        self.assertEqual(4, Msg.objects.filter(msg_type=IVR).count())
 
         # now let's have them press the number 3 (for maybe)
         response = self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), dict(Digits=3))
         self.assertContains(response, '<Say>This might be crazy.</Say>')
         messages = Msg.objects.filter(msg_type=IVR).order_by('pk')
-        self.assertEquals(6, messages.count())
-        self.assertEquals(7, self.org.get_credits_used())
+        self.assertEqual(6, messages.count())
+        self.assertEqual(7, self.org.get_credits_used())
 
         for msg in messages:
-            self.assertEquals(1, msg.steps.all().count(), msg="Message '%s' not attached to step" % msg.text)
+            self.assertEqual(1, msg.steps.all().count(), msg="Message '%s' not attached to step" % msg.text)
 
         # twilio would then disconnect the user and notify us of a completed call
         self.client.post(reverse('ivr.ivrcall_handle', args=[call.pk]), dict(CallStatus='completed'))
         call = IVRCall.objects.get(pk=call.pk)
-        self.assertEquals(IVRCall.COMPLETED, call.status)
+        self.assertEqual(IVRCall.COMPLETED, call.status)
         self.assertFalse(FlowRun.objects.filter(connection=call).first().is_active)
         self.assertIsNotNone(call.ended_on)
 
@@ -1034,7 +1034,7 @@ class IVRTests(FlowFileTest):
         self.assertEqual(flow.get_run_stats()['completed'], 1)
 
         # should still have no active runs
-        self.assertEquals(0, FlowRun.objects.filter(is_active=True).count())
+        self.assertEqual(0, FlowRun.objects.filter(is_active=True).count())
 
         # and we've exited the flow
         step = FlowStep.objects.all().order_by('-pk').first()
@@ -1049,7 +1049,7 @@ class IVRTests(FlowFileTest):
             call_to_update.update_status(twilio_status, 0, channel_type)
             call_to_update.save()
             call_to_update.refresh_from_db()
-            self.assertEquals(temba_status, IVRCall.objects.get(pk=call_to_update.pk).status)
+            self.assertEqual(temba_status, IVRCall.objects.get(pk=call_to_update.pk).status)
 
             if temba_status in IVRCall.DONE:
                 self.assertIsNotNone(call_to_update.ended_on)
@@ -1085,7 +1085,7 @@ class IVRTests(FlowFileTest):
         # we should have an outbound ivr call now, and no steps yet
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
         self.assertIsNotNone(call)
-        self.assertEquals(0, FlowStep.objects.all().count())
+        self.assertEqual(0, FlowStep.objects.all().count())
 
         # after a call is picked up, twilio will call back to our server
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
@@ -1095,11 +1095,11 @@ class IVRTests(FlowFileTest):
         steps = FlowStep.objects.all().order_by('pk')
 
         # the first step has exactly one message which is an outgoing IVR message
-        self.assertEquals(1, steps.first().messages.all().count())
-        self.assertEquals(1, steps.first().messages.filter(direction=IVRCall.OUTGOING, msg_type=IVR).count())
+        self.assertEqual(1, steps.first().messages.all().count())
+        self.assertEqual(1, steps.first().messages.filter(direction=IVRCall.OUTGOING, msg_type=IVR).count())
 
         # the next step shouldn't have any messages yet since they haven't pressed anything
-        self.assertEquals(0, steps[1].messages.all().count())
+        self.assertEqual(0, steps[1].messages.all().count())
 
         # try updating our status to completed for a test contact
         Contact.set_simulation(True)
@@ -1147,14 +1147,14 @@ class IVRTests(FlowFileTest):
         flow.start([], [test_contact])
 
         # should be using the usersettings number in test mode
-        self.assertEquals('Placing test call to +1 800-555-1212', ActionLog.objects.all().first().text)
+        self.assertEqual('Placing test call to +1 800-555-1212', ActionLog.objects.all().first().text)
 
         # we should have an outbound ivr call now
         call = IVRCall.objects.filter(direction=IVRCall.OUTGOING).first()
 
-        self.assertEquals(timedelta(seconds=0), call.get_duration())
+        self.assertEqual(timedelta(seconds=0), call.get_duration())
         self.assertIsNotNone(call)
-        self.assertEquals('CallSid', call.external_id)
+        self.assertEqual('CallSid', call.external_id)
 
         # after a call is picked up, twilio will call back to our server
         post_data = dict(CallSid='CallSid', CallStatus='in-progress', CallDuration=20)
@@ -1191,8 +1191,8 @@ class IVRTests(FlowFileTest):
         self.assertContains(response, '<Say>Would you like me to call you? Press one for yes, two for no, or three for maybe.</Say>')
 
         call = IVRCall.objects.all().first()
-        self.assertEquals('+250788382382', call.contact_urn.path)
-        self.assertEquals('CallSid', call.external_id)
+        self.assertEqual('+250788382382', call.contact_urn.path)
+        self.assertEqual('CallSid', call.external_id)
 
         status_callback = dict(CallSid='CallSid', CallbackSource='call-progress-events',
                                CallStatus='completed', Direction='inbound',
@@ -1208,7 +1208,7 @@ class IVRTests(FlowFileTest):
         self.assertContains(response, 'No call found')
 
         flow.refresh_from_db()
-        self.assertEquals(CURRENT_EXPORT_VERSION, flow.version_number)
+        self.assertEqual(CURRENT_EXPORT_VERSION, flow.version_number)
 
         # now try an inbound call after remove our channel
         self.channel.is_active = False
@@ -1278,8 +1278,8 @@ class IVRTests(FlowFileTest):
         call = IVRCall.objects.all().first()
         self.assertIsNotNone(call)
         self.assertEqual(call.direction, IVRCall.INCOMING)
-        self.assertEquals('+250788382382', call.contact_urn.path)
-        self.assertEquals('ext-id', call.external_id)
+        self.assertEqual('+250788382382', call.contact_urn.path)
+        self.assertEqual('ext-id', call.external_id)
 
         self.assertEqual(ChannelLog.objects.all().count(), 2)
         channel_log = ChannelLog.objects.first()
@@ -1339,9 +1339,9 @@ class IVRTests(FlowFileTest):
 
         call = IVRCall.objects.get()
         self.assertIsNotNone(call)
-        self.assertEquals('+250788382382', call.contact_urn.path)
+        self.assertEqual('+250788382382', call.contact_urn.path)
         self.assertEqual(call.direction, IVRCall.INCOMING)
-        self.assertEquals('ext-id', call.external_id)
+        self.assertEqual('ext-id', call.external_id)
 
         self.assertEqual(ChannelLog.objects.all().count(), 1)
         channel_log = ChannelLog.objects.first()
@@ -1350,7 +1350,7 @@ class IVRTests(FlowFileTest):
 
         from temba.orgs.models import CURRENT_EXPORT_VERSION
         flow.refresh_from_db()
-        self.assertEquals(CURRENT_EXPORT_VERSION, flow.version_number)
+        self.assertEqual(CURRENT_EXPORT_VERSION, flow.version_number)
 
         self.assertIsNot(call.status, IVRCall.COMPLETED)
 
@@ -1368,7 +1368,7 @@ class IVRTests(FlowFileTest):
         run = call.runs.all().first()
         self.assertEqual(200, response.status_code)
         self.assertContains(response, "Updated call status")
-        self.assertEquals(call.status, IVRCall.COMPLETED)
+        self.assertEqual(call.status, IVRCall.COMPLETED)
         self.assertTrue(run.is_completed())
 
         self.assertEqual(ChannelLog.objects.all().count(), 2)
@@ -1505,7 +1505,7 @@ class IVRTests(FlowFileTest):
                          From='+250788382382', To=self.channel.address)
         response = self.client.post(reverse('handlers.twilio_handler', args=['voice', self.channel.uuid]), post_data)
 
-        self.assertEquals(response.status_code, 400)
+        self.assertEqual(response.status_code, 400)
 
     @patch('temba.ivr.clients.TwilioClient', MockTwilioClient)
     @patch('twilio.util.RequestValidator', MockRequestValidator)

--- a/temba/locations/tests.py
+++ b/temba/locations/tests.py
@@ -33,7 +33,7 @@ class LocationTest(TembaTest):
 
         # our country is set to rwanda, we should get it as the main object
         response = self.client.get(reverse('locations.adminboundary_alias'))
-        self.assertEquals(self.country, response.context['object'])
+        self.assertEqual(self.country, response.context['object'])
 
         # ok, now get the geometry for rwanda
         response = self.client.get(
@@ -46,7 +46,7 @@ class LocationTest(TembaTest):
         self.assertTrue('features' in response_json)
 
         # should have our two top level states
-        self.assertEquals(2, len(response_json['features']))
+        self.assertEqual(2, len(response_json['features']))
 
         # now get it for one of the sub areas
         response = self.client.get(
@@ -57,7 +57,7 @@ class LocationTest(TembaTest):
         self.assertTrue('features' in response_json)
 
         # should have our single district in it
-        self.assertEquals(1, len(response_json['features']))
+        self.assertEqual(1, len(response_json['features']))
 
         # now grab our aliases
         response = self.client.get(
@@ -65,10 +65,10 @@ class LocationTest(TembaTest):
         response_json = response.json()
 
         # should just be kigali, without any aliases
-        self.assertEquals(2, len(response_json))
-        self.assertEquals("Eastern Province", response_json[0]['name'])
-        self.assertEquals("Kigali City", response_json[1]['name'])
-        self.assertEquals('', response_json[1]['aliases'])
+        self.assertEqual(2, len(response_json))
+        self.assertEqual("Eastern Province", response_json[0]['name'])
+        self.assertEqual("Kigali City", response_json[1]['name'])
+        self.assertEqual('', response_json[1]['aliases'])
 
         # update our alias for kigali
         response = self.client.post(reverse('locations.adminboundary_boundaries', args=[self.country.osm_id]),
@@ -76,7 +76,7 @@ class LocationTest(TembaTest):
                                         [dict(osm_id=self.state1.osm_id, aliases="kigs\nkig")]),
                                     content_type='application/json')
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # fetch our aliases again
         response = self.client.get(
@@ -84,8 +84,8 @@ class LocationTest(TembaTest):
         response_json = response.json()
 
         # now have kigs as an alias
-        self.assertEquals("Kigali City", response_json[1]['name'])
-        self.assertEquals('kig\nkigs', response_json[1]['aliases'])
+        self.assertEqual("Kigali City", response_json[1]['name'])
+        self.assertEqual('kig\nkigs', response_json[1]['aliases'])
 
         # test nested admin level aliases update
         geo_data = [
@@ -109,7 +109,7 @@ class LocationTest(TembaTest):
         response = self.client.post(reverse('locations.adminboundary_boundaries', args=[self.country.osm_id]),
                                     json.dumps(geo_data), content_type='application/json')
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # exact match
         boundary = self.org.find_boundary_by_name('kigali city', AdminBoundary.LEVEL_STATE, self.country)
@@ -134,8 +134,8 @@ class LocationTest(TembaTest):
         response = self.client.get(
             reverse('locations.adminboundary_boundaries', args=[self.country.osm_id]))
         response_json = response.json()
-        self.assertEquals(response_json[0].get('name'), self.state2.name)
-        self.assertEquals(response_json[0].get('aliases'), 'Eastern P')
+        self.assertEqual(response_json[0].get('name'), self.state2.name)
+        self.assertEqual(response_json[0].get('aliases'), 'Eastern P')
         self.assertTrue('Kageyo Gat' in response_json[0].get('match'))
 
         # trigger wrong request data using bad json
@@ -144,15 +144,15 @@ class LocationTest(TembaTest):
                                     content_type='application/json')
 
         response_json = response.json()
-        self.assertEquals(400, response.status_code)
-        self.assertEquals(response_json.get('status'), 'error')
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(response_json.get('status'), 'error')
 
         # Get geometry of admin boundary without sub-levels, should return one feature
         response = self.client.get(
             reverse('locations.adminboundary_geometry', args=[self.ward3.osm_id]))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         response_json = response.json()
-        self.assertEquals(len(response_json.get('features')), 1)
+        self.assertEqual(len(response_json.get('features')), 1)
 
 
 class DownloadGeoJsonTest(TembaTest):
@@ -187,4 +187,4 @@ class DownloadGeoJsonTest(TembaTest):
         self.assertFalse(os.path.exists(bad_path))
         self.assertTrue(os.path.exists(good_path))
         with open(good_path, 'r') as fp:
-            self.assertEquals(fp.read(), 'the-relation-json')
+            self.assertEqual(fp.read(), 'the-relation-json')

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -202,8 +202,8 @@ class MsgTest(TembaTest):
         response = self.client.get(outbox_url)
 
         # check our completions JSON and functions JSON
-        self.assertEquals(response.context['completions'], json.dumps(completions))
-        self.assertEquals(response.context['function_completions'], json.dumps(get_function_listing()))
+        self.assertEqual(response.context['completions'], json.dumps(completions))
+        self.assertEqual(response.context['function_completions'], json.dumps(get_function_listing()))
 
         # add some contact fields
         field = ContactField.get_or_create(self.org, self.admin, 'cell', "Cell")
@@ -215,7 +215,7 @@ class MsgTest(TembaTest):
         response = self.client.get(outbox_url)
 
         # contact fields are included at the end in alphabetical order
-        self.assertEquals(response.context['completions'], json.dumps(completions))
+        self.assertEqual(response.context['completions'], json.dumps(completions))
 
         # a Twitter channel
         Channel.create(self.org, self.user, None, 'TT')
@@ -224,7 +224,7 @@ class MsgTest(TembaTest):
 
         response = self.client.get(outbox_url)
         # the Twitter URN scheme is included
-        self.assertEquals(response.context['completions'], json.dumps(completions))
+        self.assertEqual(response.context['completions'], json.dumps(completions))
 
     def test_create_outgoing(self):
         tel_urn = "tel:250788382382"
@@ -236,14 +236,14 @@ class MsgTest(TembaTest):
 
         # check creating by URN string
         msg = Msg.create_outgoing(self.org, self.admin, tel_urn, "Extra spaces to remove    ")
-        self.assertEquals(msg.contact, tel_contact)
-        self.assertEquals(msg.contact_urn, tel_urn_obj)
-        self.assertEquals(msg.text, "Extra spaces to remove")  # check message text is stripped
+        self.assertEqual(msg.contact, tel_contact)
+        self.assertEqual(msg.contact_urn, tel_urn_obj)
+        self.assertEqual(msg.text, "Extra spaces to remove")  # check message text is stripped
 
         # check creating by URN string and specific channel
         msg = Msg.create_outgoing(self.org, self.admin, tel_urn, "Hello 1", channel=self.channel)
-        self.assertEquals(msg.contact, tel_contact)
-        self.assertEquals(msg.contact_urn, tel_urn_obj)
+        self.assertEqual(msg.contact, tel_contact)
+        self.assertEqual(msg.contact_urn, tel_urn_obj)
 
         # try creating by URN string and specific channel with different scheme
         with self.assertRaises(UnreachableException):
@@ -251,13 +251,13 @@ class MsgTest(TembaTest):
 
         # check creating by URN object
         msg = Msg.create_outgoing(self.org, self.admin, tel_urn_obj, "Hello 1")
-        self.assertEquals(msg.contact, tel_contact)
-        self.assertEquals(msg.contact_urn, tel_urn_obj)
+        self.assertEqual(msg.contact, tel_contact)
+        self.assertEqual(msg.contact_urn, tel_urn_obj)
 
         # check creating by URN object and specific channel
         msg = Msg.create_outgoing(self.org, self.admin, tel_urn_obj, "Hello 1", channel=self.channel)
-        self.assertEquals(msg.contact, tel_contact)
-        self.assertEquals(msg.contact_urn, tel_urn_obj)
+        self.assertEqual(msg.contact, tel_contact)
+        self.assertEqual(msg.contact_urn, tel_urn_obj)
 
         # try creating by URN object and specific channel with different scheme
         with self.assertRaises(UnreachableException):
@@ -265,13 +265,13 @@ class MsgTest(TembaTest):
 
         # check creating by contact
         msg = Msg.create_outgoing(self.org, self.admin, tel_contact, "Hello 1")
-        self.assertEquals(msg.contact, tel_contact)
-        self.assertEquals(msg.contact_urn, tel_urn_obj)
+        self.assertEqual(msg.contact, tel_contact)
+        self.assertEqual(msg.contact_urn, tel_urn_obj)
 
         # check creating by contact and specific channel
         msg = Msg.create_outgoing(self.org, self.admin, tel_contact, "Hello 1", channel=self.channel)
-        self.assertEquals(msg.contact, tel_contact)
-        self.assertEquals(msg.contact_urn, tel_urn_obj)
+        self.assertEqual(msg.contact, tel_contact)
+        self.assertEqual(msg.contact_urn, tel_urn_obj)
 
         # try creating by contact and specific channel with different scheme
         with self.assertRaises(UnreachableException):
@@ -346,8 +346,8 @@ class MsgTest(TembaTest):
         broadcast.send(True)
 
         # should have no messages but marked as sent
-        self.assertEquals(0, broadcast.msgs.all().count())
-        self.assertEquals(SENT, broadcast.status)
+        self.assertEqual(0, broadcast.msgs.all().count())
+        self.assertEqual(SENT, broadcast.status)
 
     def test_send_all(self):
         contact = self.create_contact('Stephen', '+12078778899')
@@ -356,10 +356,10 @@ class MsgTest(TembaTest):
         partial_recipients = list(), Contact.objects.filter(pk=contact.pk)
         broadcast.send(True, partial_recipients=partial_recipients)
 
-        self.assertEquals(1, broadcast.recipients.all().count())
-        self.assertEquals(2, broadcast.msgs.all().count())
-        self.assertEquals(1, broadcast.msgs.all().filter(contact_urn__path='+12078778899').count())
-        self.assertEquals(1, broadcast.msgs.all().filter(contact_urn__path='+12078778800').count())
+        self.assertEqual(1, broadcast.recipients.all().count())
+        self.assertEqual(2, broadcast.msgs.all().count())
+        self.assertEqual(1, broadcast.msgs.all().filter(contact_urn__path='+12078778899').count())
+        self.assertEqual(1, broadcast.msgs.all().filter(contact_urn__path='+12078778800').count())
 
         # should not create a broadcast recipient if a similar one exists
         broadcast = Broadcast.create(self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", [contact], send_all=True)
@@ -368,10 +368,10 @@ class MsgTest(TembaTest):
         partial_recipients = list(), Contact.objects.filter(pk=contact.pk)
         broadcast.send(True, partial_recipients=partial_recipients)
 
-        self.assertEquals(1, broadcast.recipients.all().count())
-        self.assertEquals(2, broadcast.msgs.all().count())
-        self.assertEquals(1, broadcast.msgs.all().filter(contact_urn__path='+12078778899').count())
-        self.assertEquals(1, broadcast.msgs.all().filter(contact_urn__path='+12078778800').count())
+        self.assertEqual(1, broadcast.recipients.all().count())
+        self.assertEqual(2, broadcast.msgs.all().count())
+        self.assertEqual(1, broadcast.msgs.all().filter(contact_urn__path='+12078778899').count())
+        self.assertEqual(1, broadcast.msgs.all().filter(contact_urn__path='+12078778800').count())
 
     def test_update_contacts(self):
         broadcast = Broadcast.create(self.org, self.admin, "If a broadcast is sent and nobody receives it, does it still send?", [])
@@ -380,7 +380,7 @@ class MsgTest(TembaTest):
         broadcast.update_contacts([self.joe.id])
 
         broadcast.refresh_from_db()
-        self.assertEquals(1, broadcast.recipient_count)
+        self.assertEqual(1, broadcast.recipient_count)
 
         # send it
         broadcast.send()
@@ -460,21 +460,21 @@ class MsgTest(TembaTest):
         # visit inbox page  as a user not in the organization
         self.login(self.non_org_user)
         response = self.client.get(inbox_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # visit inbox page as a manager of the organization
         response = self.fetch_protected(inbox_url, self.admin)
 
-        self.assertEquals(response.context['object_list'].count(), 5)
-        self.assertEquals(response.context['folders'][0]['url'], '/msg/inbox/')
-        self.assertEquals(response.context['folders'][0]['count'], 5)
-        self.assertEquals(response.context['actions'], ['archive', 'label'])
+        self.assertEqual(response.context['object_list'].count(), 5)
+        self.assertEqual(response.context['folders'][0]['url'], '/msg/inbox/')
+        self.assertEqual(response.context['folders'][0]['count'], 5)
+        self.assertEqual(response.context['actions'], ['archive', 'label'])
 
         # visit inbox page as administrator
         response = self.fetch_protected(inbox_url, self.admin)
 
-        self.assertEquals(response.context['object_list'].count(), 5)
-        self.assertEquals(response.context['actions'], ['archive', 'label'])
+        self.assertEqual(response.context['object_list'].count(), 5)
+        self.assertEqual(response.context['actions'], ['archive', 'label'])
 
         # let's add some labels
         folder = Label.get_or_create_folder(self.org, self.user, "folder")
@@ -497,21 +497,21 @@ class MsgTest(TembaTest):
 
         # update our label name
         response = self.client.get(reverse('msgs.label_update', args=[label1.pk]))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertTrue('folder' in response.context['form'].fields)
 
         post_data = dict(name="Foo")
         response = self.client.post(reverse('msgs.label_update', args=[label1.pk]), post_data)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
         label1 = Label.label_objects.get(pk=label1.pk)
-        self.assertEquals("Foo", label1.name)
+        self.assertEqual("Foo", label1.name)
 
         # test deleting the label
         response = self.client.get(reverse('msgs.label_delete', args=[label1.pk]))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         response = self.client.post(reverse('msgs.label_delete', args=[label1.pk]))
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
         self.assertFalse(Label.label_objects.filter(pk=label1.id))
 
         # shouldn't have a remove on the update page
@@ -536,31 +536,31 @@ class MsgTest(TembaTest):
         # visit archived page  as a user not in the organization
         self.login(self.non_org_user)
         response = self.client.get(archive_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # visit archived page as a manager of the organization
         response = self.fetch_protected(archive_url, self.admin)
 
-        self.assertEquals(response.context['object_list'].count(), 1)
-        self.assertEquals(response.context['actions'], ['restore', 'label', 'delete'])
+        self.assertEqual(response.context['object_list'].count(), 1)
+        self.assertEqual(response.context['actions'], ['restore', 'label', 'delete'])
 
         # check that the inbox does not contains archived messages
 
         # visit inbox page as a user not in the organization
         self.login(self.non_org_user)
         response = self.client.get(inbox_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # visit inbox page as an admin of the organization
         response = self.fetch_protected(inbox_url, self.admin)
 
-        self.assertEquals(response.context['object_list'].count(), 4)
-        self.assertEquals(response.context['actions'], ['archive', 'label'])
+        self.assertEqual(response.context['object_list'].count(), 4)
+        self.assertEqual(response.context['actions'], ['archive', 'label'])
 
         # test restoring an archived message back to inbox
         post_data = dict(action='restore', objects=[msg1.pk])
         self.client.post(inbox_url, post_data, follow=True)
-        self.assertEquals(Msg.objects.filter(visibility=Msg.VISIBILITY_ARCHIVED).count(), 0)
+        self.assertEqual(Msg.objects.filter(visibility=Msg.VISIBILITY_ARCHIVED).count(), 0)
 
         # messages from test contact are not included in the inbox
         test_contact = Contact.get_test_contact(self.admin)
@@ -623,8 +623,8 @@ class MsgTest(TembaTest):
         self.login(self.admin)
         response = self.client.get(url)
 
-        self.assertEquals(set(response.context['object_list']), {msg1})
-        self.assertEquals(response.context['actions'], ['label'])
+        self.assertEqual(set(response.context['object_list']), {msg1})
+        self.assertEqual(response.context['actions'], ['label'])
 
     def test_failed(self):
         failed_url = reverse('msgs.msg_failed')
@@ -643,7 +643,7 @@ class MsgTest(TembaTest):
         broadcast.update()
         msg2 = broadcast.get_messages()[0]
 
-        self.assertEquals(FAILED, broadcast.status)
+        self.assertEqual(FAILED, broadcast.status)
 
         # message without a broadcast
         msg3 = Msg.create_outgoing(self.org, self.admin, self.joe, "messsage number 3")
@@ -653,13 +653,13 @@ class MsgTest(TembaTest):
         # visit fail page  as a user not in the organization
         self.login(self.non_org_user)
         response = self.client.get(failed_url)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # visit inbox page as an administrator
         response = self.fetch_protected(failed_url, self.admin)
 
-        self.assertEquals(response.context['object_list'].count(), 3)
-        self.assertEquals(response.context['actions'], ['resend'])
+        self.assertEqual(response.context['object_list'].count(), 3)
+        self.assertEqual(response.context['actions'], ['resend'])
 
         self.assertContains(response, reverse('channels.channellog_read', args=[log.id]))
 
@@ -676,13 +676,13 @@ class MsgTest(TembaTest):
         self.assertEqual(Msg.objects.filter(status=PENDING).count(), 1)
 
         # make sure there was a new outgoing message created that got attached to our broadcast
-        self.assertEquals(1, broadcast.get_messages().count())
+        self.assertEqual(1, broadcast.get_messages().count())
 
         resent_msg = broadcast.get_messages()[0]
-        self.assertNotEquals(msg2, resent_msg)
-        self.assertEquals(msg2.text, resent_msg.text)
-        self.assertEquals(msg2.contact, resent_msg.contact)
-        self.assertEquals(PENDING, resent_msg.status)
+        self.assertNotEqual(msg2, resent_msg)
+        self.assertEqual(msg2.text, resent_msg.text)
+        self.assertEqual(msg2.contact, resent_msg.contact)
+        self.assertEqual(PENDING, resent_msg.status)
 
     @patch('temba.utils.email.send_temba_email')
     def test_message_export(self, mock_send_temba_email):
@@ -919,7 +919,7 @@ class BroadcastTest(TembaTest):
 
     def test_broadcast_batch(self):
         broadcast = Broadcast.create(self.org, self.user, "Like a tweet", [self.joe_and_frank, self.kevin])
-        self.assertEquals(3, broadcast.recipient_count)
+        self.assertEqual(3, broadcast.recipient_count)
 
         # change our broadcast size to 2
         import temba.msgs.models as msgs_models
@@ -930,7 +930,7 @@ class BroadcastTest(TembaTest):
             msgs_models.BATCH_SIZE = 2
             broadcast.send()
 
-            self.assertEquals(broadcast.get_message_count(), 3)
+            self.assertEqual(broadcast.get_message_count(), 3)
             self.assertEqual(set(broadcast.recipients.all()), {self.joe, self.frank, self.kevin})
         finally:
             msgs_models.BATCH_SIZE = orig_batch_size
@@ -941,11 +941,11 @@ class BroadcastTest(TembaTest):
             sms.status = new_sms_status
             sms.save()
             sms.broadcast.update()
-            self.assertEquals(sms.broadcast.status, broadcast_status)
+            self.assertEqual(sms.broadcast.status, broadcast_status)
 
         broadcast = Broadcast.create(self.org, self.user, "Like a tweet", [self.joe_and_frank, self.kevin, self.lucy])
-        self.assertEquals('I', broadcast.status)
-        self.assertEquals(4, broadcast.recipient_count)
+        self.assertEqual('I', broadcast.status)
+        self.assertEqual(4, broadcast.recipient_count)
 
         # no recipients created yet, done when we send
         self.assertEqual(set(broadcast.recipients.all()), set())
@@ -956,7 +956,7 @@ class BroadcastTest(TembaTest):
         self.assertEqual(set(broadcast.recipients.all()), {self.joe, self.frank, self.kevin, self.lucy})
 
         # after calling send, all messages are queued
-        self.assertEquals(broadcast.status, 'Q')
+        self.assertEqual(broadcast.status, 'Q')
 
         # test errored broadcast logic now that all sms status are queued
         msgs = broadcast.get_messages()
@@ -986,7 +986,7 @@ class BroadcastTest(TembaTest):
         # test delivered broadcast logic
         assertBroadcastStatus(broadcast.get_messages()[0], 'D', 'D')
 
-        self.assertEquals("Temba (%d)" % broadcast.id, str(broadcast))
+        self.assertEqual("Temba (%d)" % broadcast.id, str(broadcast))
 
     def test_send(self):
         # remove all channels first
@@ -1003,16 +1003,16 @@ class BroadcastTest(TembaTest):
 
         # test when we are simulating
         response = self.client.get(send_url + "?simulation=true")
-        self.assertEquals(['omnibox', 'text', 'schedule', 'step_node'], response.context['fields'])
+        self.assertEqual(['omnibox', 'text', 'schedule', 'step_node'], response.context['fields'])
 
         test_contact = Contact.get_test_contact(self.admin)
 
         post_data = dict(text="you simulator display this", omnibox="c-%s,c-%s,c-%s" % (self.joe.uuid, self.frank.uuid, test_contact.uuid))
         self.client.post(send_url + "?simulation=true", post_data)
-        self.assertEquals(Broadcast.objects.all().count(), 1)
-        self.assertEquals(Broadcast.objects.all()[0].groups.all().count(), 0)
-        self.assertEquals(Broadcast.objects.all()[0].contacts.all().count(), 1)
-        self.assertEquals(Broadcast.objects.all()[0].contacts.all()[0], test_contact)
+        self.assertEqual(Broadcast.objects.all().count(), 1)
+        self.assertEqual(Broadcast.objects.all()[0].groups.all().count(), 0)
+        self.assertEqual(Broadcast.objects.all()[0].contacts.all().count(), 1)
+        self.assertEqual(Broadcast.objects.all()[0].contacts.all()[0], test_contact)
 
         # delete this broadcast to keep future test right
         Broadcast.objects.all()[0].delete()
@@ -1023,7 +1023,7 @@ class BroadcastTest(TembaTest):
         Channel.create(self.org, self.user, None, "TT")
 
         response = self.client.get(send_url)
-        self.assertEquals(['omnibox', 'text', 'schedule', 'step_node'], response.context['fields'])
+        self.assertEqual(['omnibox', 'text', 'schedule', 'step_node'], response.context['fields'])
 
         post_data = dict(text="message #1", omnibox="g-%s,c-%s,c-%s" % (self.joe_and_frank.uuid, self.joe.uuid, self.lucy.uuid))
         self.client.post(send_url, post_data, follow=True)
@@ -1043,26 +1043,26 @@ class BroadcastTest(TembaTest):
         Channel.create(self.org, self.user, None, 'A', None, secret="12345", gcm_id="123")
 
         response = self.client.get(send_url)
-        self.assertEquals(['omnibox', 'text', 'schedule', 'step_node'], response.context['fields'])
+        self.assertEqual(['omnibox', 'text', 'schedule', 'step_node'], response.context['fields'])
 
         post_data = dict(text="message #2", omnibox='g-%s,c-%s' % (self.joe_and_frank.uuid, self.kevin.uuid))
         self.client.post(send_url, post_data, follow=True)
         broadcast = Broadcast.objects.order_by('-id').first()
         self.assertEqual(broadcast.text, {'base': "message #2"})
-        self.assertEquals(broadcast.groups.count(), 1)
-        self.assertEquals(broadcast.contacts.count(), 1)
+        self.assertEqual(broadcast.groups.count(), 1)
+        self.assertEqual(broadcast.contacts.count(), 1)
 
         # directly on user page
         post_data = dict(text="contact send", from_contact=True, omnibox="c-%s" % self.kevin.uuid)
         response = self.client.post(send_url, post_data)
         self.assertRedirect(response, reverse('contacts.contact_read', args=[self.kevin.uuid]))
-        self.assertEquals(Broadcast.objects.all().count(), 3)
+        self.assertEqual(Broadcast.objects.all().count(), 3)
 
         # test sending to an arbitrary user
         post_data = dict(text="message content", omnibox='n-2065551212')
         self.client.post(send_url, post_data, follow=True)
-        self.assertEquals(Broadcast.objects.all().count(), 4)
-        self.assertEquals(1, Contact.objects.filter(urns__path='2065551212').count())
+        self.assertEqual(Broadcast.objects.all().count(), 4)
+        self.assertEqual(1, Contact.objects.filter(urns__path='2065551212').count())
 
         # test missing senders
         post_data = dict(text="message content")
@@ -1073,7 +1073,7 @@ class BroadcastTest(TembaTest):
         post_data = dict(text="message content", omnibox='')
         response = self.client.post(send_url + '?_format=json', post_data, follow=True)
         self.assertIn("At least one recipient is required", response.content)
-        self.assertEquals('application/json', response._headers.get('content-type')[1])
+        self.assertEqual('application/json', response._headers.get('content-type')[1])
 
         post_data = dict(text="this is a test message", omnibox="c-%s" % self.kevin.uuid, _format="json")
         response = self.client.post(send_url, post_data, follow=True)
@@ -1102,8 +1102,8 @@ class BroadcastTest(TembaTest):
         self.assertIn("success", response.content)
         broadcast = Broadcast.objects.order_by('-id').first()
         self.assertEqual(broadcast.text, {'base': "message content"})
-        self.assertEquals(broadcast.groups.count(), 0)
-        self.assertEquals(broadcast.contacts.count(), 1)
+        self.assertEqual(broadcast.groups.count(), 0)
+        self.assertEqual(broadcast.contacts.count(), 1)
         self.assertTrue(self.joe in broadcast.contacts.all())
 
         # Activate simulation mode
@@ -1114,8 +1114,8 @@ class BroadcastTest(TembaTest):
         self.assertIn("success", response.content)
         broadcast = Broadcast.objects.order_by('-id').first()
         self.assertEqual(broadcast.text, {'base': "message content"})
-        self.assertEquals(broadcast.groups.count(), 0)
-        self.assertEquals(broadcast.contacts.count(), 1)
+        self.assertEqual(broadcast.groups.count(), 0)
+        self.assertEqual(broadcast.contacts.count(), 1)
         self.assertTrue(test_contact in broadcast.contacts.all())
 
     def test_unreachable(self):
@@ -1159,36 +1159,36 @@ class BroadcastTest(TembaTest):
 
         sms = self.create_msg(contact=contact, text="Text", direction=OUTGOING)
 
-        self.assertEquals(["Text"], Msg.get_text_parts(sms.text))
+        self.assertEqual(["Text"], Msg.get_text_parts(sms.text))
         sms.text = ""
-        self.assertEquals([""], Msg.get_text_parts(sms.text))
+        self.assertEqual([""], Msg.get_text_parts(sms.text))
 
         # 160 chars
         sms.text = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
-        self.assertEquals(1, len(Msg.get_text_parts(sms.text)))
+        self.assertEqual(1, len(Msg.get_text_parts(sms.text)))
 
         # 161 characters with space
         sms.text = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 1234567890"
         parts = Msg.get_text_parts(sms.text)
-        self.assertEquals(2, len(parts))
-        self.assertEquals(150, len(parts[0]))
-        self.assertEquals(10, len(parts[1]))
+        self.assertEqual(2, len(parts))
+        self.assertEqual(150, len(parts[0]))
+        self.assertEqual(10, len(parts[1]))
 
         # 161 characters without space
         sms.text = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901"
         parts = Msg.get_text_parts(sms.text)
-        self.assertEquals(2, len(parts))
-        self.assertEquals(160, len(parts[0]))
-        self.assertEquals(1, len(parts[1]))
+        self.assertEqual(2, len(parts))
+        self.assertEqual(160, len(parts[0]))
+        self.assertEqual(1, len(parts[1]))
 
         # 160 characters with max length 40
         sms.text = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
         parts = Msg.get_text_parts(sms.text, max_length=40)
-        self.assertEquals(4, len(parts))
-        self.assertEquals(40, len(parts[0]))
-        self.assertEquals(40, len(parts[1]))
-        self.assertEquals(40, len(parts[2]))
-        self.assertEquals(40, len(parts[3]))
+        self.assertEqual(4, len(parts))
+        self.assertEqual(40, len(parts[0]))
+        self.assertEqual(40, len(parts[1]))
+        self.assertEqual(40, len(parts[2]))
+        self.assertEqual(40, len(parts[3]))
 
     def test_substitute_variables(self):
         ContactField.get_or_create(self.org, self.admin, 'goats', "Goats", False, Value.TYPE_DECIMAL)
@@ -1199,75 +1199,75 @@ class BroadcastTest(TembaTest):
         def substitute(s, context):
             return Msg.substitute_variables(s, context, contact=self.joe)
 
-        self.assertEquals(("Hello World", []), substitute("Hello World", dict()))
-        self.assertEquals(("Hello World Joe", []), substitute("Hello World @contact.first_name", dict()))
-        self.assertEquals(("Hello World Joe Blow", []), substitute("Hello World @contact", dict()))
-        self.assertEquals(("Hello World: Well", []), substitute("Hello World: @flow.water_source", dict(flow=dict(water_source="Well"))))
-        self.assertEquals(("Hello World: Well  Boil: @flow.boil", ["Undefined variable: flow.boil"]), substitute("Hello World: @flow.water_source  Boil: @flow.boil", dict(flow=dict(water_source="Well"))))
+        self.assertEqual(("Hello World", []), substitute("Hello World", dict()))
+        self.assertEqual(("Hello World Joe", []), substitute("Hello World @contact.first_name", dict()))
+        self.assertEqual(("Hello World Joe Blow", []), substitute("Hello World @contact", dict()))
+        self.assertEqual(("Hello World: Well", []), substitute("Hello World: @flow.water_source", dict(flow=dict(water_source="Well"))))
+        self.assertEqual(("Hello World: Well  Boil: @flow.boil", ["Undefined variable: flow.boil"]), substitute("Hello World: @flow.water_source  Boil: @flow.boil", dict(flow=dict(water_source="Well"))))
 
-        self.assertEquals(("Hello joe", []), substitute("Hello @(LOWER(contact.first_name))", dict()))
-        self.assertEquals(("Hello Joe", []), substitute("Hello @(PROPER(LOWER(contact.first_name)))", dict()))
-        self.assertEquals(("Hello Joe", []), substitute("Hello @(first_word(contact))", dict()))
-        self.assertEquals(("Hello Blow", []), substitute("Hello @(Proper(remove_first_word(contact)))", dict()))
-        self.assertEquals(("Hello Joe Blow", []), substitute("Hello @(PROPER(contact))", dict()))
-        self.assertEquals(("Hello JOE", []), substitute("Hello @(UPPER(contact.first_name))", dict()))
-        self.assertEquals(("Hello 3", []), substitute("Hello @(contact.goats)", dict()))
+        self.assertEqual(("Hello joe", []), substitute("Hello @(LOWER(contact.first_name))", dict()))
+        self.assertEqual(("Hello Joe", []), substitute("Hello @(PROPER(LOWER(contact.first_name)))", dict()))
+        self.assertEqual(("Hello Joe", []), substitute("Hello @(first_word(contact))", dict()))
+        self.assertEqual(("Hello Blow", []), substitute("Hello @(Proper(remove_first_word(contact)))", dict()))
+        self.assertEqual(("Hello Joe Blow", []), substitute("Hello @(PROPER(contact))", dict()))
+        self.assertEqual(("Hello JOE", []), substitute("Hello @(UPPER(contact.first_name))", dict()))
+        self.assertEqual(("Hello 3", []), substitute("Hello @(contact.goats)", dict()))
 
-        self.assertEquals(("Email is: foo@bar.com", []),
-                          substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@bar.com"))))
-        self.assertEquals(("Email is: foo@@bar.com", []),
-                          substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@@bar.com"))))
+        self.assertEqual(("Email is: foo@bar.com", []),
+                         substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@bar.com"))))
+        self.assertEqual(("Email is: foo@@bar.com", []),
+                         substitute("Email is: @(remove_first_word(flow.sms))", dict(flow=dict(sms="Join foo@@bar.com"))))
 
         # check date variables
         text, errors = substitute("Today is @date.today", dict())
-        self.assertEquals(errors, [])
-        self.assertRegexpMatches(text, "Today is \d\d-\d\d-\d\d\d\d")
+        self.assertEqual(errors, [])
+        self.assertRegex(text, "Today is \d\d-\d\d-\d\d\d\d")
 
         text, errors = substitute("Today is @date.now", dict())
-        self.assertEquals(errors, [])
-        self.assertRegexpMatches(text, "Today is \d\d-\d\d-\d\d\d\d \d\d:\d\d")
+        self.assertEqual(errors, [])
+        self.assertRegex(text, "Today is \d\d-\d\d-\d\d\d\d \d\d:\d\d")
 
         text, errors = substitute("Your DOB is @contact.dob", dict())
-        self.assertEquals(errors, [])
+        self.assertEqual(errors, [])
         # TODO clearly this is not ideal but unavoidable for now as we always add current time to parsed dates
-        self.assertRegexpMatches(text, "Your DOB is 28-05-1981 \d\d:\d\d")
+        self.assertRegex(text, "Your DOB is 28-05-1981 \d\d:\d\d")
 
         # unicode tests
         self.joe.name = u"شاملیدل عمومی"
         self.joe.save()
 
-        self.assertEquals((u"شاملیدل", []), substitute("@(first_word(contact))", dict()))
-        self.assertEquals((u"عمومی", []), substitute("@(proper(remove_first_word(contact)))", dict()))
+        self.assertEqual((u"شاملیدل", []), substitute("@(first_word(contact))", dict()))
+        self.assertEqual((u"عمومی", []), substitute("@(proper(remove_first_word(contact)))", dict()))
 
         # credit card
         self.joe.name = '1234567890123456'
         self.joe.save()
-        self.assertEquals(("1 2 3 4 , 5 6 7 8 , 9 0 1 2 , 3 4 5 6", []), substitute("@(read_digits(contact))", dict()))
+        self.assertEqual(("1 2 3 4 , 5 6 7 8 , 9 0 1 2 , 3 4 5 6", []), substitute("@(read_digits(contact))", dict()))
 
         # phone number
         self.joe.name = '123456789012'
         self.joe.save()
-        self.assertEquals(("1 2 3 , 4 5 6 , 7 8 9 , 0 1 2", []), substitute("@(read_digits(contact))", dict()))
+        self.assertEqual(("1 2 3 , 4 5 6 , 7 8 9 , 0 1 2", []), substitute("@(read_digits(contact))", dict()))
 
         # triplets
         self.joe.name = '123456'
         self.joe.save()
-        self.assertEquals(("1 2 3 , 4 5 6", []), substitute("@(read_digits(contact))", dict()))
+        self.assertEqual(("1 2 3 , 4 5 6", []), substitute("@(read_digits(contact))", dict()))
 
         # soc security
         self.joe.name = '123456789'
         self.joe.save()
-        self.assertEquals(("1 2 3 , 4 5 , 6 7 8 9", []), substitute("@(read_digits(contact))", dict()))
+        self.assertEqual(("1 2 3 , 4 5 , 6 7 8 9", []), substitute("@(read_digits(contact))", dict()))
 
         # regular number, street address, etc
         self.joe.name = '12345'
         self.joe.save()
-        self.assertEquals(("1,2,3,4,5", []), substitute("@(read_digits(contact))", dict()))
+        self.assertEqual(("1,2,3,4,5", []), substitute("@(read_digits(contact))", dict()))
 
         # regular number, street address, etc
         self.joe.name = '123'
         self.joe.save()
-        self.assertEquals(("1,2,3", []), substitute("@(read_digits(contact))", dict()))
+        self.assertEqual(("1,2,3", []), substitute("@(read_digits(contact))", dict()))
 
     def test_expressions_context(self):
         ContactField.get_or_create(self.org, self.admin, "superhero_name", "Superhero Name")
@@ -1326,17 +1326,17 @@ class BroadcastTest(TembaTest):
         self.broadcast.send(trigger_send=False)
 
         # no message created for Frank because he misses some fields for variables substitution
-        self.assertEquals(Msg.objects.all().count(), 3)
+        self.assertEqual(Msg.objects.all().count(), 3)
 
         sms_to_joe = Msg.objects.get(contact=self.joe)
         sms_to_frank = Msg.objects.get(contact=self.frank)
         sms_to_kevin = Msg.objects.get(contact=self.kevin)
 
-        self.assertEquals(sms_to_joe.text, 'Hi Joe Blow, You live in Kacyiru and your team is Amavubi.')
+        self.assertEqual(sms_to_joe.text, 'Hi Joe Blow, You live in Kacyiru and your team is Amavubi.')
         self.assertFalse(sms_to_joe.has_template_error)
-        self.assertEquals(sms_to_frank.text, 'Hi Frank Blow, You live in Remera and your team is .')
+        self.assertEqual(sms_to_frank.text, 'Hi Frank Blow, You live in Remera and your team is .')
         self.assertFalse(sms_to_frank.has_template_error)
-        self.assertEquals(sms_to_kevin.text, 'Hi Kevin Durant, You live in Kanombe and your team is Junior.')
+        self.assertEqual(sms_to_kevin.text, 'Hi Kevin Durant, You live in Kanombe and your team is Junior.')
         self.assertFalse(sms_to_kevin.has_template_error)
 
     def test_purge(self):
@@ -1807,11 +1807,11 @@ class LabelCRUDLTest(TembaTest):
 
         self.login(self.user)
         response = self.client.get(delete_url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         self.login(self.admin)
         response = self.client.get(delete_url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_list(self):
         folder = Label.get_or_create_folder(self.org, self.user, "Folder")
@@ -1867,18 +1867,18 @@ class ScheduleTest(TembaTest):
         self.assertFalse(sms.high_priority)
 
         # we should now have 11 messages pending
-        self.assertEquals(11, Msg.objects.filter(channel=self.channel, status=PENDING).count())
+        self.assertEqual(11, Msg.objects.filter(channel=self.channel, status=PENDING).count())
 
         # let's trigger a sending of the messages
         self.org.trigger_send()
 
         # we still should have 11 messages that have sent
-        self.assertEquals(11, Msg.objects.filter(channel=self.channel, status=PENDING).count())
+        self.assertEqual(11, Msg.objects.filter(channel=self.channel, status=PENDING).count())
 
         # let's trigger a sending of the messages again
         self.org.trigger_send(Msg.objects.filter(channel=self.channel, status=PENDING))
 
-        self.assertEquals(11, Msg.objects.filter(channel=self.channel, status=WIRED).count())
+        self.assertEqual(11, Msg.objects.filter(channel=self.channel, status=WIRED).count())
 
 
 class ConsoleTest(TembaTest):
@@ -1912,7 +1912,7 @@ class ConsoleTest(TembaTest):
 
     def test_msg_console(self):
         # make sure our org is properly set
-        self.assertEquals(self.console.org, self.org)
+        self.assertEqual(self.console.org, self.org)
 
         # try changing it with something empty
         self.console.do_org("")
@@ -1920,18 +1920,18 @@ class ConsoleTest(TembaTest):
         self.assertEchoed("Temba")
 
         # shouldn't have changed current org
-        self.assertEquals(self.console.org, self.org)
+        self.assertEqual(self.console.org, self.org)
 
         # try changing entirely
         self.console.do_org("%d" % self.org2.id)
         self.assertEchoed("You are now sending messages for Trileet Inc.")
-        self.assertEquals(self.console.org, self.org2)
-        self.assertEquals(self.console.contact.org, self.org2)
+        self.assertEqual(self.console.org, self.org2)
+        self.assertEqual(self.console.contact.org, self.org2)
 
         # back to temba
         self.console.do_org("%d" % self.org.id)
-        self.assertEquals(self.console.org, self.org)
-        self.assertEquals(self.console.contact.org, self.org)
+        self.assertEqual(self.console.org, self.org)
+        self.assertEqual(self.console.contact.org, self.org)
 
         # contact help
         self.console.do_contact("")
@@ -1940,7 +1940,7 @@ class ConsoleTest(TembaTest):
         # switch our contact
         self.console.do_contact("0788123123")
         self.assertEchoed("You are now sending as John")
-        self.assertEquals(self.console.contact, self.john)
+        self.assertEqual(self.console.contact, self.john)
 
         # send a message
         self.console.default("Hello World")
@@ -1948,9 +1948,9 @@ class ConsoleTest(TembaTest):
 
         # make sure the message was created for our contact and handled
         msg = Msg.objects.get()
-        self.assertEquals(msg.text, "Hello World")
-        self.assertEquals(msg.contact, self.john)
-        self.assertEquals(msg.status, HANDLED)
+        self.assertEqual(msg.text, "Hello World")
+        self.assertEqual(msg.contact, self.john)
+        self.assertEqual(msg.status, HANDLED)
 
         # now trigger a flow
         self.console.default("Color")
@@ -1989,9 +1989,9 @@ class BroadcastLanguageTest(TembaTest):
         bcast.send()
 
         # assert the right language was used for each contact
-        self.assertEquals(fre_msg, Msg.objects.get(contact=self.francois).text)
-        self.assertEquals(eng_msg, Msg.objects.get(contact=self.greg).text)
-        self.assertEquals(fre_msg, Msg.objects.get(contact=self.wilbert).text)
+        self.assertEqual(fre_msg, Msg.objects.get(contact=self.francois).text)
+        self.assertEqual(eng_msg, Msg.objects.get(contact=self.greg).text)
+        self.assertEqual(fre_msg, Msg.objects.get(contact=self.wilbert).text)
 
         eng_msg = "Please see attachment"
         fre_msg = "SVP regardez l'attachement."

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -139,7 +139,7 @@ class OrgTest(TembaTest):
 
         # can we see the edit page
         response = self.client.get(reverse('orgs.org_edit'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # update the name and slug of the organization
         data = dict(name="Temba", timezone="Africa/Kigali", date_format=DAYFIRST, slug="nice temba")
@@ -148,36 +148,36 @@ class OrgTest(TembaTest):
 
         data = dict(name="Temba", timezone="Africa/Kigali", date_format=MONTHFIRST, slug="nice-temba")
         response = self.client.post(reverse('orgs.org_edit'), data)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         org = Org.objects.get(pk=self.org.pk)
-        self.assertEquals("Temba", org.name)
-        self.assertEquals("nice-temba", org.slug)
+        self.assertEqual("Temba", org.name)
+        self.assertEqual("nice-temba", org.slug)
 
     def test_recommended_channel(self):
         self.org.timezone = pytz.timezone('Africa/Nairobi')
         self.org.save()
-        self.assertEquals(self.org.get_recommended_channel(), 'AT')
+        self.assertEqual(self.org.get_recommended_channel(), 'AT')
 
         self.org.timezone = pytz.timezone('America/Phoenix')
         self.org.save()
-        self.assertEquals(self.org.get_recommended_channel(), 'T')
+        self.assertEqual(self.org.get_recommended_channel(), 'T')
 
         self.org.timezone = pytz.timezone('Asia/Jakarta')
         self.org.save()
-        self.assertEquals(self.org.get_recommended_channel(), 'H9')
+        self.assertEqual(self.org.get_recommended_channel(), 'H9')
 
         self.org.timezone = pytz.timezone('Africa/Mogadishu')
         self.org.save()
-        self.assertEquals(self.org.get_recommended_channel(), 'SQ')
+        self.assertEqual(self.org.get_recommended_channel(), 'SQ')
 
         self.org.timezone = pytz.timezone('Europe/Amsterdam')
         self.org.save()
-        self.assertEquals(self.org.get_recommended_channel(), 'NX')
+        self.assertEqual(self.org.get_recommended_channel(), 'NX')
 
         self.org.timezone = pytz.timezone('Africa/Kigali')
         self.org.save()
-        self.assertEquals(self.org.get_recommended_channel(), 'A')
+        self.assertEqual(self.org.get_recommended_channel(), 'A')
 
     def test_country(self):
         country_url = reverse('orgs.org_country')
@@ -188,7 +188,7 @@ class OrgTest(TembaTest):
         # login as admin instead
         self.login(self.admin)
         response = self.client.get(country_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # save with Rwanda as a country
         response = self.client.post(country_url, dict(country=AdminBoundary.objects.get(name='Rwanda').pk))
@@ -211,7 +211,7 @@ class OrgTest(TembaTest):
         # assert it has been
         org = Org.objects.get(pk=self.org.pk)
         self.assertFalse(org.country)
-        self.assertEquals('RW', org.get_country_code())
+        self.assertEqual('RW', org.get_country_code())
 
         # remove all our channels so we no longer have a backdown
         org.channels.all().delete()
@@ -226,8 +226,8 @@ class OrgTest(TembaTest):
         self.create_msg(direction=INCOMING, contact=self.contact, text="Orange")
 
         # check start and end date for this plan
-        self.assertEquals(timezone.now().date(), self.org.current_plan_start())
-        self.assertEquals(timezone.now().date() + relativedelta(months=1), self.org.current_plan_end())
+        self.assertEqual(timezone.now().date(), self.org.current_plan_start())
+        self.assertEqual(timezone.now().date() + relativedelta(months=1), self.org.current_plan_end())
 
         # check our credits
         self.login(self.admin)
@@ -266,18 +266,18 @@ class OrgTest(TembaTest):
 
         # check that our user settings have changed
         settings = self.admin.get_settings()
-        self.assertEquals('pt-br', settings.language)
+        self.assertEqual('pt-br', settings.language)
 
     def test_usersettings(self):
         self.login(self.admin)
 
         post_data = dict(tel='+250788382382')
         self.client.post(reverse('orgs.usersettings_phone'), post_data)
-        self.assertEquals('+250 788 382 382', UserSettings.objects.get(user=self.admin).get_tel_formatted())
+        self.assertEqual('+250 788 382 382', UserSettings.objects.get(user=self.admin).get_tel_formatted())
 
         post_data = dict(tel='bad number')
         response = self.client.post(reverse('orgs.usersettings_phone'), post_data)
-        self.assertEquals(response.context['form'].errors['tel'][0], 'Invalid phone number, try again.')
+        self.assertEqual(response.context['form'].errors['tel'][0], 'Invalid phone number, try again.')
 
     def test_org_suspension(self):
         from temba.flows.models import FlowRun
@@ -297,16 +297,16 @@ class OrgTest(TembaTest):
         post_data = dict(text="send me ur bank account login im ur friend.", omnibox="c-%s" % mark.uuid)
         response = self.client.post(send_url, post_data, follow=True)
 
-        self.assertEquals('Sorry, your account is currently suspended. To enable sending messages, please contact support.',
-                          response.context['form'].errors['__all__'][0])
+        self.assertEqual('Sorry, your account is currently suspended. To enable sending messages, please contact support.',
+                         response.context['form'].errors['__all__'][0])
 
         # we also can't start flows
         flow = self.create_flow()
         post_data = dict(omnibox="c-%s" % mark.uuid, restart_participants='on')
         response = self.client.post(reverse('flows.flow_broadcast', args=[flow.pk]), post_data, follow=True)
 
-        self.assertEquals('Sorry, your account is currently suspended. To enable sending messages, please contact support.',
-                          response.context['form'].errors['__all__'][0])
+        self.assertEqual('Sorry, your account is currently suspended. To enable sending messages, please contact support.',
+                         response.context['form'].errors['__all__'][0])
 
         # or use the api to do either
         def postAPI(url, data):
@@ -344,7 +344,7 @@ class OrgTest(TembaTest):
         self.login(self.admin)
 
         response = self.client.get(update_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # set a webhook with headers
         post_data = response.context['form'].initial
@@ -353,12 +353,12 @@ class OrgTest(TembaTest):
         post_data['header_1_value'] = 'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
 
         response = self.client.post(update_url, post_data)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
         self.assertRedirect(response, reverse('orgs.org_home'))
 
         # check that our webhook settings have changed
         org = Org.objects.get(pk=self.org.pk)
-        self.assertEquals('http://webhooks.uniceflabs.org', org.get_webhook_url())
+        self.assertEqual('http://webhooks.uniceflabs.org', org.get_webhook_url())
         self.assertDictEqual({'Authorization': 'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='}, org.get_webhook_headers())
 
     def test_org_administration(self):
@@ -386,7 +386,7 @@ class OrgTest(TembaTest):
         self.login(self.superuser)
 
         response = self.client.get(manage_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertNotContains(response, "(Suspended)")
 
         self.org.set_suspended()
@@ -398,7 +398,7 @@ class OrgTest(TembaTest):
 
         # and can go to that org
         response = self.client.get(update_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # change to the trial plan
         post_data = {
@@ -422,7 +422,7 @@ class OrgTest(TembaTest):
         }
 
         response = self.client.post(update_url, post_data)
-        self.assertEquals(302, response.status_code)
+        self.assertEqual(302, response.status_code)
 
         # restore
         post_data['status'] = RESTORED
@@ -732,12 +732,12 @@ class OrgTest(TembaTest):
         self.client.logout()
 
         response = self.client.get(admin_create_login_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
-        self.assertEquals(self.org.pk, response.context['org'].pk)
+        self.assertEqual(self.org.pk, response.context['org'].pk)
 
         # we have a form with 4 fields and one hidden 'loc'
-        self.assertEquals(5, len(response.context['form'].fields))
+        self.assertEqual(5, len(response.context['form'].fields))
         self.assertTrue('first_name' in response.context['form'].fields)
         self.assertTrue('last_name' in response.context['form'].fields)
         self.assertTrue('email' in response.context['form'].fields)
@@ -750,7 +750,7 @@ class OrgTest(TembaTest):
         post_data['password'] = "norbertkwizeranorbert"
 
         response = self.client.post(admin_create_login_url, post_data, follow=True)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         new_invited_user = User.objects.get(email="norkans7@gmail.com")
         self.assertTrue(new_invited_user in self.org.administrators.all())
@@ -768,10 +768,10 @@ class OrgTest(TembaTest):
 
         post_data = dict(first_name='Surveyor', last_name='User', email='surveyor@gmail.com', password='password')
         response = self.client.post(admin_create_login_url, post_data, follow=True)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # as a surveyor we should have been rerourted
-        self.assertEquals(reverse('orgs.org_surveyor'), response._request.path)
+        self.assertEqual(reverse('orgs.org_surveyor'), response._request.path)
         self.assertFalse(Invitation.objects.get(pk=surveyor_invite.pk).is_active)
 
         # make sure we are a surveyor
@@ -781,8 +781,8 @@ class OrgTest(TembaTest):
         # if we login, we should be rerouted too
         self.client.logout()
         response = self.client.post('/users/login/', {'username': 'surveyor@gmail.com', 'password': 'password'}, follow=True)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(reverse('orgs.org_surveyor'), response._request.path)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(reverse('orgs.org_surveyor'), response._request.path)
 
     def test_surveyor(self):
         self.client.logout()
@@ -851,13 +851,13 @@ class OrgTest(TembaTest):
         self.login(self.admin)
 
         response = self.client.get(reverse('orgs.org_home'))
-        self.assertEquals(response.context['org'], self.org)
+        self.assertEqual(response.context['org'], self.org)
 
         # add self.manager to self.org2 viewers
         self.org2.viewers.add(self.admin)
 
         response = self.client.get(choose_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         self.assertTrue('organization' in response.context['form'].fields)
 
@@ -865,9 +865,9 @@ class OrgTest(TembaTest):
         post_data['organization'] = self.org2.pk
 
         response = self.client.post(choose_url, post_data, follow=True)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         response = self.client.get(reverse('orgs.org_home'))
-        self.assertEquals(response.context_data['org'], self.org2)
+        self.assertEqual(response.context_data['org'], self.org2)
 
         # a non org user get's logged out
         self.login(self.non_org_user)
@@ -899,19 +899,19 @@ class OrgTest(TembaTest):
 
         # should list our one topup
         response = self.client.get(manage_url)
-        self.assertEquals(1, len(response.context['object_list']))
+        self.assertEqual(1, len(response.context['object_list']))
 
         # create a new one
         post_data = dict(price='1000', credits='500', comment="")
         response = self.client.post(create_url, post_data)
-        self.assertEquals(2, TopUp.objects.filter(org=self.org).count())
-        self.assertEquals(1500, self.org.get_credits_remaining())
+        self.assertEqual(2, TopUp.objects.filter(org=self.org).count())
+        self.assertEqual(1500, self.org.get_credits_remaining())
 
         # update one of our topups
         post_data = dict(is_active=True, price='0', credits='5000', comment="", expires_on="2025-04-03 13:47:46")
         response = self.client.post(update_url, post_data)
 
-        self.assertEquals(5500, self.org.get_credits_remaining())
+        self.assertEqual(5500, self.org.get_credits_remaining())
 
     def test_topup_model(self):
         topup = TopUp.create(self.admin, price=None, credits=1000)
@@ -943,22 +943,22 @@ class OrgTest(TembaTest):
         create_msgs(contact, 10)
 
         with self.assertNumQueries(1):
-            self.assertEquals(150, self.org.get_low_credits_threshold())
+            self.assertEqual(150, self.org.get_low_credits_threshold())
 
         with self.assertNumQueries(0):
-            self.assertEquals(150, self.org.get_low_credits_threshold())
+            self.assertEqual(150, self.org.get_low_credits_threshold())
 
         # we should have 1000 minus 10 credits for this org
         with self.assertNumQueries(4):
-            self.assertEquals(990, self.org.get_credits_remaining())  # from db
+            self.assertEqual(990, self.org.get_credits_remaining())  # from db
 
         with self.assertNumQueries(0):
-            self.assertEquals(1000, self.org.get_credits_total())  # from cache
-            self.assertEquals(10, self.org.get_credits_used())
-            self.assertEquals(990, self.org.get_credits_remaining())
+            self.assertEqual(1000, self.org.get_credits_total())  # from cache
+            self.assertEqual(10, self.org.get_credits_used())
+            self.assertEqual(990, self.org.get_credits_remaining())
 
-        self.assertEquals(10, welcome_topup.msgs.count())
-        self.assertEquals(10, TopUp.objects.get(pk=welcome_topup.pk).get_used())
+        self.assertEqual(10, welcome_topup.msgs.count())
+        self.assertEqual(10, TopUp.objects.get(pk=welcome_topup.pk).get_used())
 
         # at this point we shouldn't have squashed any topupcredits, so should have the same number as our used
         self.assertEqual(10, TopUpCredits.objects.all().count())
@@ -973,31 +973,31 @@ class OrgTest(TembaTest):
         TopUp.objects.filter(pk=welcome_topup.pk).update(credits=15)
         self.org.update_caches(OrgEvent.topup_updated, None)  # invalidates our credits remaining cache
 
-        self.assertEquals(15, self.org.get_credits_total())
-        self.assertEquals(5, self.org.get_credits_remaining())
+        self.assertEqual(15, self.org.get_credits_total())
+        self.assertEqual(5, self.org.get_credits_remaining())
 
         # create 10 more messages, only 5 of which will get a topup
         create_msgs(contact, 10)
 
-        self.assertEquals(15, TopUp.objects.get(pk=welcome_topup.pk).msgs.count())
-        self.assertEquals(15, TopUp.objects.get(pk=welcome_topup.pk).get_used())
+        self.assertEqual(15, TopUp.objects.get(pk=welcome_topup.pk).msgs.count())
+        self.assertEqual(15, TopUp.objects.get(pk=welcome_topup.pk).get_used())
 
         self.assertFalse(self.org._calculate_active_topup())
 
         with self.assertNumQueries(0):
-            self.assertEquals(15, self.org.get_credits_total())
-            self.assertEquals(20, self.org.get_credits_used())
-            self.assertEquals(-5, self.org.get_credits_remaining())
+            self.assertEqual(15, self.org.get_credits_total())
+            self.assertEqual(20, self.org.get_credits_used())
+            self.assertEqual(-5, self.org.get_credits_remaining())
 
         # again create 10 more messages, none of which will get a topup
         create_msgs(contact, 10)
 
         with self.assertNumQueries(0):
-            self.assertEquals(15, self.org.get_credits_total())
-            self.assertEquals(30, self.org.get_credits_used())
-            self.assertEquals(-15, self.org.get_credits_remaining())
+            self.assertEqual(15, self.org.get_credits_total())
+            self.assertEqual(30, self.org.get_credits_used())
+            self.assertEqual(-15, self.org.get_credits_remaining())
 
-        self.assertEquals(15, TopUp.objects.get(pk=welcome_topup.pk).get_used())
+        self.assertEqual(15, TopUp.objects.get(pk=welcome_topup.pk).get_used())
 
         # raise our topup to take 20 and create another for 5
         TopUp.objects.filter(pk=welcome_topup.pk).update(credits=20)
@@ -1007,19 +1007,19 @@ class OrgTest(TembaTest):
         # apply topups which will max out both and reduce debt to 5
         self.org.apply_topups()
 
-        self.assertEquals(20, welcome_topup.msgs.count())
-        self.assertEquals(20, TopUp.objects.get(pk=welcome_topup.pk).get_used())
-        self.assertEquals(5, new_topup.msgs.count())
-        self.assertEquals(5, TopUp.objects.get(pk=new_topup.pk).get_used())
-        self.assertEquals(25, self.org.get_credits_total())
-        self.assertEquals(30, self.org.get_credits_used())
-        self.assertEquals(-5, self.org.get_credits_remaining())
+        self.assertEqual(20, welcome_topup.msgs.count())
+        self.assertEqual(20, TopUp.objects.get(pk=welcome_topup.pk).get_used())
+        self.assertEqual(5, new_topup.msgs.count())
+        self.assertEqual(5, TopUp.objects.get(pk=new_topup.pk).get_used())
+        self.assertEqual(25, self.org.get_credits_total())
+        self.assertEqual(30, self.org.get_credits_used())
+        self.assertEqual(-5, self.org.get_credits_remaining())
 
         # create a message from our test contact, should not count against our totals
         test_msg = self.create_msg(contact=test_contact, direction='I', text="Test")
 
         self.assertIsNone(test_msg.topup_id)
-        self.assertEquals(30, self.org.get_credits_used())
+        self.assertEqual(30, self.org.get_credits_used())
 
         # test special status
         self.assertFalse(self.org.is_multi_user_tier())
@@ -1033,21 +1033,21 @@ class OrgTest(TembaTest):
         self.org.apply_topups()
         self.assertFalse(Msg.objects.filter(org=self.org, contact__is_test=False, topup=None))
         self.assertFalse(Msg.objects.filter(org=self.org, contact__is_test=True).exclude(topup=None))
-        self.assertEquals(5, TopUp.objects.get(pk=mega_topup.pk).get_used())
+        self.assertEqual(5, TopUp.objects.get(pk=mega_topup.pk).get_used())
 
         # we aren't yet multi user since this topup was free
-        self.assertEquals(0, self.org.get_purchased_credits())
+        self.assertEqual(0, self.org.get_purchased_credits())
         self.assertFalse(self.org.is_multi_user_tier())
 
-        self.assertEquals(100025, self.org.get_credits_total())
-        self.assertEquals(30, self.org.get_credits_used())
-        self.assertEquals(99995, self.org.get_credits_remaining())
+        self.assertEqual(100025, self.org.get_credits_total())
+        self.assertEqual(30, self.org.get_credits_used())
+        self.assertEqual(99995, self.org.get_credits_remaining())
 
         # and new messages use the mega topup
         msg = self.create_msg(contact=contact, direction='I', text="Test")
-        self.assertEquals(msg.topup, mega_topup)
+        self.assertEqual(msg.topup, mega_topup)
 
-        self.assertEquals(6, TopUp.objects.get(pk=mega_topup.pk).get_used())
+        self.assertEqual(6, TopUp.objects.get(pk=mega_topup.pk).get_used())
 
         # but now it expires
         yesterday = timezone.now() - relativedelta(days=1)
@@ -1063,10 +1063,10 @@ class OrgTest(TembaTest):
         self.org.update_caches(OrgEvent.topup_updated, None)
 
         with self.assertNumQueries(3):
-            self.assertEquals(0, self.org.get_purchased_credits())
-            self.assertEquals(31, self.org.get_credits_total())
-            self.assertEquals(32, self.org.get_credits_used())
-            self.assertEquals(-1, self.org.get_credits_remaining())
+            self.assertEqual(0, self.org.get_purchased_credits())
+            self.assertEqual(31, self.org.get_credits_total())
+            self.assertEqual(32, self.org.get_credits_used())
+            self.assertEqual(-1, self.org.get_credits_remaining())
 
         # all top up expired
         TopUp.objects.all().update(expires_on=yesterday)
@@ -1080,14 +1080,14 @@ class OrgTest(TembaTest):
         self.org.apply_topups()
 
         with self.assertNumQueries(3):
-            self.assertEquals(99, self.org.get_credits_expiring_soon())
+            self.assertEqual(99, self.org.get_credits_expiring_soon())
 
         with self.assertNumQueries(1):
-            self.assertEquals(15, self.org.get_low_credits_threshold())
+            self.assertEqual(15, self.org.get_low_credits_threshold())
 
         with self.assertNumQueries(0):
-            self.assertEquals(99, self.org.get_credits_expiring_soon())
-            self.assertEquals(15, self.org.get_low_credits_threshold())
+            self.assertEqual(99, self.org.get_credits_expiring_soon())
+            self.assertEqual(15, self.org.get_low_credits_threshold())
 
         # some cedits expires but more credits will remain active
         later_active_topup = TopUp.create(self.admin, price=0, credits=200)
@@ -1098,14 +1098,14 @@ class OrgTest(TembaTest):
         self.org.apply_topups()
 
         with self.assertNumQueries(3):
-            self.assertEquals(0, self.org.get_credits_expiring_soon())
+            self.assertEqual(0, self.org.get_credits_expiring_soon())
 
         with self.assertNumQueries(1):
-            self.assertEquals(45, self.org.get_low_credits_threshold())
+            self.assertEqual(45, self.org.get_low_credits_threshold())
 
         with self.assertNumQueries(0):
-            self.assertEquals(0, self.org.get_credits_expiring_soon())
-            self.assertEquals(45, self.org.get_low_credits_threshold())
+            self.assertEqual(0, self.org.get_credits_expiring_soon())
+            self.assertEqual(45, self.org.get_low_credits_threshold())
 
         # no expiring credits
         gift_topup.expires_on = five_week_ahead
@@ -1114,14 +1114,14 @@ class OrgTest(TembaTest):
         self.org.apply_topups()
 
         with self.assertNumQueries(3):
-            self.assertEquals(0, self.org.get_credits_expiring_soon())
+            self.assertEqual(0, self.org.get_credits_expiring_soon())
 
         with self.assertNumQueries(1):
-            self.assertEquals(45, self.org.get_low_credits_threshold())
+            self.assertEqual(45, self.org.get_low_credits_threshold())
 
         with self.assertNumQueries(0):
-            self.assertEquals(0, self.org.get_credits_expiring_soon())
-            self.assertEquals(45, self.org.get_low_credits_threshold())
+            self.assertEqual(0, self.org.get_credits_expiring_soon())
+            self.assertEqual(45, self.org.get_low_credits_threshold())
 
         # do not consider expired topup
         gift_topup.expires_on = yesterday
@@ -1130,24 +1130,24 @@ class OrgTest(TembaTest):
         self.org.apply_topups()
 
         with self.assertNumQueries(3):
-            self.assertEquals(0, self.org.get_credits_expiring_soon())
+            self.assertEqual(0, self.org.get_credits_expiring_soon())
 
         with self.assertNumQueries(1):
-            self.assertEquals(30, self.org.get_low_credits_threshold())
+            self.assertEqual(30, self.org.get_low_credits_threshold())
 
         with self.assertNumQueries(0):
-            self.assertEquals(0, self.org.get_credits_expiring_soon())
-            self.assertEquals(30, self.org.get_low_credits_threshold())
+            self.assertEqual(0, self.org.get_credits_expiring_soon())
+            self.assertEqual(30, self.org.get_low_credits_threshold())
 
         TopUp.objects.all().update(is_active=False)
         self.org.update_caches(OrgEvent.topup_updated, None)
         self.org.apply_topups()
 
         with self.assertNumQueries(1):
-            self.assertEquals(0, self.org.get_low_credits_threshold())
+            self.assertEqual(0, self.org.get_low_credits_threshold())
 
         with self.assertNumQueries(0):
-            self.assertEquals(0, self.org.get_low_credits_threshold())
+            self.assertEqual(0, self.org.get_low_credits_threshold())
 
         # now buy some credits to make us multi user
         TopUp.create(self.admin, price=100, credits=100000)
@@ -1173,7 +1173,7 @@ class OrgTest(TembaTest):
             self.admin.set_org(self.org)
 
             response = self.client.get(connect_url)
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             self.assertEqual(list(response.context['form'].fields.keys()), ['account_sid', 'account_token', 'loc'])
 
             # try posting without an account token
@@ -1194,8 +1194,8 @@ class OrgTest(TembaTest):
             self.client.post(connect_url, post_data)
 
             self.org.refresh_from_db()
-            self.assertEquals(self.org.config_json()['ACCOUNT_SID'], "AccountSid")
-            self.assertEquals(self.org.config_json()['ACCOUNT_TOKEN'], "AccountToken")
+            self.assertEqual(self.org.config_json()['ACCOUNT_SID'], "AccountSid")
+            self.assertEqual(self.org.config_json()['ACCOUNT_TOKEN'], "AccountToken")
 
             # when the user submit the secondary token, we use it to get the primary one from the rest API
             with patch('temba.tests.MockTwilioClient.MockAccounts.get') as mock_get_primary:
@@ -1203,28 +1203,28 @@ class OrgTest(TembaTest):
 
                 self.client.post(connect_url, post_data)
                 self.org.refresh_from_db()
-                self.assertEquals(self.org.config_json()['ACCOUNT_SID'], "AccountSid")
-                self.assertEquals(self.org.config_json()['ACCOUNT_TOKEN'], "PrimaryAccountToken")
+                self.assertEqual(self.org.config_json()['ACCOUNT_SID'], "AccountSid")
+                self.assertEqual(self.org.config_json()['ACCOUNT_TOKEN'], "PrimaryAccountToken")
 
                 twilio_account_url = reverse('orgs.org_twilio_account')
                 response = self.client.get(twilio_account_url)
-                self.assertEquals("AccountSid", response.context['account_sid'])
+                self.assertEqual("AccountSid", response.context['account_sid'])
 
                 self.org.refresh_from_db()
                 config = self.org.config_json()
-                self.assertEquals('AccountSid', config['ACCOUNT_SID'])
-                self.assertEquals('PrimaryAccountToken', config['ACCOUNT_TOKEN'])
+                self.assertEqual('AccountSid', config['ACCOUNT_SID'])
+                self.assertEqual('PrimaryAccountToken', config['ACCOUNT_TOKEN'])
 
                 # post without a sid or token, should get a form validation error
                 response = self.client.post(twilio_account_url, dict(disconnect='false'), follow=True)
-                self.assertEquals('[{"message": "You must enter your Twilio Account SID", "code": ""}]',
-                                  response.context['form'].errors['__all__'].as_json())
+                self.assertEqual('[{"message": "You must enter your Twilio Account SID", "code": ""}]',
+                                 response.context['form'].errors['__all__'].as_json())
 
                 # all our twilio creds should remain the same
                 self.org.refresh_from_db()
                 config = self.org.config_json()
-                self.assertEquals(config['ACCOUNT_SID'], "AccountSid")
-                self.assertEquals(config['ACCOUNT_TOKEN'], "PrimaryAccountToken")
+                self.assertEqual(config['ACCOUNT_SID'], "AccountSid")
+                self.assertEqual(config['ACCOUNT_TOKEN'], "PrimaryAccountToken")
 
                 # now try with all required fields, and a bonus field we shouldn't change
                 self.client.post(twilio_account_url, dict(account_sid='AccountSid',
@@ -1233,7 +1233,7 @@ class OrgTest(TembaTest):
                                                           name='DO NOT CHANGE ME'), follow=True)
                 # name shouldn't change
                 self.org.refresh_from_db()
-                self.assertEquals(self.org.name, "Temba")
+                self.assertEqual(self.org.name, "Temba")
 
                 # now disconnect our twilio connection
                 self.assertTrue(self.org.is_connected_to_twilio())
@@ -1354,7 +1354,7 @@ class OrgTest(TembaTest):
         self.login(self.admin)
 
         self.org.refresh_from_db()
-        self.assertEquals((None, None), self.org.get_chatbase_credentials())
+        self.assertEqual((None, None), self.org.get_chatbase_credentials())
 
         chatbase_account_url = reverse('orgs.org_chatbase')
         response = self.client.get(chatbase_account_url)
@@ -1364,18 +1364,18 @@ class OrgTest(TembaTest):
 
         response = self.client.post(chatbase_account_url, payload, follow=True)
         self.assertContains(response, "Missing data: Agent Name or API Key.Please check them again and retry.")
-        self.assertEquals((None, None), self.org.get_chatbase_credentials())
+        self.assertEqual((None, None), self.org.get_chatbase_credentials())
 
         payload.update(dict(api_key='api_key', agent_name='chatbase_agent', type='user'))
 
         self.client.post(chatbase_account_url, payload, follow=True)
 
         self.org.refresh_from_db()
-        self.assertEquals(('api_key', '1.0'), self.org.get_chatbase_credentials())
+        self.assertEqual(('api_key', '1.0'), self.org.get_chatbase_credentials())
 
-        self.assertEquals(self.org.config_json()['CHATBASE_API_KEY'], 'api_key')
-        self.assertEquals(self.org.config_json()['CHATBASE_AGENT_NAME'], 'chatbase_agent')
-        self.assertEquals(self.org.config_json()['CHATBASE_VERSION'], '1.0')
+        self.assertEqual(self.org.config_json()['CHATBASE_API_KEY'], 'api_key')
+        self.assertEqual(self.org.config_json()['CHATBASE_AGENT_NAME'], 'chatbase_agent')
+        self.assertEqual(self.org.config_json()['CHATBASE_VERSION'], '1.0')
 
         with self.assertRaises(Exception):
             contact = self.create_contact('Anakin Skywalker', '+12067791212')
@@ -1397,7 +1397,7 @@ class OrgTest(TembaTest):
         self.client.post(chatbase_account_url, payload, follow=True)
 
         self.org.refresh_from_db()
-        self.assertEquals((None, None), self.org.get_chatbase_credentials())
+        self.assertEqual((None, None), self.org.get_chatbase_credentials())
 
         with self.settings(SEND_CHATBASE=True):
             contact = self.create_contact('Anakin Skywalker', '+12067791212')
@@ -1459,39 +1459,39 @@ class OrgTest(TembaTest):
         self.assertFalse(self.org.has_smtp_config())
 
         response = self.client.post(smtp_server_url, dict(disconnect='false'), follow=True)
-        self.assertEquals('[{"message": "You must enter a from email", "code": ""}]',
-                          response.context['form'].errors['__all__'].as_json())
+        self.assertEqual('[{"message": "You must enter a from email", "code": ""}]',
+                         response.context['form'].errors['__all__'].as_json())
 
         response = self.client.post(smtp_server_url, dict(smtp_from_email='foobar.com',
                                                           disconnect='false'), follow=True)
-        self.assertEquals('[{"message": "Please enter a valid email address", "code": ""}]',
-                          response.context['form'].errors['__all__'].as_json())
+        self.assertEqual('[{"message": "Please enter a valid email address", "code": ""}]',
+                         response.context['form'].errors['__all__'].as_json())
 
         response = self.client.post(smtp_server_url, dict(smtp_from_email='foo@bar.com',
                                                           disconnect='false'), follow=True)
-        self.assertEquals('[{"message": "You must enter the SMTP host", "code": ""}]',
-                          response.context['form'].errors['__all__'].as_json())
+        self.assertEqual('[{"message": "You must enter the SMTP host", "code": ""}]',
+                         response.context['form'].errors['__all__'].as_json())
 
         response = self.client.post(smtp_server_url, dict(smtp_from_email='foo@bar.com',
                                                           smtp_host='smtp.example.com',
                                                           disconnect='false'), follow=True)
-        self.assertEquals('[{"message": "You must enter the SMTP username", "code": ""}]',
-                          response.context['form'].errors['__all__'].as_json())
+        self.assertEqual('[{"message": "You must enter the SMTP username", "code": ""}]',
+                         response.context['form'].errors['__all__'].as_json())
 
         response = self.client.post(smtp_server_url, dict(smtp_from_email='foo@bar.com',
                                                           smtp_host='smtp.example.com',
                                                           smtp_username='support@example.com',
                                                           disconnect='false'), follow=True)
-        self.assertEquals('[{"message": "You must enter the SMTP password", "code": ""}]',
-                          response.context['form'].errors['__all__'].as_json())
+        self.assertEqual('[{"message": "You must enter the SMTP password", "code": ""}]',
+                         response.context['form'].errors['__all__'].as_json())
 
         response = self.client.post(smtp_server_url, dict(smtp_from_email='foo@bar.com',
                                                           smtp_host='smtp.example.com',
                                                           smtp_username='support@example.com',
                                                           smtp_password='secret',
                                                           disconnect='false'), follow=True)
-        self.assertEquals('[{"message": "You must enter the SMTP port", "code": ""}]',
-                          response.context['form'].errors['__all__'].as_json())
+        self.assertEqual('[{"message": "You must enter the SMTP port", "code": ""}]',
+                         response.context['form'].errors['__all__'].as_json())
 
         response = self.client.post(smtp_server_url, dict(smtp_from_email='foo@bar.com',
                                                           smtp_host='smtp.example.com',
@@ -1503,15 +1503,15 @@ class OrgTest(TembaTest):
 
         self.org.refresh_from_db()
         self.assertTrue(self.org.has_smtp_config())
-        self.assertEquals(self.org.config_json()['SMTP_FROM_EMAIL'], 'foo@bar.com')
-        self.assertEquals(self.org.config_json()['SMTP_HOST'], 'smtp.example.com')
-        self.assertEquals(self.org.config_json()['SMTP_USERNAME'], 'support@example.com')
-        self.assertEquals(self.org.config_json()['SMTP_PASSWORD'], 'secret')
-        self.assertEquals(self.org.config_json()['SMTP_PORT'], '465')
-        self.assertEquals(self.org.config_json()['SMTP_ENCRYPTION'], '')
+        self.assertEqual(self.org.config_json()['SMTP_FROM_EMAIL'], 'foo@bar.com')
+        self.assertEqual(self.org.config_json()['SMTP_HOST'], 'smtp.example.com')
+        self.assertEqual(self.org.config_json()['SMTP_USERNAME'], 'support@example.com')
+        self.assertEqual(self.org.config_json()['SMTP_PASSWORD'], 'secret')
+        self.assertEqual(self.org.config_json()['SMTP_PORT'], '465')
+        self.assertEqual(self.org.config_json()['SMTP_ENCRYPTION'], '')
 
         response = self.client.get(smtp_server_url)
-        self.assertEquals('foo@bar.com', response.context['flow_from_email'])
+        self.assertEqual('foo@bar.com', response.context['flow_from_email'])
 
         self.client.post(smtp_server_url, dict(smtp_from_email='support@example.com',
                                                smtp_host='smtp.example.com',
@@ -1524,7 +1524,7 @@ class OrgTest(TembaTest):
 
         # name shouldn't change
         self.org.refresh_from_db()
-        self.assertEquals(self.org.name, "Temba")
+        self.assertEqual(self.org.name, "Temba")
         self.assertTrue(self.org.has_smtp_config())
 
         self.client.post(smtp_server_url, dict(smtp_from_email='support@example.com',
@@ -1538,7 +1538,7 @@ class OrgTest(TembaTest):
         # password shouldn't change
         self.org.refresh_from_db()
         self.assertTrue(self.org.has_smtp_config())
-        self.assertEquals(self.org.config_json()['SMTP_PASSWORD'], 'secret')
+        self.assertEqual(self.org.config_json()['SMTP_PASSWORD'], 'secret')
 
         response = self.client.post(smtp_server_url, dict(smtp_from_email='support@example.com',
                                                           smtp_host='smtp.example.com',
@@ -1549,8 +1549,8 @@ class OrgTest(TembaTest):
                                                           disconnect='false'), follow=True)
 
         # should have error for blank password
-        self.assertEquals('[{"message": "You must enter the SMTP password", "code": ""}]',
-                          response.context['form'].errors['__all__'].as_json())
+        self.assertEqual('[{"message": "You must enter the SMTP password", "code": ""}]',
+                         response.context['form'].errors['__all__'].as_json())
 
         self.client.post(smtp_server_url, dict(disconnect='true'), follow=True)
 
@@ -1567,12 +1567,12 @@ class OrgTest(TembaTest):
 
         self.org.refresh_from_db()
         self.assertTrue(self.org.has_smtp_config())
-        self.assertEquals(self.org.config_json()['SMTP_FROM_EMAIL'], 'support@example.com')
-        self.assertEquals(self.org.config_json()['SMTP_HOST'], 'smtp.example.com')
-        self.assertEquals(self.org.config_json()['SMTP_USERNAME'], 'support@example.com')
-        self.assertEquals(self.org.config_json()['SMTP_PASSWORD'], 'secret')
-        self.assertEquals(self.org.config_json()['SMTP_PORT'], '465')
-        self.assertEquals(self.org.config_json()['SMTP_ENCRYPTION'], 'T')
+        self.assertEqual(self.org.config_json()['SMTP_FROM_EMAIL'], 'support@example.com')
+        self.assertEqual(self.org.config_json()['SMTP_HOST'], 'smtp.example.com')
+        self.assertEqual(self.org.config_json()['SMTP_USERNAME'], 'support@example.com')
+        self.assertEqual(self.org.config_json()['SMTP_PASSWORD'], 'secret')
+        self.assertEqual(self.org.config_json()['SMTP_PORT'], '465')
+        self.assertEqual(self.org.config_json()['SMTP_ENCRYPTION'], 'T')
 
     @patch('nexmo.Client.create_application')
     def test_connect_nexmo(self, mock_create_application):
@@ -1600,47 +1600,47 @@ class OrgTest(TembaTest):
                 # nexmo should now be connected
                 self.org = Org.objects.get(pk=self.org.pk)
                 self.assertTrue(self.org.is_connected_to_nexmo())
-                self.assertEquals(self.org.config_json()['NEXMO_KEY'], 'key')
-                self.assertEquals(self.org.config_json()['NEXMO_SECRET'], 'secret')
+                self.assertEqual(self.org.config_json()['NEXMO_KEY'], 'key')
+                self.assertEqual(self.org.config_json()['NEXMO_SECRET'], 'secret')
 
                 nexmo_uuid = self.org.config_json()['NEXMO_UUID']
 
-                self.assertEquals(mock_create_application.call_args_list[0][1]['params']['answer_url'],
-                                  "https://%s%s" % (settings.TEMBA_HOST.lower(),
-                                                    reverse('handlers.nexmo_call_handler', args=['answer',
-                                                                                                 nexmo_uuid])))
+                self.assertEqual(mock_create_application.call_args_list[0][1]['params']['answer_url'],
+                                 "https://%s%s" % (settings.TEMBA_HOST.lower(),
+                                                   reverse('handlers.nexmo_call_handler', args=['answer',
+                                                                                                nexmo_uuid])))
 
-                self.assertEquals(mock_create_application.call_args_list[0][1]['params']['event_url'],
-                                  "https://%s%s" % (settings.TEMBA_HOST.lower(),
-                                                    reverse('handlers.nexmo_call_handler', args=['event',
-                                                                                                 nexmo_uuid])))
+                self.assertEqual(mock_create_application.call_args_list[0][1]['params']['event_url'],
+                                 "https://%s%s" % (settings.TEMBA_HOST.lower(),
+                                                   reverse('handlers.nexmo_call_handler', args=['event',
+                                                                                                nexmo_uuid])))
 
-                self.assertEquals(mock_create_application.call_args_list[0][1]['params']['answer_method'], 'POST')
-                self.assertEquals(mock_create_application.call_args_list[0][1]['params']['event_method'], 'POST')
+                self.assertEqual(mock_create_application.call_args_list[0][1]['params']['answer_method'], 'POST')
+                self.assertEqual(mock_create_application.call_args_list[0][1]['params']['event_method'], 'POST')
 
-                self.assertEquals(mock_create_application.call_args_list[0][1]['params']['type'], 'voice')
-                self.assertEquals(mock_create_application.call_args_list[0][1]['params']['name'],
-                                  "%s/%s" % (settings.TEMBA_HOST.lower(), nexmo_uuid))
+                self.assertEqual(mock_create_application.call_args_list[0][1]['params']['type'], 'voice')
+                self.assertEqual(mock_create_application.call_args_list[0][1]['params']['name'],
+                                 "%s/%s" % (settings.TEMBA_HOST.lower(), nexmo_uuid))
 
                 nexmo_account_url = reverse('orgs.org_nexmo_account')
                 response = self.client.get(nexmo_account_url)
-                self.assertEquals("key", response.context['api_key'])
+                self.assertEqual("key", response.context['api_key'])
 
                 self.org.refresh_from_db()
                 config = self.org.config_json()
-                self.assertEquals('key', config[NEXMO_KEY])
-                self.assertEquals('secret', config[NEXMO_SECRET])
+                self.assertEqual('key', config[NEXMO_KEY])
+                self.assertEqual('secret', config[NEXMO_SECRET])
 
                 # post without api token, should get validation error
                 response = self.client.post(nexmo_account_url, dict(disconnect='false'), follow=True)
-                self.assertEquals('[{"message": "You must enter your Nexmo Account API Key", "code": ""}]',
-                                  response.context['form'].errors['__all__'].as_json())
+                self.assertEqual('[{"message": "You must enter your Nexmo Account API Key", "code": ""}]',
+                                 response.context['form'].errors['__all__'].as_json())
 
                 # nexmo config should remain the same
                 self.org.refresh_from_db()
                 config = self.org.config_json()
-                self.assertEquals('key', config[NEXMO_KEY])
-                self.assertEquals('secret', config[NEXMO_SECRET])
+                self.assertEqual('key', config[NEXMO_KEY])
+                self.assertEqual('secret', config[NEXMO_SECRET])
 
                 # now try with all required fields, and a bonus field we shouldn't change
                 self.client.post(nexmo_account_url, dict(api_key='other_key',
@@ -1649,7 +1649,7 @@ class OrgTest(TembaTest):
                                                          name='DO NOT CHNAGE ME'), follow=True)
                 # name shouldn't change
                 self.org.refresh_from_db()
-                self.assertEquals(self.org.name, "Temba")
+                self.assertEqual(self.org.name, "Temba")
 
                 # should change nexmo config
                 with patch('nexmo.Client.get_balance') as mock_get_balance:
@@ -1660,8 +1660,8 @@ class OrgTest(TembaTest):
 
                     self.org.refresh_from_db()
                     config = self.org.config_json()
-                    self.assertEquals('other_key', config[NEXMO_KEY])
-                    self.assertEquals('secret-too', config[NEXMO_SECRET])
+                    self.assertEqual('other_key', config[NEXMO_KEY])
+                    self.assertEqual('secret-too', config[NEXMO_SECRET])
 
                 self.assertTrue(self.org.is_connected_to_nexmo())
                 self.client.post(nexmo_account_url, dict(disconnect='true'), follow=True)
@@ -1735,8 +1735,8 @@ class OrgTest(TembaTest):
             self.client.post(connect_url, dict(auth_id='auth-id', auth_token='auth-token'))
 
             # plivo should be added to the session
-            self.assertEquals(self.client.session[Channel.CONFIG_PLIVO_AUTH_ID], 'auth-id')
-            self.assertEquals(self.client.session[Channel.CONFIG_PLIVO_AUTH_TOKEN], 'auth-token')
+            self.assertEqual(self.client.session[Channel.CONFIG_PLIVO_AUTH_ID], 'auth-id')
+            self.assertEqual(self.client.session[Channel.CONFIG_PLIVO_AUTH_TOKEN], 'auth-token')
 
     def test_tiers(self):
 
@@ -1990,7 +1990,7 @@ class AnonOrgTest(TembaTest):
         flow.start([], [contact])
 
         # should have one SMS
-        self.assertEquals(1, Msg.objects.all().count())
+        self.assertEqual(1, Msg.objects.all().count())
 
         # shouldn't show the number on the outgoing page
         response = self.client.get(reverse('msgs.msg_outbox'))
@@ -2032,7 +2032,7 @@ class OrgCRUDLTest(TembaTest):
         self.user.groups.add(granters)
 
         response = self.client.get(grant_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # fill out the form
         post_data = dict(email='john@carmack.com', first_name="John", last_name="Carmack",
@@ -2042,7 +2042,7 @@ class OrgCRUDLTest(TembaTest):
         self.assertContains(response, "created")
 
         org = Org.objects.get(name="Oculus")
-        self.assertEquals(100000, org.get_credits_remaining())
+        self.assertEqual(100000, org.get_credits_remaining())
 
         # check user exists and is admin
         User.objects.get(username="john@carmack.com")
@@ -2058,7 +2058,7 @@ class OrgCRUDLTest(TembaTest):
         self.assertContains(response, "created")
 
         org = Org.objects.get(name="id Software")
-        self.assertEquals(100000, org.get_credits_remaining())
+        self.assertEqual(100000, org.get_credits_remaining())
 
         self.assertTrue(org.administrators.filter(username="john@carmack.com"))
         self.assertTrue(org.administrators.filter(username="tito"))
@@ -2156,7 +2156,7 @@ class OrgCRUDLTest(TembaTest):
 
         # should now be able to go to channels page
         response = self.client.get(reverse('channels.channel_claim'))
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # check that we have all the tabs
         self.assertContains(response, reverse('msgs.msg_inbox'))
@@ -2187,14 +2187,14 @@ class OrgCRUDLTest(TembaTest):
         self.client.login(username="myal12345678901234567890@relieves.org", password="HelloWorld1")
         response = self.client.get(reverse('orgs.org_home'))
 
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
         # try setting our webhook and subscribe to one of the events
         response = self.client.post(reverse('orgs.org_webhook'), dict(webhook='http://fake.com/webhook.php', mt_sms=1))
         self.assertRedirect(response, reverse('orgs.org_home'))
 
         org = Org.objects.get(name="Relieves World")
-        self.assertEquals("http://fake.com/webhook.php", org.get_webhook_url())
+        self.assertEqual("http://fake.com/webhook.php", org.get_webhook_url())
         self.assertTrue(org.is_notified_of_mt_sms())
         self.assertFalse(org.is_notified_of_mo_sms())
         self.assertFalse(org.is_notified_of_mt_call())
@@ -2204,13 +2204,13 @@ class OrgCRUDLTest(TembaTest):
         # try changing our username, wrong password
         post_data = dict(email='myal@wr.org', current_password='HelloWorld')
         response = self.client.post(reverse('orgs.user_edit'), post_data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertTrue('current_password' in response.context['form'].errors)
 
         # bad new password
         post_data = dict(email='myal@wr.org', current_password='HelloWorld1', new_password='passwor')
         response = self.client.post(reverse('orgs.user_edit'), post_data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertTrue('new_password' in response.context['form'].errors)
 
         User.objects.create(username='bill@msn.com', email='bill@msn.com')
@@ -2218,7 +2218,7 @@ class OrgCRUDLTest(TembaTest):
         # dupe user
         post_data = dict(email='bill@msn.com', current_password='HelloWorld1')
         response = self.client.post(reverse('orgs.user_edit'), post_data)
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertTrue('email' in response.context['form'].errors)
 
         post_data = dict(email='myal@wr.org', first_name="Myal", last_name="Greene", language="en-us", current_password='HelloWorld1')
@@ -2292,24 +2292,24 @@ class OrgCRUDLTest(TembaTest):
         User.objects.create_superuser("superuser", "superuser@group.com", "superuser")
 
         response = self.client.post(login_url, dict(username="superuser", password="superuser"))
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         response = self.client.post(login_url, dict(username="superuser", password="superuser"), follow=True)
-        self.assertEquals(response.request['PATH_INFO'], reverse('orgs.org_manage'))
+        self.assertEqual(response.request['PATH_INFO'], reverse('orgs.org_manage'))
 
         response = self.client.post(login_url, dict(username="SUPeruser", password="superuser"))
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         response = self.client.post(login_url, dict(username="SUPeruser", password="superuser"), follow=True)
-        self.assertEquals(response.request['PATH_INFO'], reverse('orgs.org_manage'))
+        self.assertEqual(response.request['PATH_INFO'], reverse('orgs.org_manage'))
 
         User.objects.create_superuser("withCAPS", "with_caps@group.com", "thePASSWORD")
 
         response = self.client.post(login_url, dict(username="withcaps", password="thePASSWORD"))
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         response = self.client.post(login_url, dict(username="withcaps", password="thePASSWORD"), follow=True)
-        self.assertEquals(response.request['PATH_INFO'], reverse('orgs.org_manage'))
+        self.assertEqual(response.request['PATH_INFO'], reverse('orgs.org_manage'))
 
         # passwords stay case sensitive
         response = self.client.post(login_url, dict(username="withcaps", password="thepassword"), follow=True)
@@ -2350,7 +2350,7 @@ class OrgCRUDLTest(TembaTest):
 
         # make sure that contact's created on is our cs rep
         contact = Contact.objects.get(urns__path='+250788123123', org=self.org)
-        self.assertEquals(self.csrep, contact.created_by)
+        self.assertEqual(self.csrep, contact.created_by)
 
         # make sure we can manage topups as well
         TopUp.objects.create(org=self.org, price=100, credits=1000, expires_on=timezone.now() + timedelta(days=30),
@@ -2425,23 +2425,23 @@ class LanguageTest(TembaTest):
         self.assertEqual(len(results), 1)
 
     def test_language_codes(self):
-        self.assertEquals('French', languages.get_language_name('fre'))
-        self.assertEquals('Creoles and pidgins, English based', languages.get_language_name('cpe'))
+        self.assertEqual('French', languages.get_language_name('fre'))
+        self.assertEqual('Creoles and pidgins, English based', languages.get_language_name('cpe'))
 
         # should strip off anything after an open paren or semicolon
-        self.assertEquals('Official Aramaic', languages.get_language_name('arc'))
-        self.assertEquals('Haitian', languages.get_language_name('hat'))
+        self.assertEqual('Official Aramaic', languages.get_language_name('arc'))
+        self.assertEqual('Haitian', languages.get_language_name('hat'))
 
         # check that search returns results and in the proper order
         matches = languages.search_language_names('Fre')
-        self.assertEquals(4, len(matches))
-        self.assertEquals('Creoles and pidgins, French-based', matches[0]['text'])
-        self.assertEquals('French', matches[1]['text'])
-        self.assertEquals('French, Middle (ca.1400-1600)', matches[2]['text'])
-        self.assertEquals('French, Old (842-ca.1400)', matches[3]['text'])
+        self.assertEqual(4, len(matches))
+        self.assertEqual('Creoles and pidgins, French-based', matches[0]['text'])
+        self.assertEqual('French', matches[1]['text'])
+        self.assertEqual('French, Middle (ca.1400-1600)', matches[2]['text'])
+        self.assertEqual('French, Old (842-ca.1400)', matches[3]['text'])
 
         # try a language that doesn't exist
-        self.assertEquals(None, languages.get_language_name('xyz'))
+        self.assertEqual(None, languages.get_language_name('xyz'))
 
     def test_get_localized_text(self):
         text_translations = dict(eng="Hello", esp="Hola")
@@ -2491,8 +2491,8 @@ class BulkExportTest(TembaTest):
         flow = Flow.objects.filter(name='Trigger a Flow', org=self.org).first()
         definition = flow.as_json()
         actions = definition[Flow.ACTION_SETS][0]['actions']
-        self.assertEquals(1, len(actions))
-        self.assertEquals('Triggered Flow', actions[0]['flow']['name'])
+        self.assertEqual(1, len(actions))
+        self.assertEqual('Triggered Flow', actions[0]['flow']['name'])
 
     def test_trigger_dependency(self):
         # tests the case of us doing an export of only a single flow (despite dependencies) and making sure we
@@ -2581,7 +2581,7 @@ class BulkExportTest(TembaTest):
 
         # should have this actionset, but only one action now since one was removed
         other_actionset = ActionSet.objects.filter(flow=flow, y=145, x=731).first()
-        self.assertEquals(1, len(other_actionset.get_actions()))
+        self.assertEqual(1, len(other_actionset.get_actions()))
 
         # now make sure it does the same thing from an actionset
         self.import_file('start_missing_flow_from_actionset')
@@ -2596,7 +2596,7 @@ class BulkExportTest(TembaTest):
         settings.BRANDING[settings.DEFAULT_BRAND]['tiers'] = dict(import_flows=1, multi_user=100000, multi_org=1000000)
         post_data = dict(import_file=open('%s/test_flows/new_mother.json' % settings.MEDIA_ROOT, 'rb'))
         response = self.client.post(reverse('orgs.org_import'), post_data)
-        self.assertEquals(response.context['form'].errors['import_file'][0], 'Sorry, import is a premium feature')
+        self.assertEqual(response.context['form'].errors['import_file'][0], 'Sorry, import is a premium feature')
 
         # now purchase some credits and try again
         TopUp.objects.create(org=self.org, price=1, credits=10000,
@@ -2611,14 +2611,14 @@ class BulkExportTest(TembaTest):
         # now try again with purchased credits, but our file is too old
         post_data = dict(import_file=open('%s/test_flows/too_old.json' % settings.MEDIA_ROOT, 'rb'))
         response = self.client.post(reverse('orgs.org_import'), post_data)
-        self.assertEquals(response.context['form'].errors['import_file'][0], 'This file is no longer valid. Please export a new version and try again.')
+        self.assertEqual(response.context['form'].errors['import_file'][0], 'This file is no longer valid. Please export a new version and try again.')
 
         # simulate an unexpected exception during import
         with patch('temba.triggers.models.Trigger.import_triggers') as validate:
             validate.side_effect = Exception('Unexpected Error')
             post_data = dict(import_file=open('%s/test_flows/new_mother.json' % settings.MEDIA_ROOT, 'rb'))
             response = self.client.post(reverse('orgs.org_import'), post_data)
-            self.assertEquals(response.context['form'].errors['import_file'][0], 'Sorry, your import file is invalid.')
+            self.assertEqual(response.context['form'].errors['import_file'][0], 'Sorry, your import file is invalid.')
 
             # trigger import failed, new flows that were added should get rolled back
             self.assertIsNone(Flow.objects.filter(org=self.org, name='New Mother').first())
@@ -2645,16 +2645,16 @@ class BulkExportTest(TembaTest):
     def test_export_import(self):
 
         def assert_object_counts():
-            self.assertEquals(8, Flow.objects.filter(org=self.org, is_active=True, is_archived=False, flow_type='F').count())
-            self.assertEquals(2, Flow.objects.filter(org=self.org, is_active=True, is_archived=False, flow_type='M').count())
-            self.assertEquals(1, Campaign.objects.filter(org=self.org, is_archived=False).count())
-            self.assertEquals(4, CampaignEvent.objects.filter(campaign__org=self.org, event_type='F').count())
-            self.assertEquals(2, CampaignEvent.objects.filter(campaign__org=self.org, event_type='M').count())
-            self.assertEquals(2, Trigger.objects.filter(org=self.org, trigger_type='K', is_archived=False).count())
-            self.assertEquals(1, Trigger.objects.filter(org=self.org, trigger_type='C', is_archived=False).count())
-            self.assertEquals(1, Trigger.objects.filter(org=self.org, trigger_type='M', is_archived=False).count())
-            self.assertEquals(3, ContactGroup.user_groups.filter(org=self.org).count())
-            self.assertEquals(1, Label.label_objects.filter(org=self.org).count())
+            self.assertEqual(8, Flow.objects.filter(org=self.org, is_active=True, is_archived=False, flow_type='F').count())
+            self.assertEqual(2, Flow.objects.filter(org=self.org, is_active=True, is_archived=False, flow_type='M').count())
+            self.assertEqual(1, Campaign.objects.filter(org=self.org, is_archived=False).count())
+            self.assertEqual(4, CampaignEvent.objects.filter(campaign__org=self.org, event_type='F').count())
+            self.assertEqual(2, CampaignEvent.objects.filter(campaign__org=self.org, event_type='M').count())
+            self.assertEqual(2, Trigger.objects.filter(org=self.org, trigger_type='K', is_archived=False).count())
+            self.assertEqual(1, Trigger.objects.filter(org=self.org, trigger_type='C', is_archived=False).count())
+            self.assertEqual(1, Trigger.objects.filter(org=self.org, trigger_type='M', is_archived=False).count())
+            self.assertEqual(3, ContactGroup.user_groups.filter(org=self.org).count())
+            self.assertEqual(1, Label.label_objects.filter(org=self.org).count())
 
         # import all our bits
         self.import_file('the_clinic')
@@ -2680,7 +2680,7 @@ class BulkExportTest(TembaTest):
         message_flow = Flow.objects.filter(flow_type='M', events__offset=-1).order_by('pk').first()
         action_set = message_flow.action_sets.order_by('-y').first()
         actions = action_set.get_actions_dict()
-        self.assertEquals("Hi there, just a quick reminder that you have an appointment at The Clinic at @contact.next_appointment. If you can't make it please call 1-888-THE-CLINIC.", actions[0]['msg']['base'])
+        self.assertEqual("Hi there, just a quick reminder that you have an appointment at The Clinic at @contact.next_appointment. If you can't make it please call 1-888-THE-CLINIC.", actions[0]['msg']['base'])
         actions[0]['msg'] = 'No reminders for you!'
         action_set.set_actions_dict(actions)
         action_set.save()
@@ -2692,11 +2692,11 @@ class BulkExportTest(TembaTest):
         confirm_appointment = Flow.objects.get(pk=confirm_appointment.pk)
         action_set = confirm_appointment.action_sets.order_by('-y').first()
         actions = action_set.get_actions_dict()
-        self.assertEquals("Thanks, your appointment at The Clinic has been confirmed for @contact.next_appointment. See you then!", actions[0]['msg']['base'])
+        self.assertEqual("Thanks, your appointment at The Clinic has been confirmed for @contact.next_appointment. See you then!", actions[0]['msg']['base'])
 
         # same with our trigger
         trigger = Trigger.objects.filter(keyword='patient').first()
-        self.assertEquals(Flow.objects.filter(name='Register Patient').first(), trigger.flow)
+        self.assertEqual(Flow.objects.filter(name='Register Patient').first(), trigger.flow)
 
         # our old campaign message flow should be inactive now
         self.assertTrue(Flow.objects.filter(pk=message_flow.pk, is_active=False))
@@ -2705,7 +2705,7 @@ class BulkExportTest(TembaTest):
         message_flow = Flow.objects.filter(flow_type='M', events__offset=-1, is_active=True).order_by('pk').first()
         action_set = Flow.objects.get(pk=message_flow.pk).action_sets.order_by('-y').first()
         actions = action_set.get_actions_dict()
-        self.assertEquals("Hi there, just a quick reminder that you have an appointment at The Clinic at @contact.next_appointment. If you can't make it please call 1-888-THE-CLINIC.", actions[0]['msg']['base'])
+        self.assertEqual("Hi there, just a quick reminder that you have an appointment at The Clinic at @contact.next_appointment. If you can't make it please call 1-888-THE-CLINIC.", actions[0]['msg']['base'])
 
         # and we should have the same number of items as after the first import
         assert_object_counts()
@@ -2730,12 +2730,12 @@ class BulkExportTest(TembaTest):
 
         response = self.client.post(reverse('orgs.org_export'), post_data)
         exported = response.json()
-        self.assertEquals(CURRENT_EXPORT_VERSION, exported.get('version', 0))
-        self.assertEquals('https://app.rapidpro.io', exported.get('site', None))
+        self.assertEqual(CURRENT_EXPORT_VERSION, exported.get('version', 0))
+        self.assertEqual('https://app.rapidpro.io', exported.get('site', None))
 
-        self.assertEquals(8, len(exported.get('flows', [])))
-        self.assertEquals(4, len(exported.get('triggers', [])))
-        self.assertEquals(1, len(exported.get('campaigns', [])))
+        self.assertEqual(8, len(exported.get('flows', [])))
+        self.assertEqual(4, len(exported.get('triggers', [])))
+        self.assertEqual(1, len(exported.get('campaigns', [])))
 
         # set our org language to english
         self.org.set_languages(self.admin, ['eng', 'fre'], 'eng')
@@ -2767,9 +2767,9 @@ class BulkExportTest(TembaTest):
         assert_object_counts()
 
         # and our objets should have the same names as before
-        self.assertEquals('Confirm Appointment', Flow.objects.get(pk=flow.pk).name)
-        self.assertEquals('Appointment Schedule', Campaign.objects.all().first().name)
-        self.assertEquals('Pending Appointments', ContactGroup.user_groups.get(pk=group.pk).name)
+        self.assertEqual('Confirm Appointment', Flow.objects.get(pk=flow.pk).name)
+        self.assertEqual('Appointment Schedule', Campaign.objects.all().first().name)
+        self.assertEqual('Pending Appointments', ContactGroup.user_groups.get(pk=group.pk).name)
 
         # let's rename our objects again
         flow.name = "A new name"
@@ -2785,9 +2785,9 @@ class BulkExportTest(TembaTest):
         self.org.import_app(exported, self.admin, site='http://temba.io')
 
         # the newly named objects won't get updated in this case and we'll create new ones instead
-        self.assertEquals(9, Flow.objects.filter(org=self.org, is_archived=False, flow_type='F').count())
-        self.assertEquals(2, Campaign.objects.filter(org=self.org, is_archived=False).count())
-        self.assertEquals(4, ContactGroup.user_groups.filter(org=self.org).count())
+        self.assertEqual(9, Flow.objects.filter(org=self.org, is_archived=False, flow_type='F').count())
+        self.assertEqual(2, Campaign.objects.filter(org=self.org, is_archived=False).count())
+        self.assertEqual(4, ContactGroup.user_groups.filter(org=self.org).count())
 
         # now archive a flow
         register = Flow.objects.filter(name='Register Patient').first()
@@ -2808,7 +2808,7 @@ class BulkExportTest(TembaTest):
 
         # make sure we have the previously exported expiration
         confirm_appointment = Flow.objects.get(name='Confirm Appointment')
-        self.assertEquals(60, confirm_appointment.expires_after_minutes)
+        self.assertEqual(60, confirm_appointment.expires_after_minutes)
 
         # now delete a flow
         register = Flow.objects.filter(name='Register Patient').first()
@@ -2838,9 +2838,9 @@ class CreditAlertTest(TembaTest):
                 CreditAlert.check_org_credits()
 
                 # one alert created and sent
-                self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                alert_type=ORG_CREDIT_OVER).count())
-                self.assertEquals(1, len(mail.outbox))
+                self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                               alert_type=ORG_CREDIT_OVER).count())
+                self.assertEqual(1, len(mail.outbox))
 
                 # alert email is for out of credits type
                 sent_email = mail.outbox[0]
@@ -2850,9 +2850,9 @@ class CreditAlertTest(TembaTest):
 
                 # no new alert if one is sent and no new email
                 CreditAlert.check_org_credits()
-                self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                alert_type=ORG_CREDIT_OVER).count())
-                self.assertEquals(1, len(mail.outbox))
+                self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                               alert_type=ORG_CREDIT_OVER).count())
+                self.assertEqual(1, len(mail.outbox))
 
                 # reset alerts
                 CreditAlert.reset_for_org(self.org)
@@ -2860,9 +2860,9 @@ class CreditAlertTest(TembaTest):
 
                 # can resend a new alert
                 CreditAlert.check_org_credits()
-                self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                alert_type=ORG_CREDIT_OVER).count())
-                self.assertEquals(2, len(mail.outbox))
+                self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                               alert_type=ORG_CREDIT_OVER).count())
+                self.assertEqual(2, len(mail.outbox))
 
                 mock_get_credits_remaining.return_value = 10
 
@@ -2874,9 +2874,9 @@ class CreditAlertTest(TembaTest):
                     CreditAlert.check_org_credits()
 
                     # low credit alert created and email sent
-                    self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                    alert_type=ORG_CREDIT_LOW).count())
-                    self.assertEquals(3, len(mail.outbox))
+                    self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                                   alert_type=ORG_CREDIT_LOW).count())
+                    self.assertEqual(3, len(mail.outbox))
 
                     # email sent
                     sent_email = mail.outbox[2]
@@ -2886,9 +2886,9 @@ class CreditAlertTest(TembaTest):
 
                     # no new alert if one is sent and no new email
                     CreditAlert.check_org_credits()
-                    self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                    alert_type=ORG_CREDIT_LOW).count())
-                    self.assertEquals(3, len(mail.outbox))
+                    self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                                   alert_type=ORG_CREDIT_LOW).count())
+                    self.assertEqual(3, len(mail.outbox))
 
                     # reset alerts
                     CreditAlert.reset_for_org(self.org)
@@ -2896,9 +2896,9 @@ class CreditAlertTest(TembaTest):
 
                     # can resend a new alert
                     CreditAlert.check_org_credits()
-                    self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                    alert_type=ORG_CREDIT_LOW).count())
-                    self.assertEquals(4, len(mail.outbox))
+                    self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                                   alert_type=ORG_CREDIT_LOW).count())
+                    self.assertEqual(4, len(mail.outbox))
 
                     mock_has_low_credits.return_value = False
 
@@ -2917,9 +2917,9 @@ class CreditAlertTest(TembaTest):
                         CreditAlert.check_org_credits()
 
                         # expiring credit alert created and email sent
-                        self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                        alert_type=ORG_CREDIT_EXPIRING).count())
-                        self.assertEquals(5, len(mail.outbox))
+                        self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                                       alert_type=ORG_CREDIT_EXPIRING).count())
+                        self.assertEqual(5, len(mail.outbox))
 
                         # email sent
                         sent_email = mail.outbox[4]
@@ -2929,9 +2929,9 @@ class CreditAlertTest(TembaTest):
 
                         # no new alert if one is sent and no new email
                         CreditAlert.check_org_credits()
-                        self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                        alert_type=ORG_CREDIT_EXPIRING).count())
-                        self.assertEquals(5, len(mail.outbox))
+                        self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                                       alert_type=ORG_CREDIT_EXPIRING).count())
+                        self.assertEqual(5, len(mail.outbox))
 
                         # reset alerts
                         CreditAlert.reset_for_org(self.org)
@@ -2939,9 +2939,9 @@ class CreditAlertTest(TembaTest):
 
                         # can resend a new alert
                         CreditAlert.check_org_credits()
-                        self.assertEquals(1, CreditAlert.objects.filter(is_active=True, org=self.org,
-                                                                        alert_type=ORG_CREDIT_EXPIRING).count())
-                        self.assertEquals(6, len(mail.outbox))
+                        self.assertEqual(1, CreditAlert.objects.filter(is_active=True, org=self.org,
+                                                                       alert_type=ORG_CREDIT_EXPIRING).count())
+                        self.assertEqual(6, len(mail.outbox))
 
 
 class UnreadCountTest(FlowFileTest):
@@ -2960,26 +2960,26 @@ class UnreadCountTest(FlowFileTest):
         Msg.process_message(msg)
 
         # our flow unread count should have gone up
-        self.assertEquals(1, flow.get_and_clear_unread_responses())
+        self.assertEqual(1, flow.get_and_clear_unread_responses())
 
         # cleared by the first call
-        self.assertEquals(0, flow.get_and_clear_unread_responses())
+        self.assertEqual(0, flow.get_and_clear_unread_responses())
 
         # at this point our flow should have started.. go to our trigger list page to see if our context is correct
         self.login(self.admin)
         trigger_list = reverse('triggers.trigger_list')
         response = self.client.get(trigger_list)
 
-        self.assertEquals(0, response.context['msgs_unread_count'])
-        self.assertEquals(1, response.context['flows_unread_count'])
+        self.assertEqual(0, response.context['msgs_unread_count'])
+        self.assertEqual(1, response.context['flows_unread_count'])
 
         # answer another question in the flow
         msg = self.create_msg(contact=contact, text="red")
         Msg.process_message(msg)
 
         response = self.client.get(trigger_list)
-        self.assertEquals(0, response.context['msgs_unread_count'])
-        self.assertEquals(2, response.context['flows_unread_count'])
+        self.assertEqual(0, response.context['msgs_unread_count'])
+        self.assertEqual(2, response.context['flows_unread_count'])
 
         # finish the flow and send a message outside it
         msg = self.create_msg(contact=contact, text="primus")
@@ -2992,18 +2992,18 @@ class UnreadCountTest(FlowFileTest):
         Msg.process_message(msg)
 
         response = self.client.get(trigger_list)
-        self.assertEquals(4, response.context['flows_unread_count'])
-        self.assertEquals(1, response.context['msgs_unread_count'])
+        self.assertEqual(4, response.context['flows_unread_count'])
+        self.assertEqual(1, response.context['msgs_unread_count'])
 
         # visit the msg pane
         response = self.client.get(reverse('msgs.msg_inbox'))
-        self.assertEquals(4, response.context['flows_unread_count'])
-        self.assertEquals(0, response.context['msgs_unread_count'])
+        self.assertEqual(4, response.context['flows_unread_count'])
+        self.assertEqual(0, response.context['msgs_unread_count'])
 
         # now the flow list pane
         response = self.client.get(reverse('flows.flow_list'))
-        self.assertEquals(0, response.context['flows_unread_count'])
-        self.assertEquals(0, response.context['msgs_unread_count'])
+        self.assertEqual(0, response.context['flows_unread_count'])
+        self.assertEqual(0, response.context['msgs_unread_count'])
 
         # make sure a test contact doesn't update our counts
         test_contact = self.create_contact("Test Contact", "+12065551214", is_test=True)
@@ -3012,11 +3012,11 @@ class UnreadCountTest(FlowFileTest):
         Msg.process_message(msg)
 
         # assert our counts weren't updated
-        self.assertEquals(0, self.org.get_unread_msg_count(UNREAD_INBOX_MSGS))
-        self.assertEquals(0, self.org.get_unread_msg_count(UNREAD_FLOW_MSGS))
+        self.assertEqual(0, self.org.get_unread_msg_count(UNREAD_INBOX_MSGS))
+        self.assertEqual(0, self.org.get_unread_msg_count(UNREAD_FLOW_MSGS))
 
         # wasn't counted for the individual flow
-        self.assertEquals(0, flow.get_and_clear_unread_responses())
+        self.assertEqual(0, flow.get_and_clear_unread_responses())
 
 
 class EmailContextProcessorsTest(SmartminTest):
@@ -3030,7 +3030,7 @@ class EmailContextProcessorsTest(SmartminTest):
         self.request.get_host.return_value = "rapidpro.io"
         response = self.middleware.process_request(self.request)
         self.assertIsNone(response)
-        self.assertEquals(link_components(self.request, self.admin), dict(protocol="https", hostname="app.rapidpro.io"))
+        self.assertEqual(link_components(self.request, self.admin), dict(protocol="https", hostname="app.rapidpro.io"))
 
         with self.settings(HOSTNAME="rapidpro.io"):
             forget_url = reverse('users.user_forget')
@@ -3039,7 +3039,7 @@ class EmailContextProcessorsTest(SmartminTest):
             post_data['email'] = 'nouser@nouser.com'
 
             response = self.client.post(forget_url, post_data, follow=True)
-            self.assertEquals(1, len(mail.outbox))
+            self.assertEqual(1, len(mail.outbox))
             sent_email = mail.outbox[0]
             self.assertEqual(len(sent_email.to), 1)
             self.assertEqual(sent_email.to[0], 'nouser@nouser.com')
@@ -3075,7 +3075,7 @@ class StripeCreditsTest(TembaTest):
         # assert we sent our confirmation emai
         self.assertEqual(1, len(mail.outbox))
         email = mail.outbox[0]
-        self.assertEquals("RapidPro Receipt", email.subject)
+        self.assertEqual("RapidPro Receipt", email.subject)
         self.assertTrue('Rudolph' in email.body)
         self.assertTrue('Visa' in email.body)
         self.assertTrue('$20' in email.body)
@@ -3106,7 +3106,7 @@ class StripeCreditsTest(TembaTest):
         # assert we sent our confirmation emai
         self.assertEqual(1, len(mail.outbox))
         email = mail.outbox[0]
-        self.assertEquals("RapidPro Receipt", email.subject)
+        self.assertEqual("RapidPro Receipt", email.subject)
         self.assertTrue('bitcoin' in email.body)
         self.assertTrue('abcde' in email.body)
         self.assertTrue('$20' in email.body)
@@ -3200,7 +3200,7 @@ class StripeCreditsTest(TembaTest):
         # assert we sent our confirmation email
         self.assertEqual(1, len(mail.outbox))
         email = mail.outbox[0]
-        self.assertEquals("RapidPro Receipt", email.subject)
+        self.assertEqual("RapidPro Receipt", email.subject)
         self.assertTrue('Rudolph' in email.body)
         self.assertTrue('Visa' in email.body)
         self.assertTrue('$20' in email.body)

--- a/temba/public/tests.py
+++ b/temba/public/tests.py
@@ -16,25 +16,25 @@ class PublicTest(SmartminTest):
     def test_index(self):
         home_url = reverse('public.public_index')
         response = self.client.get(home_url, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], '/')
+        self.assertEqual(response.request['PATH_INFO'], '/')
 
         # try to create a lead from the homepage
         lead_create_url = reverse('public.lead_create')
         post_data = dict()
         response = self.client.post(lead_create_url, post_data, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], '/')
+        self.assertEqual(response.request['PATH_INFO'], '/')
         self.assertTrue(response.context['errors'])
-        self.assertEquals(response.context['error_msg'], 'This field is required.')
+        self.assertEqual(response.context['error_msg'], 'This field is required.')
 
         post_data['email'] = 'wrong_email_format'
         response = self.client.post(lead_create_url, post_data, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], '/')
+        self.assertEqual(response.request['PATH_INFO'], '/')
         self.assertTrue(response.context['errors'])
-        self.assertEquals(response.context['error_msg'], 'Enter a valid email address.')
+        self.assertEqual(response.context['error_msg'], 'Enter a valid email address.')
 
         post_data['email'] = 'immortal@temba.com'
         response = self.client.post(lead_create_url, post_data, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], reverse('orgs.org_signup'))
+        self.assertEqual(response.request['PATH_INFO'], reverse('orgs.org_signup'))
 
     def test_privacy(self):
         response = self.client.get(reverse('public.public_privacy'))
@@ -44,11 +44,11 @@ class PublicTest(SmartminTest):
         welcome_url = reverse('public.public_welcome')
         response = self.client.get(welcome_url, follow=True)
         self.assertTrue('next' in response.request['QUERY_STRING'])
-        self.assertEquals(response.request['PATH_INFO'], reverse('users.user_login'))
+        self.assertEqual(response.request['PATH_INFO'], reverse('users.user_login'))
 
         self.login(self.user)
         response = self.client.get(welcome_url, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], reverse('public.public_welcome'))
+        self.assertEqual(response.request['PATH_INFO'], reverse('public.public_welcome'))
 
     def test_leads(self):
         create_url = reverse('public.lead_create')
@@ -56,45 +56,45 @@ class PublicTest(SmartminTest):
         post_data = dict()
         post_data['email'] = 'eugene@temba.com'
         response = self.client.post(create_url, post_data, follow=True)
-        self.assertEquals(len(Lead.objects.all()), 1)
+        self.assertEqual(len(Lead.objects.all()), 1)
 
         # create mailing list with the same email again, we actually allow dupes now
         post_data['email'] = 'eugene@temba.com'
         response = self.client.post(create_url, post_data, follow=True)
-        self.assertEquals(len(Lead.objects.all()), 2)
+        self.assertEqual(len(Lead.objects.all()), 2)
 
         # invalid email
         post_data['email'] = 'asdfasdf'
         response = self.client.post(create_url, post_data, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], '/')
-        self.assertEquals(len(Lead.objects.all()), 2)
+        self.assertEqual(response.request['PATH_INFO'], '/')
+        self.assertEqual(len(Lead.objects.all()), 2)
 
     def test_demo_coupon(self):
         coupon_url = reverse('demo.generate_coupon')
         response = self.client.get(coupon_url, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], coupon_url)
+        self.assertEqual(response.request['PATH_INFO'], coupon_url)
         self.assertIn('coupon', response.content)
 
     def test_demo_status(self):
         status_url = reverse('demo.order_status')
         response = self.client.get(status_url, follow=True)
-        self.assertEquals(response.request['PATH_INFO'], status_url)
+        self.assertEqual(response.request['PATH_INFO'], status_url)
         self.assertIn('Invalid', response.content)
 
         response = self.client.get("%s?text=somethinginvalid" % status_url)
-        self.assertEquals(response.request['PATH_INFO'], status_url)
+        self.assertEqual(response.request['PATH_INFO'], status_url)
         self.assertIn('Invalid', response.content)
 
         response = self.client.get("%s?text=cu001" % status_url)
-        self.assertEquals(response.request['PATH_INFO'], status_url)
+        self.assertEqual(response.request['PATH_INFO'], status_url)
         self.assertIn('Shipped', response.content)
 
         response = self.client.get("%s?text=cu002" % status_url)
-        self.assertEquals(response.request['PATH_INFO'], status_url)
+        self.assertEqual(response.request['PATH_INFO'], status_url)
         self.assertIn('Pending', response.content)
 
         response = self.client.get("%s?text=cu003" % status_url)
-        self.assertEquals(response.request['PATH_INFO'], status_url)
+        self.assertEqual(response.request['PATH_INFO'], status_url)
         self.assertIn('Cancelled', response.content)
 
     def test_templatetags(self):
@@ -118,11 +118,11 @@ class PublicTest(SmartminTest):
         response = self.client.get(sitemap_url)
 
         # but first item is always home page
-        self.assertEquals(response.context['urlset'][0], {'priority': '0.5',
-                                                          'item': 'public.public_index',
-                                                          'lastmod': None,
-                                                          'changefreq': 'daily',
-                                                          'location': u'http://example.com/'})
+        self.assertEqual(response.context['urlset'][0], {'priority': '0.5',
+                                                         'item': 'public.public_index',
+                                                         'lastmod': None,
+                                                         'changefreq': 'daily',
+                                                         'location': u'http://example.com/'})
 
         num_fixed_items = len(response.context['urlset'])
 

--- a/temba/reports/tests.py
+++ b/temba/reports/tests.py
@@ -13,22 +13,22 @@ class ReportTest(TembaTest):
         create_url = reverse('reports.report_create')
 
         response = self.client.get(create_url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         response = self.client.get(create_url, follow=True)
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.request['PATH_INFO'], reverse('flows.ruleset_analytics'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request['PATH_INFO'], reverse('flows.ruleset_analytics'))
 
         response = self.client.post(create_url, {"title": "first report", "description": "some description", "config": "{}"})
-        self.assertEquals(response.json()['status'], "error")
+        self.assertEqual(response.json()['status'], "error")
         self.assertFalse('report' in response.json())
 
         response = self.client.post(create_url, data='{"title":"first report", "description":"some description", "config":""}', content_type='application/json')
-        self.assertEquals(response.json()['status'], "success")
+        self.assertEqual(response.json()['status'], "success")
         self.assertTrue('report' in response.json())
         self.assertTrue('id' in response.json()['report'])
         report = Report.objects.get()
-        self.assertEquals(report.pk, response.json()['report']['id'])
+        self.assertEqual(report.pk, response.json()['report']['id'])
 
     def test_report_model(self):
         Report.create_report(self.org, self.admin, dict(title="first", description="blah blah text",

--- a/temba/schedules/tests.py
+++ b/temba/schedules/tests.py
@@ -39,7 +39,7 @@ class ScheduleTest(TembaTest):
     def test_get_days_bitmask(self):
         now = timezone.now()
         sched = Schedule.create_schedule(now, "W", self.user, 244)
-        self.assertEquals(sched.get_days_bitmask(), ['4', '16', '32', '64', '128'])
+        self.assertEqual(sched.get_days_bitmask(), ['4', '16', '32', '64', '128'])
 
     def test_schedule(self):
         # updates two days later on Saturday
@@ -47,28 +47,28 @@ class ScheduleTest(TembaTest):
         sched = self.create_schedule('W', [THURSDAY, SATURDAY], start_date=tomorrow)
 
         self.assertTrue(sched.has_pending_fire())
-        self.assertEquals(sched.status, 'S')
+        self.assertEqual(sched.status, 'S')
 
-        self.assertEquals(sched.get_repeat_days_display(), ['Thursday', 'Saturday'])
+        self.assertEqual(sched.get_repeat_days_display(), ['Thursday', 'Saturday'])
 
         sched.unschedule()
-        self.assertEquals(sched.status, 'U')
+        self.assertEqual(sched.status, 'U')
 
     def test_next_fire(self):
 
         # updates two days later on Saturday
         sched = self.create_schedule('W', [THURSDAY, SATURDAY])
 
-        self.assertEquals(sched.repeat_days, 80)
-        self.assertEquals(datetime(2013, 1, 5, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(sched.repeat_days, 80)
+        self.assertEqual(datetime(2013, 1, 5, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
 
         # updates six days later on Wednesday
         sched = self.create_schedule('W', [WEDNESDAY, THURSDAY])
-        self.assertEquals(datetime(2013, 1, 9, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(datetime(2013, 1, 9, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
 
         # since we are starting thursday, a thursday should be 7 days out
         sched = self.create_schedule('W', [THURSDAY])
-        self.assertEquals(datetime(2013, 1, 10, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(datetime(2013, 1, 10, hour=10).replace(tzinfo=timezone.pytz.utc), sched.get_next_fire(sched.next_fire))
 
         # now update, should advance to next thursday (present time)
         now = timezone.now()
@@ -84,30 +84,30 @@ class ScheduleTest(TembaTest):
                 next_update += timedelta(days=1)
 
         self.assertTrue(sched.update_schedule())
-        self.assertEquals(next_update, sched.next_fire)
+        self.assertEqual(next_update, sched.next_fire)
 
         # try a weekly schedule
         sched = self.create_schedule('W', [THURSDAY])
-        self.assertEquals(datetime(2013, 1, 10, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(datetime(2013, 1, 10, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
         self.assertTrue(sched.update_schedule())
-        self.assertEquals(next_update, sched.next_fire)
+        self.assertEqual(next_update, sched.next_fire)
 
         # lastly, a daily schedule
         sched = self.create_schedule('D')
-        self.assertEquals(datetime(2013, 1, 4, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(datetime(2013, 1, 4, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
 
         sched = self.create_schedule('M')
-        self.assertEquals(datetime(2013, 2, 3, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(datetime(2013, 2, 3, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
         self.assertTrue(sched.update_schedule(datetime(2013, 4, 1).replace(tzinfo=pytz.utc)))
-        self.assertEquals(str(datetime(2013, 4, 3, hour=10).replace(tzinfo=pytz.utc)), str(sched.next_fire))
+        self.assertEqual(str(datetime(2013, 4, 3, hour=10).replace(tzinfo=pytz.utc)), str(sched.next_fire))
 
         sched = self.create_schedule('M', start_date=datetime(2014, 1, 31, hour=10).replace(tzinfo=pytz.utc))
-        self.assertEquals(datetime(2014, 2, 28, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
+        self.assertEqual(datetime(2014, 2, 28, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(sched.next_fire))
         self.assertTrue(sched.update_schedule(datetime(2014, 3, 31).replace(tzinfo=pytz.utc)))
-        self.assertEquals(str(datetime(2014, 4, 30, hour=10).replace(tzinfo=pytz.utc)), str(sched.next_fire))
+        self.assertEqual(str(datetime(2014, 4, 30, hour=10).replace(tzinfo=pytz.utc)), str(sched.next_fire))
 
         sched = self.create_schedule('M', start_date=datetime(2014, 1, 31, hour=10).replace(tzinfo=pytz.utc))
-        self.assertEquals(datetime(2014, 2, 28, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(datetime(2014, 2, 27, hour=10).replace(tzinfo=pytz.utc)))
+        self.assertEqual(datetime(2014, 2, 28, hour=10).replace(tzinfo=pytz.utc), sched.get_next_fire(datetime(2014, 2, 27, hour=10).replace(tzinfo=pytz.utc)))
 
     def test_schedule_ui(self):
 
@@ -179,7 +179,7 @@ class ScheduleTest(TembaTest):
         response = self.client.post(update_url, post_data)
 
         schedule = Schedule.objects.get(pk=sched.pk)
-        self.assertEquals(schedule.status, 'U')
+        self.assertEqual(schedule.status, 'U')
 
         post_data = dict()
         post_data['start'] = 'stop'
@@ -188,7 +188,7 @@ class ScheduleTest(TembaTest):
         response = self.client.post(update_url, post_data)
 
         schedule = Schedule.objects.get(pk=sched.pk)
-        self.assertEquals(schedule.status, 'U')
+        self.assertEqual(schedule.status, 'U')
 
         post_data = dict()
         post_data['start'] = 'now'
@@ -198,7 +198,7 @@ class ScheduleTest(TembaTest):
         response = self.client.post(update_url, post_data)
 
         schedule = Schedule.objects.get(pk=sched.pk)
-        self.assertEquals(schedule.repeat_period, 'O')
+        self.assertEqual(schedule.repeat_period, 'O')
         self.assertFalse(schedule.next_fire)
 
         post_data = dict()
@@ -209,7 +209,7 @@ class ScheduleTest(TembaTest):
         response = self.client.post(update_url, post_data)
 
         schedule = Schedule.objects.get(pk=sched.pk)
-        self.assertEquals(schedule.repeat_period, 'D')
+        self.assertEqual(schedule.repeat_period, 'D')
 
         post_data = dict()
         post_data['repeat_period'] = 'D'
@@ -218,7 +218,7 @@ class ScheduleTest(TembaTest):
         response = self.client.post(update_url, post_data)
 
         schedule = Schedule.objects.get(pk=sched.pk)
-        self.assertEquals(schedule.repeat_period, 'D')
+        self.assertEqual(schedule.repeat_period, 'D')
 
     def test_calculating_next_fire(self):
 
@@ -239,7 +239,7 @@ class ScheduleTest(TembaTest):
         sched_date = tz.localize(datetime(2013, 1, 3, hour=23, minute=30, second=0, microsecond=0))
 
         schedule.update_schedule(sched_date)
-        self.assertEquals('2013-01-04 23:15:00-05:00', six.text_type(schedule.next_fire))
+        self.assertEqual('2013-01-04 23:15:00-05:00', six.text_type(schedule.next_fire))
 
     def test_update_near_day_boundary(self):
 
@@ -268,7 +268,7 @@ class ScheduleTest(TembaTest):
         sched = Schedule.objects.get(pk=sched.pk)
 
         # 11pm in NY should be 4am UTC the next day
-        self.assertEquals('2050-01-04 04:00:00+00:00', six.text_type(sched.next_fire))
+        self.assertEqual('2050-01-04 04:00:00+00:00', six.text_type(sched.next_fire))
 
         # a time in the past
         start_date = datetime(2010, 1, 3, 23, 45, 0, 0)

--- a/temba/tests.py
+++ b/temba/tests.py
@@ -478,7 +478,7 @@ class FlowFileTest(TembaTest):
         response = Msg.objects.filter(contact=self.contact).order_by('-created_on', '-pk').first()
 
         self.assertTrue("Missing response from contact.", response)
-        self.assertEquals(message, response.text)
+        self.assertEqual(message, response.text)
 
     def send(self, message, contact=None):
         if not contact:
@@ -526,7 +526,7 @@ class FlowFileTest(TembaTest):
                 self.assertGreaterEqual(len(replies), 1)
 
                 if len(replies) == 1:
-                    self.assertEquals(contact, replies.first().contact)
+                    self.assertEqual(contact, replies.first().contact)
                     return replies.first().text
 
                 # if it's more than one, send back a list of replies

--- a/temba/triggers/tests.py
+++ b/temba/triggers/tests.py
@@ -52,35 +52,35 @@ class TriggerTest(TembaTest):
         # try a keyword with spaces
         post_data = dict(keyword='keyword with spaces', flow=flow.id, match_type='F')
         response = self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
-        self.assertEquals(1, len(response.context['form'].errors))
+        self.assertEqual(1, len(response.context['form'].errors))
 
         # try a keyword with special characters
         post_data = dict(keyword='keyw!o^rd__', flow=flow.id, match_type='F')
         response = self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
-        self.assertEquals(1, len(response.context['form'].errors))
+        self.assertEqual(1, len(response.context['form'].errors))
 
         # unicode keyword (Arabic)
         post_data = dict(keyword='١٠٠', flow=flow.id, match_type='F')
         self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
         trigger = Trigger.objects.get(keyword=u'١٠٠')
-        self.assertEquals(flow.pk, trigger.flow.pk)
+        self.assertEqual(flow.pk, trigger.flow.pk)
 
         # unicode keyword (Hindi)
         post_data = dict(keyword='मिलाए', flow=flow.id, match_type='F')
         self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
         trigger = Trigger.objects.get(keyword=u'मिलाए')
-        self.assertEquals(flow.pk, trigger.flow.pk)
+        self.assertEqual(flow.pk, trigger.flow.pk)
 
         # a valid keyword
         post_data = dict(keyword='startkeyword', flow=flow.id, match_type='F')
         self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
         trigger = Trigger.objects.get(keyword='startkeyword')
-        self.assertEquals(flow.pk, trigger.flow.pk)
+        self.assertEqual(flow.pk, trigger.flow.pk)
 
         # try a duplicate keyword
         post_data = dict(keyword='startkeyword', flow=flow.id, match_type='F')
         response = self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
-        self.assertEquals(1, len(response.context['form'].errors))
+        self.assertEqual(1, len(response.context['form'].errors))
 
         # see our trigger on the list page
         response = self.client.get(reverse('triggers.trigger_list'))
@@ -117,8 +117,8 @@ class TriggerTest(TembaTest):
 
         post_data = dict(keyword='startkeyword', flow=flow.id, match_type='F')
         response = self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword").count(), 2)
-        self.assertEquals(1, Trigger.objects.filter(keyword="startkeyword", is_archived=False).count())
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword").count(), 2)
+        self.assertEqual(1, Trigger.objects.filter(keyword="startkeyword", is_archived=False).count())
         other_trigger = Trigger.objects.filter(keyword="startkeyword", is_archived=False)[0]
         self.assertFalse(trigger.pk == other_trigger.pk)
 
@@ -131,7 +131,7 @@ class TriggerTest(TembaTest):
         self.assertContains(response, 'startkeyword')
         response = self.client.get(reverse('triggers.trigger_list'), post_data)
         self.assertContains(response, 'startkeyword')
-        self.assertEquals(1, Trigger.objects.filter(keyword="startkeyword", is_archived=False).count())
+        self.assertEqual(1, Trigger.objects.filter(keyword="startkeyword", is_archived=False).count())
         self.assertFalse(other_trigger.pk == Trigger.objects.filter(keyword="startkeyword", is_archived=False)[0].pk)
 
         self.contact = self.create_contact('Eric', '+250788382382')
@@ -140,29 +140,29 @@ class TriggerTest(TembaTest):
         group2 = self.create_group("second", [self.contact])
         group3 = self.create_group("third", [self.contact, self.contact2])
 
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword").count(), 2)
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 1)
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword").count(), 2)
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 1)
 
         # update trigger with 2 groups
         post_data = dict(keyword='startkeyword', flow=flow.id, match_type='F', groups=[group1.pk, group2.pk])
         response = self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword").count(), 3)
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 2)
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword").count(), 3)
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 2)
 
         # get error when groups overlap
         post_data = dict(keyword='startkeyword', flow=flow.id, match_type='F')
         post_data['groups'] = [group2.pk, group3.pk]
         response = self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
-        self.assertEquals(1, len(response.context['form'].errors))
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword").count(), 3)
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 2)
+        self.assertEqual(1, len(response.context['form'].errors))
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword").count(), 3)
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 2)
 
         # allow new creation when groups do not overlap
         post_data = dict(keyword='startkeyword', flow=flow.id, match_type='F')
         post_data['groups'] = [group3.pk]
         response = self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword").count(), 4)
-        self.assertEquals(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 3)
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword").count(), 4)
+        self.assertEqual(Trigger.objects.filter(keyword="startkeyword", is_archived=False).count(), 3)
 
     def test_inbound_call_trigger(self):
         self.login(self.admin)
@@ -177,13 +177,13 @@ class TriggerTest(TembaTest):
 
         # flow is required
         response = self.client.post(reverse('triggers.trigger_inbound_call'), dict())
-        self.assertEquals(response.context['form'].errors.keys(), ['flow'])
+        self.assertEqual(response.context['form'].errors.keys(), ['flow'])
 
         # flow must be an ivr flow
         message_flow = self.create_flow()
         post_data = dict(flow=message_flow.pk)
         response = self.client.post(reverse('triggers.trigger_inbound_call'), post_data)
-        self.assertEquals(response.context['form'].errors.keys(), ['flow'])
+        self.assertEqual(response.context['form'].errors.keys(), ['flow'])
 
         # now lets create our first valid inbound call trigger
         guitarist_flow = self.create_flow()
@@ -197,7 +197,7 @@ class TriggerTest(TembaTest):
 
         # pretend we are getting a call from somebody
         trey = self.create_contact('Trey', '+17075551212')
-        self.assertEquals(guitarist_flow.pk, Trigger.find_flow_for_inbound_call(trey).pk)
+        self.assertEqual(guitarist_flow.pk, Trigger.find_flow_for_inbound_call(trey).pk)
 
         # now lets check that group specific call triggers work
         mike = self.create_contact('Mike', '+17075551213')
@@ -210,17 +210,17 @@ class TriggerTest(TembaTest):
 
         post_data = dict(flow=bassist_flow.pk, groups=[bassists.pk])
         response = self.client.post(reverse('triggers.trigger_inbound_call'), post_data)
-        self.assertEquals(2, Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL).count())
+        self.assertEqual(2, Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL).count())
 
-        self.assertEquals(bassist_flow.pk, Trigger.find_flow_for_inbound_call(mike).pk)
-        self.assertEquals(guitarist_flow.pk, Trigger.find_flow_for_inbound_call(trey).pk)
+        self.assertEqual(bassist_flow.pk, Trigger.find_flow_for_inbound_call(mike).pk)
+        self.assertEqual(guitarist_flow.pk, Trigger.find_flow_for_inbound_call(trey).pk)
 
         # release our channel
         self.channel.release()
 
         # should still have two voice flows and triggers (they aren't archived)
-        self.assertEquals(2, Flow.objects.filter(flow_type=Flow.VOICE, is_archived=False).count())
-        self.assertEquals(2, Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL, is_archived=False).count())
+        self.assertEqual(2, Flow.objects.filter(flow_type=Flow.VOICE, is_archived=False).count())
+        self.assertEqual(2, Trigger.objects.filter(trigger_type=Trigger.TYPE_INBOUND_CALL, is_archived=False).count())
 
     def test_referral_trigger(self):
         self.login(self.admin)
@@ -234,7 +234,7 @@ class TriggerTest(TembaTest):
 
         post_data = dict()
         response = self.client.post(create_url, post_data)
-        self.assertEquals(response.context['form'].errors.keys(), ['flow'])
+        self.assertEqual(response.context['form'].errors.keys(), ['flow'])
 
         # ok, valid referrer id and flow
         post_data = dict(flow=flow.id, referrer_id='signup')
@@ -255,7 +255,7 @@ class TriggerTest(TembaTest):
         # try to create the same trigger, should fail as we can only have one per referrer
         post_data = dict(flow=flow.id, referrer_id='signup')
         response = self.client.post(create_url, post_data)
-        self.assertEquals(response.context['form'].errors.keys(), ['__all__'])
+        self.assertEqual(response.context['form'].errors.keys(), ['__all__'])
 
         # should work if we specify a specific channel
         post_data['channel'] = self.fb_channel.id
@@ -271,7 +271,7 @@ class TriggerTest(TembaTest):
         update_url = reverse('triggers.trigger_update', args=[second_trigger.id])
         del post_data['channel']
         response = self.client.post(update_url, post_data)
-        self.assertEquals(response.context['form'].errors.keys(), ['__all__'])
+        self.assertEqual(response.context['form'].errors.keys(), ['__all__'])
 
         # archive our first trigger
         Trigger.apply_action_archive(self.admin, Trigger.objects.filter(channel=None))
@@ -305,7 +305,7 @@ class TriggerTest(TembaTest):
         post_data['start_datetime_value'] = "%d" % tommorrow_stamp
 
         response = self.client.post(reverse("triggers.trigger_schedule"), post_data)
-        self.assertEquals(response.context['form'].errors.keys(), ['flow'])
+        self.assertEqual(response.context['form'].errors.keys(), ['flow'])
         self.assertFalse(Trigger.objects.all())
         self.assertFalse(Schedule.objects.all())
 
@@ -327,13 +327,13 @@ class TriggerTest(TembaTest):
         post_data['repeat_period'] = 'O'
 
         response = self.client.post(reverse("triggers.trigger_schedule"), post_data)
-        self.assertEquals(1, Trigger.objects.all().count())
+        self.assertEqual(1, Trigger.objects.all().count())
 
         trigger = Trigger.objects.all().order_by('-pk')[0]
         self.assertTrue(trigger.schedule)
-        self.assertEquals(trigger.schedule.status, 'U')
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
-        self.assertEquals(trigger.contacts.all()[0].pk, stromae.pk)
+        self.assertEqual(trigger.schedule.status, 'U')
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.contacts.all()[0].pk, stromae.pk)
 
         post_data = dict()
         post_data['flow'] = flow.pk
@@ -342,13 +342,13 @@ class TriggerTest(TembaTest):
         post_data['repeat_period'] = 'O'
 
         response = self.client.post(reverse("triggers.trigger_schedule"), post_data)
-        self.assertEquals(2, Trigger.objects.all().count())
+        self.assertEqual(2, Trigger.objects.all().count())
 
         trigger = Trigger.objects.all().order_by('-pk')[0]
         self.assertTrue(trigger.schedule)
-        self.assertEquals(trigger.schedule.status, 'U')
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
-        self.assertEquals(trigger.contacts.all()[0].pk, stromae.pk)
+        self.assertEqual(trigger.schedule.status, 'U')
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.contacts.all()[0].pk, stromae.pk)
 
         post_data = dict()
         post_data['flow'] = flow.pk
@@ -358,15 +358,15 @@ class TriggerTest(TembaTest):
         post_data['start_datetime_value'] = "%d" % now_stamp
 
         response = self.client.post(reverse("triggers.trigger_schedule"), post_data)
-        self.assertEquals(3, Trigger.objects.all().count())
+        self.assertEqual(3, Trigger.objects.all().count())
 
         trigger = Trigger.objects.all().order_by('-pk')[0]
         self.assertTrue(trigger.schedule)
         self.assertFalse(trigger.schedule.next_fire)
-        self.assertEquals(trigger.schedule.repeat_period, 'O')
-        self.assertEquals(trigger.schedule.repeat_days, 0)
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
-        self.assertEquals(trigger.contacts.all()[0].pk, stromae.pk)
+        self.assertEqual(trigger.schedule.repeat_period, 'O')
+        self.assertEqual(trigger.schedule.repeat_days, 0)
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.contacts.all()[0].pk, stromae.pk)
 
         post_data = dict()
         post_data['flow'] = flow.pk
@@ -376,13 +376,13 @@ class TriggerTest(TembaTest):
         post_data['start_datetime_value'] = "%d" % tommorrow_stamp
 
         response = self.client.post(reverse("triggers.trigger_schedule"), post_data)
-        self.assertEquals(4, Trigger.objects.all().count())
+        self.assertEqual(4, Trigger.objects.all().count())
 
         trigger = Trigger.objects.all().order_by('-pk')[0]
         self.assertTrue(trigger.schedule)
-        self.assertEquals(trigger.schedule.repeat_period, 'D')
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
-        self.assertEquals(trigger.contacts.all()[0].pk, stromae.pk)
+        self.assertEqual(trigger.schedule.repeat_period, 'D')
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.contacts.all()[0].pk, stromae.pk)
 
         update_url = reverse('triggers.trigger_update', args=[trigger.pk])
 
@@ -393,7 +393,7 @@ class TriggerTest(TembaTest):
         post_data['start_datetime_value'] = "%d" % now_stamp
 
         response = self.client.post(update_url, post_data)
-        self.assertEquals(response.context['form'].errors.keys(), ['flow'])
+        self.assertEqual(response.context['form'].errors.keys(), ['flow'])
 
         post_data = dict()
         post_data['flow'] = flow.pk
@@ -406,9 +406,9 @@ class TriggerTest(TembaTest):
 
         trigger = Trigger.objects.get(pk=trigger.pk)
         self.assertTrue(trigger.schedule)
-        self.assertEquals(trigger.schedule.repeat_period, 'O')
+        self.assertEqual(trigger.schedule.repeat_period, 'O')
         self.assertFalse(trigger.schedule.next_fire)
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
         self.assertFalse(trigger.contacts.all())
 
         post_data = dict()
@@ -421,9 +421,9 @@ class TriggerTest(TembaTest):
 
         trigger = Trigger.objects.get(pk=trigger.pk)
         self.assertTrue(trigger.schedule)
-        self.assertEquals(trigger.schedule.status, 'U')
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
-        self.assertEquals(trigger.contacts.all()[0].pk, stromae.pk)
+        self.assertEqual(trigger.schedule.status, 'U')
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.contacts.all()[0].pk, stromae.pk)
 
         post_data = dict()
         post_data['flow'] = flow.pk
@@ -435,9 +435,9 @@ class TriggerTest(TembaTest):
 
         trigger = Trigger.objects.get(pk=trigger.pk)
         self.assertTrue(trigger.schedule)
-        self.assertEquals(trigger.schedule.status, 'U')
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
-        self.assertEquals(trigger.contacts.all()[0].pk, stromae.pk)
+        self.assertEqual(trigger.schedule.status, 'U')
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.contacts.all()[0].pk, stromae.pk)
 
         post_data = dict()
         post_data['flow'] = flow.pk
@@ -451,9 +451,9 @@ class TriggerTest(TembaTest):
         trigger = Trigger.objects.get(pk=trigger.pk)
 
         self.assertTrue(trigger.schedule)
-        self.assertEquals(trigger.schedule.repeat_period, 'D')
-        self.assertEquals(trigger.groups.all()[0].pk, linkin_park.pk)
-        self.assertEquals(trigger.contacts.all()[0].pk, stromae.pk)
+        self.assertEqual(trigger.schedule.repeat_period, 'D')
+        self.assertEqual(trigger.groups.all()[0].pk, linkin_park.pk)
+        self.assertEqual(trigger.contacts.all()[0].pk, stromae.pk)
 
     def test_join_group_trigger(self):
         self.login(self.admin)
@@ -524,7 +524,7 @@ class TriggerTest(TembaTest):
             trigger_form = form(self.admin)
             pick = self.get_flow('pick_a_number')
             favorites = self.get_flow('favorites')
-            self.assertEquals(2, trigger_form.fields['flow'].choices.queryset.all().count())
+            self.assertEqual(2, trigger_form.fields['flow'].choices.queryset.all().count())
 
             # now change to a single message type
             pick.flow_type = Flow.MESSAGE
@@ -533,7 +533,7 @@ class TriggerTest(TembaTest):
             # our flow should no longer be an option
             trigger_form = form(self.admin)
             choices = trigger_form.fields['flow'].choices
-            self.assertEquals(1, choices.queryset.all().count())
+            self.assertEqual(1, choices.queryset.all().count())
             self.assertIsNone(choices.queryset.filter(pk=pick.pk).first())
 
             pick.delete()
@@ -546,7 +546,7 @@ class TriggerTest(TembaTest):
         # no keyword must show validation error
         post_data = dict(action_join_group=group.pk, keyword='@#$')
         response = self.client.post(reverse("triggers.trigger_register"), data=post_data)
-        self.assertEquals(1, len(response.context['form'].errors))
+        self.assertEqual(1, len(response.context['form'].errors))
 
         # create a trigger that sets up a group join flow
         post_data = dict(action_join_group=group.pk, keyword=u'١٠٠')
@@ -580,7 +580,7 @@ class TriggerTest(TembaTest):
 
         # check that our trigger exists and shows our group
         trigger = Trigger.objects.get(keyword='join', flow=flow)
-        self.assertEquals("Join Chat", trigger.flow.name)
+        self.assertEqual("Join Chat", trigger.flow.name)
 
         # now let's try it out
         contact = self.create_contact('Ben', '+250788382382')
@@ -608,19 +608,19 @@ class TriggerTest(TembaTest):
         trigger_url = reverse("triggers.trigger_missed_call")
 
         response = self.client.get(trigger_url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         post_data = dict(flow=flow.pk)
 
         response = self.client.post(trigger_url, post_data)
         trigger = Trigger.objects.all().order_by('-pk')[0]
 
-        self.assertEquals(trigger.trigger_type, Trigger.TYPE_MISSED_CALL)
-        self.assertEquals(trigger.flow.pk, flow.pk)
+        self.assertEqual(trigger.trigger_type, Trigger.TYPE_MISSED_CALL)
+        self.assertEqual(trigger.flow.pk, flow.pk)
 
         missed_call_trigger = Trigger.get_triggers_of_type(self.org, Trigger.TYPE_MISSED_CALL).first()
 
-        self.assertEquals(missed_call_trigger.pk, trigger.pk)
+        self.assertEqual(missed_call_trigger.pk, trigger.pk)
 
         ChannelEvent.create(self.channel, six.text_type(contact.get_urn(TEL_SCHEME)), ChannelEvent.TYPE_CALL_IN_MISSED, timezone.now(), 0)
         self.assertEqual(ChannelEvent.objects.all().count(), 2)
@@ -632,12 +632,12 @@ class TriggerTest(TembaTest):
 
         response = self.client.post(reverse("triggers.trigger_update", args=[trigger.pk]), post_data)
         trigger = Trigger.objects.get(pk=trigger.pk)
-        self.assertEquals(trigger.flow.pk, other_flow.pk)
+        self.assertEqual(trigger.flow.pk, other_flow.pk)
 
         # create ten missed call triggers
         for i in range(10):
             response = self.client.get(trigger_url)
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
 
             post_data = dict(flow=flow.pk)
 
@@ -654,7 +654,7 @@ class TriggerTest(TembaTest):
         post_data['objects'] = [t.pk for t in triggers]
 
         response = self.client.post(reverse("triggers.trigger_archived"), post_data)
-        self.assertEquals(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL).count())
+        self.assertEqual(1, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL).count())
         self.assertFalse(active_trigger.pk == Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_MISSED_CALL)[0].pk)
 
     def test_new_conversation_trigger_viber(self):
@@ -822,38 +822,38 @@ class TriggerTest(TembaTest):
         self.assertFalse(catch_all_trigger)
 
         Msg.create_incoming(self.channel, six.text_type(contact.get_urn()), "Hi")
-        self.assertEquals(1, Msg.objects.all().count())
-        self.assertEquals(0, flow.runs.all().count())
+        self.assertEqual(1, Msg.objects.all().count())
+        self.assertEqual(0, flow.runs.all().count())
 
         trigger_url = reverse("triggers.trigger_catchall")
 
         response = self.client.get(trigger_url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         post_data = dict(flow=flow.pk)
 
         response = self.client.post(trigger_url, post_data)
         trigger = Trigger.objects.all().order_by('-pk')[0]
 
-        self.assertEquals(trigger.trigger_type, Trigger.TYPE_CATCH_ALL)
-        self.assertEquals(trigger.flow.pk, flow.pk)
+        self.assertEqual(trigger.trigger_type, Trigger.TYPE_CATCH_ALL)
+        self.assertEqual(trigger.flow.pk, flow.pk)
 
         catch_all_trigger = Trigger.get_triggers_of_type(self.org, Trigger.TYPE_CATCH_ALL).first()
 
-        self.assertEquals(catch_all_trigger.pk, trigger.pk)
+        self.assertEqual(catch_all_trigger.pk, trigger.pk)
 
         incoming = Msg.create_incoming(self.channel, six.text_type(contact.get_urn()), "Hi")
-        self.assertEquals(1, flow.runs.all().count())
-        self.assertEquals(flow.runs.all()[0].contact.pk, contact.pk)
+        self.assertEqual(1, flow.runs.all().count())
+        self.assertEqual(flow.runs.all()[0].contact.pk, contact.pk)
         reply = Msg.objects.get(response_to=incoming)
-        self.assertEquals('Echo: Hi', reply.text)
+        self.assertEqual('Echo: Hi', reply.text)
 
         other_flow = Flow.copy(flow, self.admin)
         post_data = dict(flow=other_flow.pk)
 
         self.client.post(reverse("triggers.trigger_update", args=[trigger.pk]), post_data)
         trigger = Trigger.objects.get(pk=trigger.pk)
-        self.assertEquals(trigger.flow.pk, other_flow.pk)
+        self.assertEqual(trigger.flow.pk, other_flow.pk)
 
         # try to create another catch all trigger
         response = self.client.post(trigger_url, post_data)
@@ -878,7 +878,7 @@ class TriggerTest(TembaTest):
         response = self.client.post(trigger_url, post_data)
 
         # should now have two catch all triggers
-        self.assertEquals(2, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL).count())
+        self.assertEqual(2, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL).count())
 
         group_catch_all = Trigger.objects.get(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL, groups=group)
 
@@ -899,7 +899,7 @@ class TriggerTest(TembaTest):
         new_catch_all.refresh_from_db()
 
         # our new triggers should have been auto-archived, our old one is now active
-        self.assertEquals(2, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL).count())
+        self.assertEqual(2, Trigger.objects.filter(is_archived=False, trigger_type=Trigger.TYPE_CATCH_ALL).count())
         self.assertTrue(new_catch_all.is_archived)
         self.assertFalse(old_catch_all.is_archived)
 
@@ -912,7 +912,7 @@ class TriggerTest(TembaTest):
         Msg.objects.all().delete()
 
         incoming = Msg.create_incoming(self.channel, six.text_type(contact.get_urn()), "Hi")
-        self.assertEquals(0, FlowRun.objects.all().count())
+        self.assertEqual(0, FlowRun.objects.all().count())
         self.assertFalse(Msg.objects.filter(response_to=incoming))
 
         # now add the contact to the group
@@ -920,10 +920,10 @@ class TriggerTest(TembaTest):
 
         # this time should trigger the flow
         incoming = Msg.create_incoming(self.channel, six.text_type(contact.get_urn()), "Hi")
-        self.assertEquals(1, FlowRun.objects.all().count())
-        self.assertEquals(other_flow.runs.all()[0].contact.pk, contact.pk)
+        self.assertEqual(1, FlowRun.objects.all().count())
+        self.assertEqual(other_flow.runs.all()[0].contact.pk, contact.pk)
         reply = Msg.objects.get(response_to=incoming)
-        self.assertEquals('Echo: Hi', reply.text)
+        self.assertEqual('Echo: Hi', reply.text)
 
         # delete the group
         group.release()
@@ -948,7 +948,7 @@ class TriggerTest(TembaTest):
         update_url = reverse('triggers.trigger_update', args=[trigger.pk])
 
         response = self.client.get(update_url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # test trigger for Flow of flow_type of FLOW
         flow = self.create_flow()
@@ -957,28 +957,28 @@ class TriggerTest(TembaTest):
         post_data = dict(keyword='kiki', flow=flow.id, match_type='F')
         self.client.post(reverse("triggers.trigger_keyword"), data=post_data)
         trigger = Trigger.objects.get(keyword='kiki')
-        self.assertEquals(flow.pk, trigger.flow.pk)
+        self.assertEqual(flow.pk, trigger.flow.pk)
 
         update_url = reverse('triggers.trigger_update', args=[trigger.pk])
 
         response = self.client.get(update_url)
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(len(response.context['form'].fields), 5)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['form'].fields), 5)
 
         group = self.create_group("first", [])
 
         # show validation error if keyword is None or not defined
         post_data = dict(flow=flow.id, match_type='O', groups=[group.id])
         response = self.client.post(update_url, post_data, follow=True)
-        self.assertEquals(1, len(response.context['form'].errors))
+        self.assertEqual(1, len(response.context['form'].errors))
 
         post_data = dict(keyword='koko', flow=flow.id, match_type='O', groups=[group.id])
         self.client.post(update_url, post_data, follow=True)
 
         trigger.refresh_from_db()
-        self.assertEquals(trigger.keyword, 'koko')
-        self.assertEquals(trigger.match_type, Trigger.MATCH_ONLY_WORD)
-        self.assertEquals(trigger.flow, flow)
+        self.assertEqual(trigger.keyword, 'koko')
+        self.assertEqual(trigger.match_type, Trigger.MATCH_ONLY_WORD)
+        self.assertEqual(trigger.flow, flow)
         self.assertTrue(group in trigger.groups.all())
 
     def test_trigger_handle(self):
@@ -1169,23 +1169,23 @@ class TriggerTest(TembaTest):
         # try a ussd code with letters instead of numbers
         post_data = dict(channel=channel.pk, keyword='*keyword#', flow=flow.pk)
         response = self.client.post(reverse("triggers.trigger_ussd"), data=post_data)
-        self.assertEquals(1, len(response.context['form'].errors))
+        self.assertEqual(1, len(response.context['form'].errors))
         self.assertTrue("keyword" in response.context['form'].errors)
-        self.assertEquals(response.context['form'].errors['keyword'], [u'USSD code must contain only *,# and numbers'])
+        self.assertEqual(response.context['form'].errors['keyword'], [u'USSD code must contain only *,# and numbers'])
 
         # try a proper ussd code
         post_data = dict(channel=channel.pk, keyword='*111#', flow=flow.pk)
         response = self.client.post(reverse("triggers.trigger_ussd"), data=post_data)
-        self.assertEquals(0, len(response.context['form'].errors))
+        self.assertEqual(0, len(response.context['form'].errors))
         trigger = Trigger.objects.get(keyword='*111#')
-        self.assertEquals(flow.pk, trigger.flow.pk)
+        self.assertEqual(flow.pk, trigger.flow.pk)
 
         # try a duplicate ussd code
         post_data = dict(channel=channel.pk, keyword='*111#', flow=flow.pk)
         response = self.client.post(reverse("triggers.trigger_ussd"), data=post_data)
-        self.assertEquals(1, len(response.context['form'].errors))
-        self.assertEquals(response.context['form'].errors['__all__'],
-                          [u'An active trigger already exists, triggers must be unique for each group'])
+        self.assertEqual(1, len(response.context['form'].errors))
+        self.assertEqual(response.context['form'].errors['__all__'],
+                         [u'An active trigger already exists, triggers must be unique for each group'])
 
         # different code on same channel should work
         post_data = dict(channel=channel.pk, keyword='*112#', flow=flow.pk)
@@ -1197,7 +1197,7 @@ class TriggerTest(TembaTest):
         # TODO: fix this with multichannel triggers
         # post_data = dict(channel=channel.pk, keyword='*112#', flow=flow.pk)
         # response = self.client.post(reverse("triggers.trigger_ussd"), data=post_data)
-        # self.assertEquals(0, len(response.context['form'].errors))
-        # self.assertEquals(2, Trigger.objects.count())
+        # self.assertEqual(0, len(response.context['form'].errors))
+        # self.assertEqual(2, Trigger.objects.count())
         # trigger = Trigger.objects.get(keyword='*112#')
-        # self.assertEquals(flow.pk, trigger.flow.pk)
+        # self.assertEqual(flow.pk, trigger.flow.pk)

--- a/temba/ussd/tests.py
+++ b/temba/ussd/tests.py
@@ -439,10 +439,10 @@ class VumiUssdTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1515", msg.external_id)
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual("1515", msg.external_id)
+                self.assertEqual(1, mock.call_count)
 
                 # should have a failsafe that it was sent
                 self.assertTrue(r.sismember(timezone.now().strftime(MSG_SENT_KEY), str(msg.id)))
@@ -451,7 +451,7 @@ class VumiUssdTest(TembaTest):
                 Channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
 
                 # we shouldn't have been called again
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual(1, mock.call_count)
 
                 self.clear_cache()
         finally:
@@ -507,10 +507,10 @@ class VumiUssdTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1515", msg.external_id)
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual("1515", msg.external_id)
+                self.assertEqual(1, mock.call_count)
 
                 # simulate Vumi calling back to us sending an ACK event
                 data = {
@@ -531,7 +531,7 @@ class VumiUssdTest(TembaTest):
 
                 # it should be SENT now
                 msg.refresh_from_db()
-                self.assertEquals(SENT, msg.status)
+                self.assertEqual(SENT, msg.status)
 
                 self.clear_cache()
         finally:
@@ -560,10 +560,10 @@ class VumiUssdTest(TembaTest):
 
                 # check the status of the message is now sent
                 msg.refresh_from_db()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1515", msg.external_id)
-                self.assertEquals(1, mock.call_count)
+                self.assertEqual("1515", msg.external_id)
+                self.assertEqual(1, mock.call_count)
 
                 # should have a failsafe that it was sent
                 self.assertTrue(r.sismember(timezone.now().strftime(MSG_SENT_KEY), str(msg.id)))
@@ -618,7 +618,7 @@ class VumiUssdTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         # no real messages stored
-        self.assertEquals(Msg.objects.count(), 0)
+        self.assertEqual(Msg.objects.count(), 0)
 
         # ensure no messages has been created
         self.assertFalse(create_incoming.called)
@@ -649,11 +649,11 @@ class VumiUssdTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         msg = Msg.objects.get()
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello from Vumi", msg.text)
-        self.assertEquals('123456', msg.external_id)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello from Vumi", msg.text)
+        self.assertEqual('123456', msg.external_id)
         Msg.objects.all().delete()
 
         # test with vumi session data
@@ -677,12 +677,12 @@ class VumiUssdTest(TembaTest):
         self.assertEqual(session.external_id, str(int(from_addr) + int(session_start)))
 
         msg = Msg.objects.get()
-        self.assertEquals(INCOMING, msg.direction)
-        self.assertEquals(self.org, msg.org)
-        self.assertEquals(self.channel, msg.channel)
-        self.assertEquals("Hello from Vumi 2", msg.text)
-        self.assertEquals('123457', msg.external_id)
-        self.assertEquals(session, msg.connection)
+        self.assertEqual(INCOMING, msg.direction)
+        self.assertEqual(self.org, msg.org)
+        self.assertEqual(self.channel, msg.channel)
+        self.assertEqual("Hello from Vumi 2", msg.text)
+        self.assertEqual('123457', msg.external_id)
+        self.assertEqual(session, msg.connection)
 
     @patch('temba.msgs.models.Msg.create_incoming')
     def test_interrupt(self, create_incoming):
@@ -705,7 +705,7 @@ class VumiUssdTest(TembaTest):
         self.assertEqual(response.status_code, 200)
 
         # no real messages stored
-        self.assertEquals(Msg.objects.count(), 0)
+        self.assertEqual(Msg.objects.count(), 0)
 
         self.assertTrue(create_incoming.called)
         self.assertEqual(create_incoming.call_count, 1)
@@ -730,8 +730,8 @@ class VumiUssdTest(TembaTest):
 
                 self.assertEqual(msg.direction, 'O')
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1515", msg.external_id)
-                self.assertEquals(msg.connection.status, USSDSession.INITIATED)
+                self.assertEqual("1515", msg.external_id)
+                self.assertEqual(msg.connection.status, USSDSession.INITIATED)
 
                 # reply and choose an option that doesn't have any destination thus needs to close the session
                 USSDSession.handle_incoming(channel=self.channel, urn="+250788383383", content="4",
@@ -741,11 +741,11 @@ class VumiUssdTest(TembaTest):
                 msg = Msg.objects.filter(direction='O').order_by('id').last()
                 self.assertEqual(msg.direction, 'O')
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("1515", msg.external_id)
+                self.assertEqual("1515", msg.external_id)
 
-                self.assertEquals(msg.connection.status, USSDSession.COMPLETED)
+                self.assertEqual(msg.connection.status, USSDSession.COMPLETED)
 
-                self.assertEquals(2, mock.call_count)
+                self.assertEqual(2, mock.call_count)
 
                 self.clear_cache()
         finally:
@@ -759,7 +759,7 @@ class VumiUssdTest(TembaTest):
                     content="None", transport_type='ussd', session_event="new", to_addr=ussd_code)
         response = self.client.post(callback_url, json.dumps(data), content_type="application/json")
         flow = self.get_flow('ussd_trigger_flow')
-        self.assertEquals(0, flow.runs.all().count())
+        self.assertEqual(0, flow.runs.all().count())
 
         trigger, _ = Trigger.objects.get_or_create(channel=self.channel, keyword=ussd_code, flow=flow,
                                                    created_by=self.user, modified_by=self.user, org=self.org,
@@ -836,9 +836,9 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
                         args=['event', self.channel.uuid]),
                 data=json.dumps(data),
                 content_type='application/json')
-            self.assertEquals(200, response.status_code)
+            self.assertEqual(200, response.status_code)
             sms = Msg.objects.get(pk=sms.id)
-            self.assertEquals(assert_status, sms.status)
+            self.assertEqual(assert_status, sms.status)
 
         assertStatus(msg, 'submitted', SENT)
         assertStatus(msg, 'delivery_succeeded', DELIVERED)
@@ -860,11 +860,11 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
 
         # load our message
         inbound_msg, outbound_msg = Msg.objects.all().order_by('pk')
-        self.assertEquals(data["from"], outbound_msg.contact.get_urn(TEL_SCHEME).path)
-        self.assertEquals(outbound_msg.response_to, inbound_msg)
-        self.assertEquals(outbound_msg.connection.status, USSDSession.TRIGGERED)
-        self.assertEquals(inbound_msg.direction, INCOMING)
-        self.assertEquals(inbound_msg.status, HANDLED)
+        self.assertEqual(data["from"], outbound_msg.contact.get_urn(TEL_SCHEME).path)
+        self.assertEqual(outbound_msg.response_to, inbound_msg)
+        self.assertEqual(outbound_msg.connection.status, USSDSession.TRIGGERED)
+        self.assertEqual(inbound_msg.direction, INCOMING)
+        self.assertEqual(inbound_msg.status, HANDLED)
 
     def test_receive_with_session_id(self):
         from temba.ussd.models import USSDSession
@@ -876,9 +876,9 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
 
         # load our message
         inbound_msg, outbound_msg = Msg.objects.all().order_by('pk')
-        self.assertEquals(outbound_msg.connection.status, USSDSession.TRIGGERED)
-        self.assertEquals(outbound_msg.connection.external_id, 'session-id')
-        self.assertEquals(inbound_msg.connection.external_id, 'session-id')
+        self.assertEqual(outbound_msg.connection.status, USSDSession.TRIGGERED)
+        self.assertEqual(outbound_msg.connection.external_id, 'session-id')
+        self.assertEqual(inbound_msg.connection.external_id, 'session-id')
 
     def test_receive_ussd_no_session(self):
         from temba.channels.handlers import JunebugHandler
@@ -916,32 +916,32 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
 
                 self.assertEqual(msg.direction, 'O')
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("07033084-5cfd-4812-90a4-e4d24ffb6e3d", msg.external_id)
-                self.assertEquals(msg.connection.status, USSDSession.INITIATED)
+                self.assertEqual("07033084-5cfd-4812-90a4-e4d24ffb6e3d", msg.external_id)
+                self.assertEqual(msg.connection.status, USSDSession.INITIATED)
 
                 # reply and choose an option that doesn't have any destination thus needs to close the session
                 USSDSession.handle_incoming(channel=self.channel, urn="+250788383383", content="4",
                                             date=timezone.now(), external_id="21345", message_id='vumi-message-id')
                 # our outgoing message
                 msg = Msg.objects.filter(direction='O').order_by('id').last()
-                self.assertEquals(WIRED, msg.status)
+                self.assertEqual(WIRED, msg.status)
                 self.assertEqual(msg.direction, 'O')
                 self.assertTrue(msg.sent_on)
-                self.assertEquals("07033084-5cfd-4812-90a4-e4d24ffb6e3d", msg.external_id)
-                self.assertEquals("vumi-message-id", msg.response_to.external_id)
+                self.assertEqual("07033084-5cfd-4812-90a4-e4d24ffb6e3d", msg.external_id)
+                self.assertEqual("vumi-message-id", msg.response_to.external_id)
 
-                self.assertEquals(msg.connection.status, USSDSession.COMPLETED)
+                self.assertEqual(msg.connection.status, USSDSession.COMPLETED)
                 self.assertTrue(isinstance(msg.connection.get_duration(), timedelta))
 
-                self.assertEquals(2, mock.call_count)
+                self.assertEqual(2, mock.call_count)
 
                 # first outbound (session continued)
                 call = mock.call_args_list[0]
                 (args, kwargs) = call
                 payload = kwargs['json']
                 self.assertIsNone(payload.get('reply_to'))
-                self.assertEquals(payload.get('to'), "+250788383383")
-                self.assertEquals(payload['channel_data'], {
+                self.assertEqual(payload.get('to'), "+250788383383")
+                self.assertEqual(payload['channel_data'], {
                     'continue_session': True
                 })
 
@@ -949,9 +949,9 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
                 call = mock.call_args_list[1]
                 (args, kwargs) = call
                 payload = kwargs['json']
-                self.assertEquals(payload['reply_to'], 'vumi-message-id')
-                self.assertEquals(payload.get('to'), None)
-                self.assertEquals(payload['channel_data'], {
+                self.assertEqual(payload['reply_to'], 'vumi-message-id')
+                self.assertEqual(payload.get('to'), None)
+                self.assertEqual(payload['channel_data'], {
                     'continue_session': False
                 })
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -188,36 +188,36 @@ class InitTest(TembaTest):
         self.assertTrue(str_to_bool('1'))
 
     def test_format_decimal(self):
-        self.assertEquals('', format_decimal(None))
-        self.assertEquals('0', format_decimal(Decimal('0.0')))
-        self.assertEquals('10', format_decimal(Decimal('10')))
-        self.assertEquals('100', format_decimal(Decimal('100.0')))
-        self.assertEquals('123', format_decimal(Decimal('123')))
-        self.assertEquals('123', format_decimal(Decimal('123.0')))
-        self.assertEquals('123.34', format_decimal(Decimal('123.34')))
-        self.assertEquals('123.34', format_decimal(Decimal('123.3400000')))
-        self.assertEquals('-123', format_decimal(Decimal('-123.0')))
+        self.assertEqual('', format_decimal(None))
+        self.assertEqual('0', format_decimal(Decimal('0.0')))
+        self.assertEqual('10', format_decimal(Decimal('10')))
+        self.assertEqual('100', format_decimal(Decimal('100.0')))
+        self.assertEqual('123', format_decimal(Decimal('123')))
+        self.assertEqual('123', format_decimal(Decimal('123.0')))
+        self.assertEqual('123.34', format_decimal(Decimal('123.34')))
+        self.assertEqual('123.34', format_decimal(Decimal('123.3400000')))
+        self.assertEqual('-123', format_decimal(Decimal('-123.0')))
 
     def test_slugify_with(self):
-        self.assertEquals('foo_bar', slugify_with('foo bar'))
-        self.assertEquals('foo$bar', slugify_with('foo bar', '$'))
+        self.assertEqual('foo_bar', slugify_with('foo bar'))
+        self.assertEqual('foo$bar', slugify_with('foo bar', '$'))
 
     def test_truncate(self):
-        self.assertEquals('abc', truncate('abc', 5))
-        self.assertEquals('abcde', truncate('abcde', 5))
-        self.assertEquals('ab...', truncate('abcdef', 5))
+        self.assertEqual('abc', truncate('abc', 5))
+        self.assertEqual('abcde', truncate('abcde', 5))
+        self.assertEqual('ab...', truncate('abcdef', 5))
 
     def test_random_string(self):
         rs = random_string(1000)
-        self.assertEquals(1000, len(rs))
+        self.assertEqual(1000, len(rs))
         self.assertFalse('1' in rs or 'I' in rs or '0' in rs or 'O' in rs)
 
     def test_percentage(self):
-        self.assertEquals(0, percentage(0, 100))
-        self.assertEquals(0, percentage(0, 0))
-        self.assertEquals(0, percentage(100, 0))
-        self.assertEquals(75, percentage(75, 100))
-        self.assertEquals(76, percentage(759, 1000))
+        self.assertEqual(0, percentage(0, 100))
+        self.assertEqual(0, percentage(0, 0))
+        self.assertEqual(0, percentage(100, 0))
+        self.assertEqual(75, percentage(75, 100))
+        self.assertEqual(76, percentage(759, 1000))
 
     def test_get_country_code_by_name(self):
         self.assertEqual('RW', get_country_code_by_name('Rwanda'))
@@ -265,10 +265,10 @@ class TemplateTagTest(TembaTest):
         flow = Flow.create(self.org, self.admin, 'Test Flow')
         trigger = Trigger.objects.create(org=self.org, keyword='trigger', flow=flow, created_by=self.admin, modified_by=self.admin)
 
-        self.assertEquals('icon-instant', icon(campaign))
-        self.assertEquals('icon-feed', icon(trigger))
-        self.assertEquals('icon-tree', icon(flow))
-        self.assertEquals("", icon(None))
+        self.assertEqual('icon-instant', icon(campaign))
+        self.assertEqual('icon-feed', icon(trigger))
+        self.assertEqual('icon-tree', icon(flow))
+        self.assertEqual("", icon(None))
 
     def test_format_seconds(self):
         from temba.utils.templatetags.temba import format_seconds
@@ -276,13 +276,13 @@ class TemplateTagTest(TembaTest):
         self.assertIsNone(format_seconds(None))
 
         # less than a minute
-        self.assertEquals("30 sec", format_seconds(30))
+        self.assertEqual("30 sec", format_seconds(30))
 
         # round down
-        self.assertEquals("1 min", format_seconds(89))
+        self.assertEqual("1 min", format_seconds(89))
 
         # round up
-        self.assertEquals("2 min", format_seconds(100))
+        self.assertEqual("2 min", format_seconds(100))
 
     def test_delta(self):
         from temba.utils.templatetags.temba import delta_filter
@@ -387,18 +387,18 @@ class EmailTest(TembaTest):
     @override_settings(SEND_EMAILS=True)
     def test_send_simple_email(self):
         send_simple_email(['recipient@bar.com'], "Test Subject", "Test Body")
-        self.assertEquals(len(mail.outbox), 1)
-        self.assertEquals(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
-        self.assertEquals(mail.outbox[0].subject, "Test Subject")
-        self.assertEquals(mail.outbox[0].body, "Test Body")
-        self.assertEquals(mail.outbox[0].recipients(), ['recipient@bar.com'])
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertEqual(mail.outbox[0].subject, "Test Subject")
+        self.assertEqual(mail.outbox[0].body, "Test Body")
+        self.assertEqual(mail.outbox[0].recipients(), ['recipient@bar.com'])
 
         send_simple_email(['recipient@bar.com'], "Test Subject", "Test Body", from_email='no-reply@foo.com')
-        self.assertEquals(len(mail.outbox), 2)
-        self.assertEquals(mail.outbox[1].from_email, 'no-reply@foo.com')
-        self.assertEquals(mail.outbox[1].subject, "Test Subject")
-        self.assertEquals(mail.outbox[1].body, "Test Body")
-        self.assertEquals(mail.outbox[1].recipients(), ["recipient@bar.com"])
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(mail.outbox[1].from_email, 'no-reply@foo.com')
+        self.assertEqual(mail.outbox[1].subject, "Test Subject")
+        self.assertEqual(mail.outbox[1].body, "Test Body")
+        self.assertEqual(mail.outbox[1].recipients(), ["recipient@bar.com"])
 
     def test_is_valid_address(self):
 
@@ -521,7 +521,7 @@ class JsonTest(TembaTest):
 
         # test the same using our object mocking
         mock = dict_to_struct('Mock', json.loads(encoded), ['now'])
-        self.assertEquals(mock.now, source['now'])
+        self.assertEqual(mock.now, source['now'])
 
         # try it with a microsecond of 0 instead
         source['now'] = timezone.now().replace(microsecond=0)
@@ -537,7 +537,7 @@ class JsonTest(TembaTest):
 
         # test the same using our object mocking
         mock = dict_to_struct('Mock', json.loads(encoded), ['now'])
-        self.assertEquals(mock.now, source['now'])
+        self.assertEqual(mock.now, source['now'])
 
 
 class QueueTest(TembaTest):
@@ -566,7 +566,7 @@ class QueueTest(TembaTest):
 
         # pop on another task and start it and complete it
         push_task(self.org, None, 'test', args1)
-        self.assertEquals(args1, start_task('test')[1])
+        self.assertEqual(args1, start_task('test')[1])
         complete_task('test', self.org.id)
 
         # should have no active workers
@@ -579,8 +579,8 @@ class QueueTest(TembaTest):
         push_task(self.org, None, 'test', args2)
 
         # should come back in order of insertion
-        self.assertEquals(args1, start_task('test')[1])
-        self.assertEquals(args2, start_task('test')[1])
+        self.assertEqual(args1, start_task('test')[1])
+        self.assertEqual(args2, start_task('test')[1])
 
         # two active workers
         self.assertEqual(r.zscore('test:active', self.org.id), 2)
@@ -609,10 +609,10 @@ class QueueTest(TembaTest):
         push_task(self.org, None, 'test', args4, LOW_PRIORITY)
 
         # high priority should be first out, then defaults, then low
-        self.assertEquals(args3, start_task('test')[1])
-        self.assertEquals(args1, start_task('test')[1])
-        self.assertEquals(args2, start_task('test')[1])
-        self.assertEquals(args4, start_task('test')[1])
+        self.assertEqual(args3, start_task('test')[1])
+        self.assertEqual(args1, start_task('test')[1])
+        self.assertEqual(args2, start_task('test')[1])
+        self.assertEqual(args4, start_task('test')[1])
 
         self.assertEqual(r.zscore('test:active', self.org.id), 4)
 
@@ -727,115 +727,115 @@ class ExpressionsTest(TembaTest):
         self.context = EvaluationContext(variables, timezone.utc, DateStyle.DAY_FIRST)
 
     def test_evaluate_template(self):
-        self.assertEquals(("Hello World", []), evaluate_template('Hello World', self.context))  # no expressions
-        self.assertEquals(("Hello = Well 5", []),
-                          evaluate_template("Hello = @(flow.water_source) @flow.users", self.context))
-        self.assertEquals(("xxJoexx", []),
-                          evaluate_template("xx@(contact.first_name)xx", self.context))  # no whitespace
-        self.assertEquals(('Hello "World"', []),
-                          evaluate_template('@( "Hello ""World""" )', self.context))  # string with escaping
-        self.assertEquals(("Hello World", []),
-                          evaluate_template('@( "Hello" & " " & "World" )', self.context))  # string concatenation
-        self.assertEquals(('("', []),
-                          evaluate_template('@("(" & """")', self.context))  # string literals containing delimiters
-        self.assertEquals(('Joe Blow and Joe Blow', []),
-                          evaluate_template('@contact and @(contact)', self.context))  # old and new style
-        self.assertEquals(("Joe Blow language is set to 'eng'", []),
-                          evaluate_template("@contact language is set to '@contact.language'", self.context))  # language
+        self.assertEqual(("Hello World", []), evaluate_template('Hello World', self.context))  # no expressions
+        self.assertEqual(("Hello = Well 5", []),
+                         evaluate_template("Hello = @(flow.water_source) @flow.users", self.context))
+        self.assertEqual(("xxJoexx", []),
+                         evaluate_template("xx@(contact.first_name)xx", self.context))  # no whitespace
+        self.assertEqual(('Hello "World"', []),
+                         evaluate_template('@( "Hello ""World""" )', self.context))  # string with escaping
+        self.assertEqual(("Hello World", []),
+                         evaluate_template('@( "Hello" & " " & "World" )', self.context))  # string concatenation
+        self.assertEqual(('("', []),
+                         evaluate_template('@("(" & """")', self.context))  # string literals containing delimiters
+        self.assertEqual(('Joe Blow and Joe Blow', []),
+                         evaluate_template('@contact and @(contact)', self.context))  # old and new style
+        self.assertEqual(("Joe Blow language is set to 'eng'", []),
+                         evaluate_template("@contact language is set to '@contact.language'", self.context))  # language
 
         # test LTR and RTL mixing
-        self.assertEquals(("one two three four", []),
-                          evaluate_template("one @flow.english four", self.context))  # LTR var, LTR value, LTR text
-        self.assertEquals(("one اثنين ثلاثة four", []),
-                          evaluate_template("one @flow.arabic four", self.context))  # LTR var, RTL value, LTR text
-        self.assertEquals(("واحد اثنين ثلاثة أربعة", []),
-                          evaluate_template("واحد @flow.arabic أربعة", self.context))  # LTR var, RTL value, RTL text
-        self.assertEquals(("واحد two three أربعة", []),
-                          evaluate_template("واحد @flow.english أربعة", self.context))  # LTR var, LTR value, RTL text
+        self.assertEqual(("one two three four", []),
+                         evaluate_template("one @flow.english four", self.context))  # LTR var, LTR value, LTR text
+        self.assertEqual(("one اثنين ثلاثة four", []),
+                         evaluate_template("one @flow.arabic four", self.context))  # LTR var, RTL value, LTR text
+        self.assertEqual(("واحد اثنين ثلاثة أربعة", []),
+                         evaluate_template("واحد @flow.arabic أربعة", self.context))  # LTR var, RTL value, RTL text
+        self.assertEqual(("واحد two three أربعة", []),
+                         evaluate_template("واحد @flow.english أربعة", self.context))  # LTR var, LTR value, RTL text
 
         # test decimal arithmetic
-        self.assertEquals(("Result: 7", []),
-                          evaluate_template("Result: @(flow.users + 2)",
-                                            self.context))  # var is int
-        self.assertEquals(("Result: 0", []),
-                          evaluate_template("Result: @(flow.count - 5)",
-                                            self.context))  # var is string
-        self.assertEquals(("Result: 0.5", []),
-                          evaluate_template("Result: @(5 / (flow.users * 2))",
-                                            self.context))  # result is decimal
-        self.assertEquals(("Result: -10", []),
-                          evaluate_template("Result: @(-5 - flow.users)", self.context))  # negatives
+        self.assertEqual(("Result: 7", []),
+                         evaluate_template("Result: @(flow.users + 2)",
+                                           self.context))  # var is int
+        self.assertEqual(("Result: 0", []),
+                         evaluate_template("Result: @(flow.count - 5)",
+                                           self.context))  # var is string
+        self.assertEqual(("Result: 0.5", []),
+                         evaluate_template("Result: @(5 / (flow.users * 2))",
+                                           self.context))  # result is decimal
+        self.assertEqual(("Result: -10", []),
+                         evaluate_template("Result: @(-5 - flow.users)", self.context))  # negatives
 
         # test date arithmetic
-        self.assertEquals(("Date: 02-12-2014 09:00", []),
-                          evaluate_template("Date: @(flow.joined + 1)",
-                                            self.context))  # var is datetime
-        self.assertEquals(("Date: 28-11-2014 09:00", []),
-                          evaluate_template("Date: @(flow.started - 3)",
-                                            self.context))  # var is string
-        self.assertEquals(("Date: 04-07-2014", []),
-                          evaluate_template("Date: @(DATE(2014, 7, 1) + 3)",
-                                            self.context))  # date constructor
-        self.assertEquals(("Date: 01-12-2014 11:30", []),
-                          evaluate_template("Date: @(flow.joined + TIME(2, 30, 0))",
-                                            self.context))  # time addition to datetime var
-        self.assertEquals(("Date: 01-12-2014 06:30", []),
-                          evaluate_template("Date: @(flow.joined - TIME(2, 30, 0))",
-                                            self.context))  # time subtraction from string var
+        self.assertEqual(("Date: 02-12-2014 09:00", []),
+                         evaluate_template("Date: @(flow.joined + 1)",
+                                           self.context))  # var is datetime
+        self.assertEqual(("Date: 28-11-2014 09:00", []),
+                         evaluate_template("Date: @(flow.started - 3)",
+                                           self.context))  # var is string
+        self.assertEqual(("Date: 04-07-2014", []),
+                         evaluate_template("Date: @(DATE(2014, 7, 1) + 3)",
+                                           self.context))  # date constructor
+        self.assertEqual(("Date: 01-12-2014 11:30", []),
+                         evaluate_template("Date: @(flow.joined + TIME(2, 30, 0))",
+                                           self.context))  # time addition to datetime var
+        self.assertEqual(("Date: 01-12-2014 06:30", []),
+                         evaluate_template("Date: @(flow.joined - TIME(2, 30, 0))",
+                                           self.context))  # time subtraction from string var
 
         # test function calls
-        self.assertEquals(("Hello joe", []),
-                          evaluate_template("Hello @(lower(contact.first_name))",
-                                            self.context))  # use lowercase for function name
-        self.assertEquals(("Hello JOE", []),
-                          evaluate_template("Hello @(UPPER(contact.first_name))",
-                                            self.context))  # use uppercase for function name
-        self.assertEquals(("Bonjour world", []),
-                          evaluate_template('@(SUBSTITUTE("Hello world", "Hello", "Bonjour"))',
-                                            self.context))  # string arguments
-        self.assertRegexpMatches(evaluate_template('Today is @(TODAY())', self.context)[0],
-                                 'Today is \d\d-\d\d-\d\d\d\d')  # function with no args
-        self.assertEquals(('3', []),
-                          evaluate_template('@(LEN( 1.2 ))',
-                                            self.context))  # auto decimal -> string conversion
-        self.assertEquals(('16', []),
-                          evaluate_template('@(LEN(flow.joined))',
-                                            self.context))  # auto datetime -> string conversion
-        self.assertEquals(('2', []),
-                          evaluate_template('@(WORD_COUNT("abc-def", FALSE))',
-                                            self.context))  # built-in variable
-        self.assertEquals(('TRUE', []),
-                          evaluate_template('@(OR(AND(True, flow.count = flow.users, 1), 0))',
-                                            self.context))  # booleans / varargs
-        self.assertEquals(('yes', []),
-                          evaluate_template('@(IF(IF(flow.count > 4, "x", "y") = "x", "yes", "no"))',
-                                            self.context))  # nested conditional
+        self.assertEqual(("Hello joe", []),
+                         evaluate_template("Hello @(lower(contact.first_name))",
+                                           self.context))  # use lowercase for function name
+        self.assertEqual(("Hello JOE", []),
+                         evaluate_template("Hello @(UPPER(contact.first_name))",
+                                           self.context))  # use uppercase for function name
+        self.assertEqual(("Bonjour world", []),
+                         evaluate_template('@(SUBSTITUTE("Hello world", "Hello", "Bonjour"))',
+                                           self.context))  # string arguments
+        self.assertRegex(evaluate_template('Today is @(TODAY())', self.context)[0],
+                         'Today is \d\d-\d\d-\d\d\d\d')  # function with no args
+        self.assertEqual(('3', []),
+                         evaluate_template('@(LEN( 1.2 ))',
+                                           self.context))  # auto decimal -> string conversion
+        self.assertEqual(('16', []),
+                         evaluate_template('@(LEN(flow.joined))',
+                                           self.context))  # auto datetime -> string conversion
+        self.assertEqual(('2', []),
+                         evaluate_template('@(WORD_COUNT("abc-def", FALSE))',
+                                           self.context))  # built-in variable
+        self.assertEqual(('TRUE', []),
+                         evaluate_template('@(OR(AND(True, flow.count = flow.users, 1), 0))',
+                                           self.context))  # booleans / varargs
+        self.assertEqual(('yes', []),
+                         evaluate_template('@(IF(IF(flow.count > 4, "x", "y") = "x", "yes", "no"))',
+                                           self.context))  # nested conditional
 
         # evaluation errors
-        self.assertEquals(("Error: @()", ["Expression error at: )"]),
-                          evaluate_template("Error: @()",
-                                            self.context))  # syntax error due to empty expression
-        self.assertEquals(("Error: @('2')", ["Expression error at: '"]),
-                          evaluate_template("Error: @('2')",
-                                            self.context))  # don't support single quote string literals
-        self.assertEquals(("Error: @(2 / 0)", ["Division by zero"]),
-                          evaluate_template("Error: @(2 / 0)",
-                                            self.context))  # division by zero
-        self.assertEquals(("Error: @(1 + flow.blank)", ["Expression could not be evaluated as decimal or date arithmetic"]),
-                          evaluate_template("Error: @(1 + flow.blank)",
-                                            self.context))  # string that isn't numeric
-        self.assertEquals(("Well @flow.boil", ["Undefined variable: flow.boil"]),
-                          evaluate_template("@flow.water_source @flow.boil",
-                                            self.context))  # undefined variables
-        self.assertEquals(("Hello @(XXX(1, 2))", ["Undefined function: XXX"]),
-                          evaluate_template("Hello @(XXX(1, 2))",
-                                            self.context))  # undefined function
-        self.assertEquals(('Hello @(ABS(1, "x", TRUE))', ["Too many arguments provided for function ABS"]),
-                          evaluate_template('Hello @(ABS(1, "x", TRUE))',
-                                            self.context))  # wrong number of args
-        self.assertEquals(('Hello @(REPT(flow.blank, -2))', ['Error calling function REPT with arguments "", -2']),
-                          evaluate_template('Hello @(REPT(flow.blank, -2))',
-                                            self.context))  # internal function error
+        self.assertEqual(("Error: @()", ["Expression error at: )"]),
+                         evaluate_template("Error: @()",
+                                           self.context))  # syntax error due to empty expression
+        self.assertEqual(("Error: @('2')", ["Expression error at: '"]),
+                         evaluate_template("Error: @('2')",
+                                           self.context))  # don't support single quote string literals
+        self.assertEqual(("Error: @(2 / 0)", ["Division by zero"]),
+                         evaluate_template("Error: @(2 / 0)",
+                                           self.context))  # division by zero
+        self.assertEqual(("Error: @(1 + flow.blank)", ["Expression could not be evaluated as decimal or date arithmetic"]),
+                         evaluate_template("Error: @(1 + flow.blank)",
+                                           self.context))  # string that isn't numeric
+        self.assertEqual(("Well @flow.boil", ["Undefined variable: flow.boil"]),
+                         evaluate_template("@flow.water_source @flow.boil",
+                                           self.context))  # undefined variables
+        self.assertEqual(("Hello @(XXX(1, 2))", ["Undefined function: XXX"]),
+                         evaluate_template("Hello @(XXX(1, 2))",
+                                           self.context))  # undefined function
+        self.assertEqual(('Hello @(ABS(1, "x", TRUE))', ["Too many arguments provided for function ABS"]),
+                         evaluate_template('Hello @(ABS(1, "x", TRUE))',
+                                           self.context))  # wrong number of args
+        self.assertEqual(('Hello @(REPT(flow.blank, -2))', ['Error calling function REPT with arguments "", -2']),
+                         evaluate_template('Hello @(REPT(flow.blank, -2))',
+                                           self.context))  # internal function error
 
     def test_evaluate_template_compat(self):
         # test old style expressions, i.e. @ and with filters
@@ -950,11 +950,11 @@ class ExpressionsTest(TembaTest):
                                                                      vararg=False)])))
 
     def test_percentage(self):
-        self.assertEquals(0, percentage(0, 100))
-        self.assertEquals(0, percentage(0, 0))
-        self.assertEquals(0, percentage(100, 0))
-        self.assertEquals(75, percentage(75, 100))
-        self.assertEquals(76, percentage(759, 1000))
+        self.assertEqual(0, percentage(0, 100))
+        self.assertEqual(0, percentage(0, 0))
+        self.assertEqual(0, percentage(100, 0))
+        self.assertEqual(75, percentage(75, 100))
+        self.assertEqual(76, percentage(759, 1000))
 
 
 class GSM7Test(TembaTest):
@@ -965,16 +965,16 @@ class GSM7Test(TembaTest):
         self.assertFalse(is_gsm7("No unicode. ☺"))
 
         replaced = replace_non_gsm7_accents("No capital accented È!")
-        self.assertEquals("No capital accented E!", replaced)
+        self.assertEqual("No capital accented E!", replaced)
         self.assertTrue(is_gsm7(replaced))
 
         replaced = replace_non_gsm7_accents("No crazy “word” quotes.")
-        self.assertEquals('No crazy "word" quotes.', replaced)
+        self.assertEqual('No crazy "word" quotes.', replaced)
         self.assertTrue(is_gsm7(replaced))
 
         # non breaking space
         replaced = replace_non_gsm7_accents("Pour chercher du boulot, comment fais-tu ?")
-        self.assertEquals('Pour chercher du boulot, comment fais-tu ?', replaced)
+        self.assertEqual('Pour chercher du boulot, comment fais-tu ?', replaced)
         self.assertTrue(is_gsm7(replaced))
 
     def test_num_segments(self):
@@ -1088,12 +1088,12 @@ class ExportTest(TembaTest):
 
             for idx, row in enumerate(reader):
                 if idx == 0:
-                    self.assertEquals(cols, row)
+                    self.assertEqual(cols, row)
                 else:
-                    self.assertEquals(values, row)
+                    self.assertEqual(values, row)
 
             # should only be three rows
-            self.assertEquals(2, idx)
+            self.assertEqual(2, idx)
 
     @patch('temba.utils.export.BaseExportTask.MAX_EXCEL_ROWS', new_callable=PropertyMock)
     def test_tableexporter_xls(self, mock_max_rows):
@@ -1120,26 +1120,26 @@ class ExportTest(TembaTest):
         temp_file, file_ext = exporter.save_file()
         workbook = load_workbook(filename=temp_file.name)
 
-        self.assertEquals(2, len(workbook.worksheets))
+        self.assertEqual(2, len(workbook.worksheets))
 
         # check our sheet 1 values
         sheet1 = workbook.worksheets[0]
 
         rows = tuple(sheet1.rows)
 
-        self.assertEquals(cols, [cell.value for cell in rows[0]])
-        self.assertEquals(values, [cell.value for cell in rows[1]])
+        self.assertEqual(cols, [cell.value for cell in rows[0]])
+        self.assertEqual(values, [cell.value for cell in rows[1]])
 
-        self.assertEquals(test_max_rows, len(list(sheet1.rows)))
-        self.assertEquals(32, len(list(sheet1.columns)))
+        self.assertEqual(test_max_rows, len(list(sheet1.rows)))
+        self.assertEqual(32, len(list(sheet1.columns)))
 
         sheet2 = workbook.worksheets[1]
         rows = tuple(sheet2.rows)
-        self.assertEquals(cols, [cell.value for cell in rows[0]])
-        self.assertEquals(values, [cell.value for cell in rows[1]])
+        self.assertEqual(cols, [cell.value for cell in rows[0]])
+        self.assertEqual(values, [cell.value for cell in rows[1]])
 
-        self.assertEquals(200 + 2, len(list(sheet2.rows)))
-        self.assertEquals(32, len(list(sheet2.columns)))
+        self.assertEqual(200 + 2, len(list(sheet2.rows)))
+        self.assertEqual(32, len(list(sheet2.columns)))
 
 
 class CurrencyTest(TembaTest):

--- a/temba/values/tests.py
+++ b/temba/values/tests.py
@@ -16,8 +16,8 @@ from .models import Value
 class ResultTest(FlowFileTest):
 
     def assertResult(self, result, index, category, count):
-        self.assertEquals(count, result['categories'][index]['count'])
-        self.assertEquals(category, result['categories'][index]['label'])
+        self.assertEqual(count, result['categories'][index]['count'])
+        self.assertEqual(category, result['categories'][index]['label'])
 
     def test_field_results(self):
         c1 = self.create_contact("Contact1", '0788111111')
@@ -33,9 +33,9 @@ class ResultTest(FlowFileTest):
         c3.set_field(self.user, 'gender', "Female")
 
         result = Value.get_value_summary(contact_field=gender)[0]
-        self.assertEquals(2, len(result['categories']))
-        self.assertEquals(3, result['set'])
-        self.assertEquals(2, result['unset'])  # this is two as we have the default contact created by our unit tests
+        self.assertEqual(2, len(result['categories']))
+        self.assertEqual(3, result['set'])
+        self.assertEqual(2, result['unset'])  # this is two as we have the default contact created by our unit tests
         self.assertFalse(result['open_ended'])
         self.assertResult(result, 0, "Female", 2)
         self.assertResult(result, 1, "Male", 1)
@@ -47,9 +47,9 @@ class ResultTest(FlowFileTest):
         c3.set_field(self.user, 'born', 1977)
 
         result = Value.get_value_summary(contact_field=born)[0]
-        self.assertEquals(2, len(result['categories']))
-        self.assertEquals(3, result['set'])
-        self.assertEquals(2, result['unset'])
+        self.assertEqual(2, len(result['categories']))
+        self.assertEqual(3, result['set'])
+        self.assertEqual(2, result['unset'])
         self.assertFalse(result['open_ended'])
         self.assertResult(result, 0, "1977", 2)
         self.assertResult(result, 1, "1990", 1)
@@ -60,9 +60,9 @@ class ResultTest(FlowFileTest):
         c2.set_field(self.user, 'state', "Kigali City")
 
         result = Value.get_value_summary(contact_field=state)[0]
-        self.assertEquals(1, len(result['categories']))
-        self.assertEquals(2, result['set'])
-        self.assertEquals(3, result['unset'])
+        self.assertEqual(1, len(result['categories']))
+        self.assertEqual(2, result['set'])
+        self.assertEqual(3, result['unset'])
         self.assertResult(result, 0, "1708283", 2)
 
         reg_date = ContactField.get_or_create(self.org, self.admin, 'reg_date', label="Registration Date", value_type=Value.TYPE_DATETIME)
@@ -72,18 +72,18 @@ class ResultTest(FlowFileTest):
         c2.set_field(self.user, 'reg_date', now.replace(hour=4))
         c3.set_field(self.user, 'reg_date', now - timedelta(days=1))
         result = Value.get_value_summary(contact_field=reg_date)[0]
-        self.assertEquals(2, len(result['categories']))
-        self.assertEquals(3, result['set'])
-        self.assertEquals(2, result['unset'])
+        self.assertEqual(2, len(result['categories']))
+        self.assertEqual(3, result['set'])
+        self.assertEqual(2, result['unset'])
         self.assertResult(result, 0, now.replace(hour=0, minute=0, second=0, microsecond=0), 2)
         self.assertResult(result, 1, (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0), 1)
 
         # make sure categories returned are sorted by count, not name
         c2.set_field(self.user, 'gender', "Male")
         result = Value.get_value_summary(contact_field=gender)[0]
-        self.assertEquals(2, len(result['categories']))
-        self.assertEquals(3, result['set'])
-        self.assertEquals(2, result['unset'])  # this is two as we have the default contact created by our unit tests
+        self.assertEqual(2, len(result['categories']))
+        self.assertEqual(3, result['set'])
+        self.assertEqual(2, result['unset'])  # this is two as we have the default contact created by our unit tests
         self.assertFalse(result['open_ended'])
         self.assertResult(result, 0, "Male", 2)
         self.assertResult(result, 1, "Female", 1)
@@ -150,7 +150,7 @@ class ResultTest(FlowFileTest):
 
         # categories should be in the same order as our rules, should have correct counts
         result = Value.get_value_summary(ruleset=color)[0]
-        self.assertEquals(3, len(result['categories']))
+        self.assertEqual(3, len(result['categories']))
         self.assertFalse(result['open_ended'])
         self.assertResult(result, 0, "Red", 2)
         self.assertResult(result, 1, "Blue", 1)
@@ -158,7 +158,7 @@ class ResultTest(FlowFileTest):
 
         # check our age category as well
         result = Value.get_value_summary(ruleset=age)[0]
-        self.assertEquals(3, len(result['categories']))
+        self.assertEqual(3, len(result['categories']))
         self.assertFalse(result['open_ended'])
         self.assertResult(result, 0, "Child", 1)
         self.assertResult(result, 1, "Adult", 2)
@@ -166,7 +166,7 @@ class ResultTest(FlowFileTest):
 
         # and our gender categories
         result = Value.get_value_summary(ruleset=gender)[0]
-        self.assertEquals(2, len(result['categories']))
+        self.assertEqual(2, len(result['categories']))
         self.assertFalse(result['open_ended'])
         self.assertResult(result, 0, "Male", 2)
         self.assertResult(result, 1, "Female", 2)
@@ -226,7 +226,7 @@ class ResultTest(FlowFileTest):
 
         # should change our male/female breakdown since c1 now no longer has a gender
         result = Value.get_value_summary(ruleset=gender)[0]
-        self.assertEquals(2, len(result['categories']))
+        self.assertEqual(2, len(result['categories']))
         self.assertResult(result, 0, "Male", 1)
         self.assertResult(result, 1, "Female", 2)
 
@@ -275,15 +275,15 @@ class ResultTest(FlowFileTest):
         result = Value.get_value_summary(ruleset=color, segment=dict(location="State"))
 
         eastern_result = result[0]
-        self.assertEquals('171591', eastern_result['boundary'])
-        self.assertEquals('Eastern Province', eastern_result['label'])
+        self.assertEqual('171591', eastern_result['boundary'])
+        self.assertEqual('Eastern Province', eastern_result['label'])
         self.assertResult(eastern_result, 0, "Red", 0)
         self.assertResult(eastern_result, 1, "Blue", 0)
         self.assertResult(eastern_result, 2, "Green", 0)
 
         kigali_result = result[1]
-        self.assertEquals('1708283', kigali_result['boundary'])
-        self.assertEquals('Kigali City', kigali_result['label'])
+        self.assertEqual('1708283', kigali_result['boundary'])
+        self.assertEqual('Kigali City', kigali_result['label'])
         self.assertResult(kigali_result, 0, "Red", 0)
         self.assertResult(kigali_result, 1, "Blue", 2)
         self.assertResult(kigali_result, 2, "Green", 0)
@@ -293,15 +293,15 @@ class ResultTest(FlowFileTest):
         result = Value.get_value_summary(ruleset=color, segment=dict(location="State"))
 
         eastern_result = result[0]
-        self.assertEquals('171591', eastern_result['boundary'])
-        self.assertEquals('Eastern Province', eastern_result['label'])
+        self.assertEqual('171591', eastern_result['boundary'])
+        self.assertEqual('Eastern Province', eastern_result['label'])
         self.assertResult(eastern_result, 0, "Red", 0)
         self.assertResult(eastern_result, 1, "Blue", 1)
         self.assertResult(eastern_result, 2, "Green", 0)
 
         kigali_result = result[1]
-        self.assertEquals('1708283', kigali_result['boundary'])
-        self.assertEquals('Kigali City', kigali_result['label'])
+        self.assertEqual('1708283', kigali_result['boundary'])
+        self.assertEqual('Kigali City', kigali_result['label'])
         self.assertResult(kigali_result, 0, "Red", 0)
         self.assertResult(kigali_result, 1, "Blue", 1)
         self.assertResult(kigali_result, 2, "Green", 0)
@@ -310,10 +310,10 @@ class ResultTest(FlowFileTest):
         result = Value.get_value_summary(ruleset=color, segment=dict(parent="1708283", location="District"))
 
         # only on district in kigali
-        self.assertEquals(1, len(result))
+        self.assertEqual(1, len(result))
         kigali_result = result[0]
-        self.assertEquals('3963734', kigali_result['boundary'])
-        self.assertEquals('Nyarugenge', kigali_result['label'])
+        self.assertEqual('3963734', kigali_result['boundary'])
+        self.assertEqual('Nyarugenge', kigali_result['label'])
         self.assertResult(kigali_result, 0, "Red", 0)
         self.assertResult(kigali_result, 1, "Blue", 2)
         self.assertResult(kigali_result, 2, "Green", 0)
@@ -330,22 +330,22 @@ class ResultTest(FlowFileTest):
         self.assertTrue('breaks' in response)
 
         # should have two categories, Blue and Others
-        self.assertEquals(2, len(response['categories']))
-        self.assertEquals("Blue", response['categories'][0])
-        self.assertEquals("Others", response['categories'][1])
+        self.assertEqual(2, len(response['categories']))
+        self.assertEqual("Blue", response['categories'][0])
+        self.assertEqual("Others", response['categories'][1])
 
         # assert our kigali result
         kigali_result = response['scores']['1708283']
-        self.assertEquals(1, kigali_result['score'])
-        self.assertEquals("Kigali City", kigali_result['name'])
-        self.assertEquals("Blue", kigali_result['results'][0]['label'])
-        self.assertEquals("Others", kigali_result['results'][1]['label'])
+        self.assertEqual(1, kigali_result['score'])
+        self.assertEqual("Kigali City", kigali_result['name'])
+        self.assertEqual("Blue", kigali_result['results'][0]['label'])
+        self.assertEqual("Others", kigali_result['results'][1]['label'])
 
-        self.assertEquals(1, kigali_result['results'][0]['count'])
-        self.assertEquals(0, kigali_result['results'][1]['count'])
+        self.assertEqual(1, kigali_result['results'][0]['count'])
+        self.assertEqual(0, kigali_result['results'][1]['count'])
 
-        self.assertEquals(100, kigali_result['results'][0]['percentage'])
-        self.assertEquals(0, kigali_result['results'][1]['percentage'])
+        self.assertEqual(100, kigali_result['results'][0]['percentage'])
+        self.assertEqual(0, kigali_result['results'][1]['percentage'])
 
         with patch('temba.values.models.Value.get_value_summary') as mock:
             mock.return_value = []
@@ -357,34 +357,34 @@ class ResultTest(FlowFileTest):
             response = response.json()
 
             # should have two categories, Blue and Others
-            self.assertEquals(2, len(response['categories']))
-            self.assertEquals("", response['categories'][0])
-            self.assertEquals("", response['categories'][1])
+            self.assertEqual(2, len(response['categories']))
+            self.assertEqual("", response['categories'][0])
+            self.assertEqual("", response['categories'][1])
 
             # all counts and percentage are 0
-            self.assertEquals(0, response['totals']['count'])
-            self.assertEquals(0, response['totals']['results'][0]['count'])
-            self.assertEquals(0, response['totals']['results'][0]['percentage'])
-            self.assertEquals(0, response['totals']['results'][1]['count'])
-            self.assertEquals(0, response['totals']['results'][1]['percentage'])
+            self.assertEqual(0, response['totals']['count'])
+            self.assertEqual(0, response['totals']['results'][0]['count'])
+            self.assertEqual(0, response['totals']['results'][0]['percentage'])
+            self.assertEqual(0, response['totals']['results'][1]['count'])
+            self.assertEqual(0, response['totals']['results'][1]['percentage'])
 
             # and empty string labels
-            self.assertEquals("", response['totals']['results'][0]['label'])
-            self.assertEquals("", response['totals']['results'][1]['label'])
+            self.assertEqual("", response['totals']['results'][0]['label'])
+            self.assertEqual("", response['totals']['results'][1]['label'])
 
         # also check our analytics view
         response = self.client.get(reverse('flows.ruleset_analytics'))
 
         # make sure we have only one flow in it
         flows = json.loads(response.context['flows'])
-        self.assertEquals(1, len(flows))
-        self.assertEquals(3, len(flows[0]['rules']))
+        self.assertEqual(1, len(flows))
+        self.assertEqual(3, len(flows[0]['rules']))
 
     def test_open_ended_word_frequencies(self):
         flow = self.get_flow('random_word')
 
         def run_flow(contact, word):
-            self.assertEquals("Thank you", self.send_message(flow, word, contact=contact, restart_participants=True))
+            self.assertEqual("Thank you", self.send_message(flow, word, contact=contact, restart_participants=True))
 
         (c1, c2, c3, c4, c5, c6) = (self.create_contact("Contact1", '0788111111'),
                                     self.create_contact("Contact2", '0788222222'),
@@ -403,7 +403,7 @@ class ResultTest(FlowFileTest):
         random = RuleSet.objects.get(flow=flow, label="Random")
 
         result = Value.get_value_summary(ruleset=random)[0]
-        self.assertEquals(10, len(result['categories']))
+        self.assertEqual(10, len(result['categories']))
         self.assertTrue(result['open_ended'])
         self.assertResult(result, 0, "awesome", 2)
         self.assertResult(result, 1, "place", 2)
@@ -424,7 +424,7 @@ class ResultTest(FlowFileTest):
 
         # encore is a french stop word and should not be included this time
         result = Value.get_value_summary(ruleset=random)[0]
-        self.assertEquals(9, len(result['categories']))
+        self.assertEqual(9, len(result['categories']))
         self.assertTrue(result['open_ended'])
         self.assertResult(result, 0, "awesome", 2)
         self.assertResult(result, 1, "place", 2)


### PR DESCRIPTION
`assertEquals()` is deprecated in Python 2 and disappears in Python 3.

Sorry about the size of this diff, I understand if this isn't a priority for you.

I'm trying to make changes in such a way that it makes the codebase more likely to run on Python 3 without being too disruptive. In this case that means adding a new dependency which will prevent any further additions of the deprecated `assertEquals()` syntax.