### PR TITLE
adding a check for raven public dsn

### DIFF
--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -91,9 +91,11 @@
       %script{src:"{{ STATIC_URL }}lib/uuid.js"}
       %script{src:"{{ STATIC_URL }}lib/bootstrap-limit.js"}
       %script{src:"{{ STATIC_URL }}lib/jquery-ui-timepicker-addon.js"}
-
-      -if not debug and not testing
-        %script{src:"{{ STATIC_URL }}lib/raven.min.js"}
+        -if not debug and not testing and RAVEN_PUBLIC_DSN
+          %script{src:"{{ STATIC_URL }}lib/raven.min.js"}
+          -block raven-config
+            :javascript
+              Raven.config('{{ RAVEN_PUBLIC_DSN }}').install();
 
     -compress js
       %script{src:"{{ STATIC_URL }}js/omnibox.js"}


### PR DESCRIPTION
before we include the raven js library. Allows us to configure the raven.js library with an environment variable/global