### PR TITLE
Fix `frame.haml` template

### DIFF
--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -165,12 +165,12 @@
       -block extra-less
       -block extra-style
 
-  -for incl in brand.head_includes
-    -include incl
+    -for incl in brand.head_includes
+      -include incl
 
-  <!--[if lt IE 9]>
-    %script{src:"//html5shim.googlecode.com/svn/trunk/html5.js"}
-  <![endif]-->
+    <!--[if lt IE 9]>
+      %script{src:"//html5shim.googlecode.com/svn/trunk/html5.js"}
+    <![endif]-->
 
 -load smartmin
 {% block body %}


### PR DESCRIPTION
Indent the `brand.head_includes` and IE9 shim slightly so that when rendered into HTML, the code results inside the header rather than between the `<head>` and `<body>` tags.