### PR TITLE
parses variables in webhook header values (issue #770)

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -4150,7 +4150,10 @@ class RuleSet(models.Model):
                 if RuleSet.CONFIG_WEBHOOK_HEADERS in self.config:
                     headers = self.config[RuleSet.CONFIG_WEBHOOK_HEADERS]
                     for item in headers:
-                        header[item.get("name")] = item.get("value")
+                        (header_value, parseerrors) = Msg.evaluate_template(
+                            item.get("value"), context, org=run.flow.org, url_encode=True
+                        )
+                        header[item.get("name")] = header_value
 
             elif self.ruleset_type == RuleSet.TYPE_RESTHOOK:
                 from temba.api.models import Resthook


### PR DESCRIPTION
This is a bit of a drive by.  I was browsing issues in this project, but am unfamiliar with it -- however I am a little familiar with Django, so I believe this should implement #770 

However, I didn't see any tests that I could readily use and the test samples were a little too opaque for me.  Maybe someone else can create the test for this or someone could point me to an example that would help.  `test_webhook` looked the most promising, but I don't understand where the data comes from that is tested and grepping didn't help.