### PR TITLE
(WIP) Bump module deps minor versions

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -6,7 +6,7 @@
 #
 amqp==2.1.4               # via kombu
 analytics-python==1.2.9
-antlr4-python3-runtime==4.7.1
+antlr4-python3-runtime==4.7.2
 appdirs==1.4.3            # via black
 asn1crypto==0.22.0        # via cryptography
 attrs==18.1.0             # via black
@@ -39,7 +39,7 @@ django-rosetta==0.7.13
 django-select2==5.10.0
 django-storages==1.5.2
 django-timezone-field==2.0
-django==2.1.3
+django==2.1.5
 djangorestframework==3.8.2
 docutils==0.13.1          # via botocore
 elasticsearch-dsl==6.1.0
@@ -81,7 +81,7 @@ phonenumbers
 pip-tools==2.0.2
 pisa==3.0.33
 polib==1.0.8              # via django-rosetta
-psycopg2-binary==2.7.5
+psycopg2-binary==2.7.6.1
 pycodestyle==2.3.1        # via flake8
 pycountry==17.5.14
 pycparser==2.17           # via cffi
@@ -100,7 +100,7 @@ python-gcm==0.4
 python-intercom==3.1.0
 python-magic==0.4.15
 python-telegram-bot==6.1.0
-pytz==2017.2
+pytz
 rapidpro-expressions==1.7
 raven==6.9.0
 rcssmin==1.0.6            # via django-compressor
@@ -115,7 +115,7 @@ s3transfer==0.1.10        # via boto3
 selenium==3.4.3
 six==1.10.0               # via analytics-python, cryptography, django-extensions, django-hamlpy, django-rosetta, elasticsearch-dsl, librato-bg, librato-metrics, microsofttranslator, mock, pip-tools, python-dateutil, python-intercom, responses, twilio
 simplejson==3.16.0
-smartmin==2.1.0
+smartmin==2.1.1
 sqlparse==0.2.3           # via django-debug-toolbar, smartmin
 stop-words==2015.2.23.1
 stripe==1.59.0

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -66,7 +66,7 @@ simplejson
 stop-words
 unidecode
 python-intercom
-pysocks; python_version >= "3.0"
+pysocks
 pip-tools
 
 ########################## testing ##########################


### PR DESCRIPTION
This is a list of deps that we should take a look at:

# Update

boto3                  1.4.4       1.9.75  # potential problems
colorama               0.3.9       0.4.1
coverage               4.4.1       4.5.2
dj-database-url        0.4.2       0.5.0
django-compressor      2.1.1       2.2
django-countries       4.6.1       5.3.2
django-extensions      1.7.9       2.1.4
django-redis           4.8.0       4.10.0
django-storages        1.5.2       1.7.1
django-timezone-field  2.0         3.0
djangorestframework    3.8.2       3.9.0
elasticsearch-dsl      6.1.0       6.3.1
elasticsearch          6.2.0       6.3.1
flake8                 3.3.0       3.6.0
flake8-deprecated      1.2.1       1.3
flake8-print           2.0.2       3.1.0
geojson                1.3.5       2.4.1
gunicorn               19.7.1      19.9.0
iptools                0.6.1       0.7.0
nexmo                  2.2.0       2.3.0
pycountry              17.5.14     18.12.8
python-telegram-bot    6.1.0       11.1.0  # problems ?
raven                  6.9.0       6.10.0
redis                  2.10.5      3.0.1  # we should upgrade carefully (3 is a new major version)
requests               2.18.1      2.21.0
responses              0.5.1       0.10.5
stripe                 1.59.0      2.17.0  # problems ?
twilio                 6.16.2      6.22.1


# Remove

django-digest          1.13
django-excel           0.0.6       0.0.10
django-rosetta         0.7.13      0.9.0
Django-Select2         5.10.0      6.3.1
django-debug-toolbar   1.8         1.11
google                 1.9.3       2.0.1
isoweek                1.3.3
jsondiff               1.1.1
pisa                   3.0.33
analytics-python       1.2.9  # segment.com, do we still use this ???
mock                   2.0.0  # replace with unittest.mock ???
selenium               3.4.3  # really ??? :)
stop-words             2015.2.23.1
unidecode              0.4.20
xlutils                2.0.0