### PR TITLE
Include organization and revision IDs in flow webhook events

### DIFF
--- a/media/test_flows/color.json
+++ b/media/test_flows/color.json
@@ -7,6 +7,7 @@
       "flow_type": "F",
       "base_language": "base",
       "metadata": {
+        "revision": 12,
         "uuid": "2a385c5b-e27c-43ac-bbc6-49653fede421",
         "author": "Ryan Lewis",
         "name": "Color Flow"

--- a/media/test_flows/color.json
+++ b/media/test_flows/color.json
@@ -7,7 +7,6 @@
       "flow_type": "F",
       "base_language": "base",
       "metadata": {
-        "revision": 12,
         "uuid": "2a385c5b-e27c-43ac-bbc6-49653fede421",
         "author": "Ryan Lewis",
         "name": "Color Flow"

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -228,7 +228,7 @@ class WebHookEvent(SmartModel):
 
         post_data = {
             'contact': contact_dict,
-            'flow': dict(name=flow.name, uuid=flow.uuid, revision_id=flow.metadata.get(flow.REVISION)),
+            'flow': dict(name=flow.name, uuid=flow.uuid, revision=flow.revisions.order_by('revision').last().revision),
             'path': run.path,
             'results': run.results,
             'run': dict(uuid=six.text_type(run.uuid), created_on=run.created_on.isoformat()),

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -228,10 +228,11 @@ class WebHookEvent(SmartModel):
 
         post_data = {
             'contact': contact_dict,
-            'flow': dict(name=flow.name, uuid=flow.uuid),
+            'flow': dict(name=flow.name, uuid=flow.uuid, revision_id=flow.metadata.get(flow.REVISION)),
             'path': run.path,
             'results': run.results,
-            'run': dict(uuid=six.text_type(run.uuid), created_on=run.created_on.isoformat())
+            'run': dict(uuid=six.text_type(run.uuid), created_on=run.created_on.isoformat()),
+            'org': dict(name=org.name, id=org.id)
         }
 
         if msg and msg.id > 0:

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -231,8 +231,7 @@ class WebHookEvent(SmartModel):
             'flow': dict(name=flow.name, uuid=flow.uuid, revision=flow.revisions.order_by('revision').last().revision),
             'path': run.path,
             'results': run.results,
-            'run': dict(uuid=six.text_type(run.uuid), created_on=run.created_on.isoformat()),
-            'org': dict(name=org.name, id=org.id)
+            'run': dict(uuid=six.text_type(run.uuid), created_on=run.created_on.isoformat())
         }
 
         if msg and msg.id > 0:

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -269,7 +269,7 @@ class WebHookTest(TembaTest):
 
         self.assertEqual(data['channel'], {'uuid': str(self.channel.uuid), 'name': self.channel.name})
         self.assertEqual(data['contact'], {'uuid': str(self.joe.uuid), 'name': self.joe.name, 'urn': six.text_type(self.joe.get_urn('tel'))})
-        self.assertEqual(data['flow'], {'uuid': str(flow.uuid), 'name': flow.name})
+        self.assertEqual(data['flow'], {'uuid': str(flow.uuid), 'name': flow.name, 'revision_id': 12})
         self.assertEqual(data['input'], {
             'urn': 'tel:+250788123123',
             'text': "Mauve",

--- a/temba/api/tests.py
+++ b/temba/api/tests.py
@@ -269,7 +269,7 @@ class WebHookTest(TembaTest):
 
         self.assertEqual(data['channel'], {'uuid': str(self.channel.uuid), 'name': self.channel.name})
         self.assertEqual(data['contact'], {'uuid': str(self.joe.uuid), 'name': self.joe.name, 'urn': six.text_type(self.joe.get_urn('tel'))})
-        self.assertEqual(data['flow'], {'uuid': str(flow.uuid), 'name': flow.name, 'revision_id': 12})
+        self.assertEqual(data['flow'], {'uuid': str(flow.uuid), 'name': flow.name, 'revision': 1})
         self.assertEqual(data['input'], {
             'urn': 'tel:+250788123123',
             'text': "Mauve",

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4776,7 +4776,7 @@ class FlowsTest(FlowFileTest):
 
         def assert_payload(payload, path_length, result_count, results):
             self.assertEqual(dict(name='Ben Haggerty', uuid=self.contact.uuid, urn='tel:+12065552020'), payload['contact'])
-            self.assertEqual(dict(name='Webhook Payload Test', uuid=flow.uuid, revision_id=61), payload['flow'])
+            self.assertEqual(dict(name='Webhook Payload Test', uuid=flow.uuid, revision=1), payload['flow'])
             self.assertEqual(dict(name='Test Channel', uuid=self.channel.uuid), payload['channel'])
             self.assertEqual(path_length, len(payload['path']))
             self.assertEqual(result_count, len(payload['results']))
@@ -8912,7 +8912,7 @@ class QueryTest(FlowFileTest):
 
         # mock our webhook call which will get triggered in the flow
         self.mockRequest('GET', '/ip_test', '{"ip":"192.168.1.1"}', content_type='application/json')
-        with QueryTracker(assert_query_count=147, stack_count=10, skip_unique_queries=True):
+        with QueryTracker(assert_query_count=148, stack_count=10, skip_unique_queries=True):
             flow.start([], [self.contact])
 
 

--- a/temba/flows/tests.py
+++ b/temba/flows/tests.py
@@ -4776,7 +4776,7 @@ class FlowsTest(FlowFileTest):
 
         def assert_payload(payload, path_length, result_count, results):
             self.assertEqual(dict(name='Ben Haggerty', uuid=self.contact.uuid, urn='tel:+12065552020'), payload['contact'])
-            self.assertEqual(dict(name='Webhook Payload Test', uuid=flow.uuid), payload['flow'])
+            self.assertEqual(dict(name='Webhook Payload Test', uuid=flow.uuid, revision_id=61), payload['flow'])
             self.assertEqual(dict(name='Test Channel', uuid=self.channel.uuid), payload['channel'])
             self.assertEqual(path_length, len(payload['path']))
             self.assertEqual(result_count, len(payload['results']))


### PR DESCRIPTION
## Changes

This PR includes a quick adjustment to the flow webhook to automatically include organization info and the flow's revision ID in the JSON payload. 

## Use Cases

- Including organization info in the payload would make it trivial to use common webhook endpoints in multi-tenant rapidpro installs; without the need for users to input org-specific urls/headers (less risk of human error/mixing things up). 

- Including the revision ID allows for more precise analysis of flow results over time, as the flows are fine-tuned. A/B testing of sorts. 

## Notes

Adding org info was pretty straightforward. Revision id proved to be slightly trickier - I ended up settling on using the metadata dict as it seemed to safely contain the needed info. 

Always open to suggestions! 