### PR TITLE
💊 Fix rp-archiver version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The set of versions that make up the latest stable release are:
  * [RapidPro v5.0.9](https://github.com/rapidpro/rapidpro/releases/tag/v5.0.9)
  * [Mailroom v2.0.9](https://github.com/nyaruka/mailroom/releases/tag/v2.0.9)
  * [Courier v2.0.2](https://github.com/nyaruka/courier/releases/tag/v2.0.2)
- * [Archiver v2.0.0](https://github.com/nyaruka/rp-archiver/releases/tag/v2.0.0)
+ * [Archiver v2.0.1](https://github.com/nyaruka/rp-archiver/releases/tag/v2.0.1)
  * [Indexer v2.0.0](https://github.com/nyaruka/rp-indexer/releases/tag/v2.0.0)
  * [Android Channel v2.0.0](https://github.com/rapidpro/android-channel/releases/tag/v2.0.0)
  * [Android Surveyor v13.1.0](https://github.com/rapidpro/surveyor/releases/tag/v13.1.0)


### PR DESCRIPTION
Need rp-archiver 2.0.1 because we dropped some columns on api_webhookevent