### PR TITLE
adding HTTP Basic Authentication for API

### DIFF
--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -55,10 +55,10 @@ class APIBasicAuthentication(BasicAuthentication):
         try:
             token = APIToken.objects.get(is_active=True, key=password)
         except APIToken.DoesNotExist:
-            raise exceptions.AuthenticationFailed("Invalid token")
+            raise exceptions.AuthenticationFailed("Invalid token or email")
 
         if token.user.username != userid:
-            raise exceptions.AuthenticationFailed("Invalid username")
+            raise exceptions.AuthenticationFailed("Invalid token or email")
 
         if token.user.is_active:
             # set the org on this user
@@ -66,7 +66,7 @@ class APIBasicAuthentication(BasicAuthentication):
 
             return token.user, token
 
-        raise exceptions.AuthenticationFailed("Invalid token")
+        raise exceptions.AuthenticationFailed("Invalid token or email")
 
 
 class OrgRateThrottle(ScopedRateThrottle):

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -39,7 +39,7 @@ class APITokenAuthentication(TokenAuthentication):
 
             return token.user, token
 
-        raise exceptions.AuthenticationFailed("User inactive or deleted")
+        raise exceptions.AuthenticationFailed("Invalid token")
 
 
 class APIBasicAuthentication(BasicAuthentication):
@@ -66,7 +66,7 @@ class APIBasicAuthentication(BasicAuthentication):
 
             return token.user, token
 
-        raise exceptions.AuthenticationFailed("User inactive or deleted")
+        raise exceptions.AuthenticationFailed("Invalid token")
 
 
 class OrgRateThrottle(ScopedRateThrottle):

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -1,7 +1,7 @@
 import logging
 
 from rest_framework import exceptions, status
-from rest_framework.authentication import TokenAuthentication, BasicAuthentication
+from rest_framework.authentication import BasicAuthentication, TokenAuthentication
 from rest_framework.exceptions import APIException
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.throttling import ScopedRateThrottle

--- a/temba/api/support.py
+++ b/temba/api/support.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.contrib.auth.models import User
 from rest_framework import exceptions, status
 from rest_framework.authentication import TokenAuthentication, BasicAuthentication
 from rest_framework.exceptions import APIException

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -290,7 +290,7 @@ class APITest(TembaTest):
         token1 = APIToken.get_or_create(self.org, self.admin, Group.objects.get(name="Administrators"))
         token2 = APIToken.get_or_create(self.org, self.admin, Group.objects.get(name="Surveyors"))
 
-        #can't fetch endpoint with invalid username
+        # can't fetch endpoint with invalid username
         response = api_request_basic_auth(contacts_url, "some@name.com", token1.key)
         self.assertResponseError(response, None, "Invalid token or email", status_code=403)
 

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -264,16 +264,16 @@ class APITest(TembaTest):
                 endpoint + ".json",
                 content_type="application/json",
                 HTTP_X_FORWARDED_HTTPS="https",
-                HTTP_AUTHORIZATION="Token {}".format(token),
+                HTTP_AUTHORIZATION=f"Token {token}",
             )
 
         def api_request_basic_auth(endpoint, username, token):
-            credentials_base64 = base64.encodebytes("{}:{}".format(username, token).encode()).decode()
+            credentials_base64 = base64.encodebytes(f"{username}:{token}".encode()).decode()
             return self.client.get(
                 endpoint + ".json",
                 content_type="application/json",
                 HTTP_X_FORWARDED_HTTPS="https",
-                HTTP_AUTHORIZATION="Basic {}".format(credentials_base64),
+                HTTP_AUTHORIZATION=f"Basic {credentials_base64}",
             )
 
         contacts_url = reverse("api.v2.contacts")

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from datetime import datetime
 from urllib.parse import quote_plus
@@ -266,6 +267,16 @@ class APITest(TembaTest):
                 HTTP_AUTHORIZATION="Token %s" % token,
             )
 
+        def api_request_basic_auth(endpoint, username, token):
+            encoded = "Basic {}".format(base64.encodebytes("{}:{}".format(username, token).encode()).decode()
+                                        .replace('\n',''))
+            return self.client.get(
+                endpoint + ".json",
+                content_type="application/json",
+                HTTP_X_FORWARDED_HTTPS="https",
+                HTTP_AUTHORIZATION=encoded,
+            )
+
         contacts_url = reverse("api.v2.contacts")
         campaigns_url = reverse("api.v2.campaigns")
 
@@ -273,19 +284,36 @@ class APITest(TembaTest):
         response = api_request(contacts_url, "1234567890")
         self.assertResponseError(response, None, "Invalid token", status_code=403)
 
+        # can't fetch endpoint with invalid token
+        response = api_request_basic_auth(contacts_url, self.admin.username, "1234567890")
+        self.assertResponseError(response, None, "Invalid token", status_code=403)
+
         token1 = APIToken.get_or_create(self.org, self.admin, Group.objects.get(name="Administrators"))
         token2 = APIToken.get_or_create(self.org, self.admin, Group.objects.get(name="Surveyors"))
 
+        #can't fetch endpoint with invalid username
+        response = api_request_basic_auth(contacts_url, "some@name.com", token1.key)
+        self.assertResponseError(response, None, "Invalid username", status_code=403)
+
         # can fetch campaigns endpoint with valid admin token
         response = api_request(campaigns_url, token1.key)
+        self.assertEqual(response.status_code, 200)
+
+        response = api_request_basic_auth(campaigns_url, self.admin.username, token1.key)
         self.assertEqual(response.status_code, 200)
 
         # but not with surveyor token
         response = api_request(campaigns_url, token2.key)
         self.assertResponseError(response, None, "You do not have permission to perform this action.", status_code=403)
 
