### PR TITLE
adding regex to match pattern at the beginning of location

### DIFF
--- a/_docs/courier.md
+++ b/_docs/courier.md
@@ -32,7 +32,7 @@ URLs with `/c/` in them might be:
 
 ```
   # all courier URLs go to courier
-  location ~ /c/ {
+  location ^~ /c/ {
     proxy_set_header Host $http_host;
     proxy_pass http://courier_server;
     break;

--- a/_docs/mailroom.md
+++ b/_docs/mailroom.md
@@ -39,7 +39,7 @@ URLs with `/mr/` in them might be:
 
 ```
 # all Mailroom URLs go to Mailroom
-location ~ /mr/ {
+location ^~ /mr/ {
   proxy_set_header Host $http_host;
   proxy_pass http://mailroom_server;
   break;


### PR DESCRIPTION
This should be a more accurate nginx config for systems that use both mailroom and courier proxied through the same nginx instance.