+        response = api_request_basic_auth(campaigns_url, self.admin.username, token2.key)
+        self.assertResponseError(response, None, "You do not have permission to perform this action.", status_code=403)
+
         # but it can be used to access the contacts endpoint
         response = api_request(contacts_url, token2.key)
+        self.assertEqual(response.status_code, 200)
+
+        response = api_request_basic_auth(contacts_url, self.admin.username, token2.key)
         self.assertEqual(response.status_code, 200)
 
         # if user loses access to the token's role, don't allow the request
@@ -293,13 +321,18 @@ class APITest(TembaTest):
         self.org.surveyors.add(self.admin)
 
         self.assertEqual(api_request(campaigns_url, token1.key).status_code, 403)
+        self.assertEqual(api_request_basic_auth(campaigns_url, self.admin.username, token1.key).status_code, 403)
         self.assertEqual(api_request(contacts_url, token2.key).status_code, 200)  # other token unaffected
+        self.assertEqual(api_request_basic_auth(contacts_url, self.admin.username, token2.key).status_code, 200)
 
         # and if user is inactive, disallow the request
         self.admin.is_active = False
         self.admin.save()
 
         response = api_request(contacts_url, token2.key)
+        self.assertResponseError(response, None, "User inactive or deleted", status_code=403)
+
+        response = api_request_basic_auth(contacts_url, self.admin.username, token2.key)
         self.assertResponseError(response, None, "User inactive or deleted", status_code=403)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_HTTPS", "https"))

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -261,7 +261,7 @@ class APITest(TembaTest):
 
         def api_request(endpoint, token):
             return self.client.get(
-                endpoint + ".json",
+                f"{endpoint}.json",
                 content_type="application/json",
                 HTTP_X_FORWARDED_HTTPS="https",
                 HTTP_AUTHORIZATION=f"Token {token}",
@@ -270,7 +270,7 @@ class APITest(TembaTest):
         def api_request_basic_auth(endpoint, username, token):
             credentials_base64 = base64.encodebytes(f"{username}:{token}".encode()).decode()
             return self.client.get(
-                endpoint + ".json",
+                f"{endpoint}.json",
                 content_type="application/json",
                 HTTP_X_FORWARDED_HTTPS="https",
                 HTTP_AUTHORIZATION=f"Basic {credentials_base64}",

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -264,17 +264,16 @@ class APITest(TembaTest):
                 endpoint + ".json",
                 content_type="application/json",
                 HTTP_X_FORWARDED_HTTPS="https",
-                HTTP_AUTHORIZATION="Token %s" % token,
+                HTTP_AUTHORIZATION="Token {}".format(token),
             )
 
         def api_request_basic_auth(endpoint, username, token):
-            encoded = "Basic {}".format(base64.encodebytes("{}:{}".format(username, token).encode()).decode()
-                                        .replace('\n',''))
+            credentials_base64 = base64.encodebytes("{}:{}".format(username, token).encode()).decode()
             return self.client.get(
                 endpoint + ".json",
                 content_type="application/json",
                 HTTP_X_FORWARDED_HTTPS="https",
-                HTTP_AUTHORIZATION=encoded,
+                HTTP_AUTHORIZATION="Basic {}".format(credentials_base64),
             )
 
         contacts_url = reverse("api.v2.contacts")
@@ -330,10 +329,10 @@ class APITest(TembaTest):
         self.admin.save()
 
         response = api_request(contacts_url, token2.key)
-        self.assertResponseError(response, None, "User inactive or deleted", status_code=403)
+        self.assertResponseError(response, None, "Invalid token", status_code=403)
 
         response = api_request_basic_auth(contacts_url, self.admin.username, token2.key)
-        self.assertResponseError(response, None, "User inactive or deleted", status_code=403)
+        self.assertResponseError(response, None, "Invalid token", status_code=403)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_HTTPS", "https"))
     def test_root(self):

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -285,14 +285,14 @@ class APITest(TembaTest):
 
         # can't fetch endpoint with invalid token
         response = api_request_basic_auth(contacts_url, self.admin.username, "1234567890")
-        self.assertResponseError(response, None, "Invalid token", status_code=403)
+        self.assertResponseError(response, None, "Invalid token or email", status_code=403)
 
         token1 = APIToken.get_or_create(self.org, self.admin, Group.objects.get(name="Administrators"))
         token2 = APIToken.get_or_create(self.org, self.admin, Group.objects.get(name="Surveyors"))
 
         #can't fetch endpoint with invalid username
         response = api_request_basic_auth(contacts_url, "some@name.com", token1.key)
-        self.assertResponseError(response, None, "Invalid username", status_code=403)
+        self.assertResponseError(response, None, "Invalid token or email", status_code=403)
 
         # can fetch campaigns endpoint with valid admin token
         response = api_request(campaigns_url, token1.key)
@@ -332,7 +332,7 @@ class APITest(TembaTest):
         self.assertResponseError(response, None, "Invalid token", status_code=403)
 
         response = api_request_basic_auth(contacts_url, self.admin.username, token2.key)
-        self.assertResponseError(response, None, "Invalid token", status_code=403)
+        self.assertResponseError(response, None, "Invalid token or email", status_code=403)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_HTTPS", "https"))
     def test_root(self):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -885,6 +885,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.SessionAuthentication",
         "temba.api.support.APITokenAuthentication",
+        "temba.api.support.APIBasicAuthentication",
     ),
     "DEFAULT_THROTTLE_CLASSES": ("temba.api.support.OrgRateThrottle",),
     "DEFAULT_THROTTLE_RATES": {


### PR DESCRIPTION
This is a response to the call for help on issue #760 

The logic is entirely the same as Token Authentication logic with one extra step of verifying if the token owner has the same username as the one provided in the credentials.
 Let me know what you think