### PR TITLE
Add prometheus monitoring

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -29,6 +29,7 @@ django-compressor==2.2
 django-countries==5.3.3
 django-hamlpy==1.2
 django-mptt==0.8.7
+django-prometheus==2.0.0
 django-redis==4.10.0
 django-storages==1.7.1
 django-timezone-field==3.0
@@ -66,6 +67,7 @@ packaging==19.0
 pathspec==0.7.0           # via black
 phonenumbers
 pip-tools==4.0.0
+prometheus-client==0.7.1  # via django-prometheus
 psycopg2-binary==2.7.7
 pycodestyle==2.5.0        # via flake8
 pycountry==18.12.8

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -12,7 +12,7 @@ asn1crypto==0.22.0        # via cryptography
 attrs==18.1.0             # via black
 beautifulsoup4==4.7.1
 billiard==3.5.0.2         # via celery
-black==19.3b0
+black==19.10b0
 boto3==1.9.91
 botocore==1.12.91         # via boto3, s3transfer
 celery[redis]==4.2.1
@@ -63,6 +63,7 @@ nexmo==2.4.0
 oauthlib==2.0.2           # via requests-oauthlib
 openpyxl==2.5.14
 packaging==19.0
+pathspec==0.7.0           # via black
 phonenumbers
 pip-tools==4.0.0
 psycopg2-binary==2.7.7
@@ -89,7 +90,7 @@ rapidpro-expressions==1.7
 raven==6.10.0
 rcssmin==1.0.6            # via django-compressor
 redis==2.10.5
-regex==2017.6.7           # via django-hamlpy, rapidpro-expressions
+regex==2017.6.7           # via black, django-hamlpy, rapidpro-expressions
 requests-oauthlib==0.8.0  # via twython
 requests-toolbelt==0.8.0  # via pyfcm
 requests==2.21.0
@@ -106,8 +107,13 @@ texttable==1.5.0          # via pyexcel
 toml==0.9.4               # via black
 twilio==6.24.0
 twython==3.5.0
+typed-ast==1.4.1          # via black
 urllib3==1.21.1           # via botocore, elasticsearch, requests
 vine==1.1.3               # via amqp
 xlrd==1.0.0               # via pyexcel-xls, smartmin
 xlsxlite==0.2.0
 xlwt==1.2.0               # via pyexcel-xls, smartmin
+zope.interface==4.7.2
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==46.0.0        # via zope.interface

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -115,7 +115,3 @@ vine==1.1.3               # via amqp
 xlrd==1.0.0               # via pyexcel-xls, smartmin
 xlsxlite==0.2.0
 xlwt==1.2.0               # via pyexcel-xls, smartmin
-zope.interface==4.7.2
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==46.0.0        # via zope.interface

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -58,7 +58,6 @@ python-intercom
 pysocks
 pip-tools
 packaging
-zope.interface
 
 ########################## testing ##########################
 black

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -57,6 +57,7 @@ python-intercom
 pysocks
 pip-tools
 packaging
+zope.interface
 
 ########################## testing ##########################
 black

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -4,6 +4,7 @@ django-compressor
 django-countries
 django-hamlpy
 django-mptt
+django-prometheus
 django-redis
 django-storages
 django-timezone-field

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1287,7 +1287,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
             updated_urns = [urn]
 
             # record contact creation in analytics
-            analytics.gauge("temba.contact_created")
+            analytics.increment("temba.contact_created")
 
             # handle group and campaign updates
             if init_new:
@@ -1438,7 +1438,7 @@ class Contact(RequireUpdateFieldsMixin, TembaModel):
 
         # record contact creation in analytics
         if getattr(contact, "is_new", False):
-            analytics.gauge("temba.contact_created")
+            analytics.increment("temba.contact_created")
 
         # handle group and campaign updates
         contact.handle_update(fields=updated_attrs, urns=updated_urns, is_new=contact.is_new)

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -178,6 +178,7 @@ if TESTING:
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 MIDDLEWARE = (
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -190,6 +191,7 @@ MIDDLEWARE = (
     "temba.middleware.OrgTimezoneMiddleware",
     "temba.middleware.ActivateLanguageMiddleware",
     "temba.middleware.OrgHeaderMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 )
 
 # security middleware configuration
@@ -230,6 +232,8 @@ INSTALLED_APPS = (
     "smartmin.users",
     # django-timezone-field
     "timezone_field",
+    # prometheus metrics
+    "django_prometheus",
     # temba apps
     "temba.apks",
     "temba.archives",

--- a/temba/urls.py
+++ b/temba/urls.py
@@ -41,6 +41,7 @@ urlpatterns = [
     url(r"^imports/", include("smartmin.csv_imports.urls")),
     url(r"^assets/", include("temba.assets.urls")),
     url(r"^jsi18n/$", JavaScriptCatalog.as_view(), js_info_dict, name="django.views.i18n.javascript_catalog"),
+    url(r"^", include("django_prometheus.urls")),
 ]
 
 if settings.DEBUG:

--- a/temba/utils/analytics/__init__.py
+++ b/temba/utils/analytics/__init__.py
@@ -1,0 +1,3 @@
+from .analytics import change_consent, gauge, identify, increment, init_analytics, set_orgs, track
+
+__all__ = ['init_analytics', 'gauge', 'identify', 'set_orgs', 'change_consent', 'track', 'increment']

--- a/temba/utils/analytics/__init__.py
+++ b/temba/utils/analytics/__init__.py
@@ -1,3 +1,3 @@
 from .analytics import change_consent, gauge, identify, increment, init_analytics, set_orgs, track
 
-__all__ = ['init_analytics', 'gauge', 'identify', 'set_orgs', 'change_consent', 'track', 'increment']
+__all__ = ["init_analytics", "gauge", "identify", "set_orgs", "change_consent", "track", "increment"]

--- a/temba/utils/analytics/analytics.py
+++ b/temba/utils/analytics/analytics.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from temba.utils import json
 
 from .librato import LibratoBackend
+from .prometheus import PrometheusBackend
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +44,12 @@ def init_analytics():  # pragma: no cover
         global _intercom
         _intercom = IntercomClient(personal_access_token=intercom_key)
 
-    # configure Librato if configured
     global _metric_backends
+
+    # configure Prometheus
+    _metric_backends.append(PrometheusBackend())
+
+    # configure Librato if configured
     librato_user = getattr(settings, "LIBRATO_USER", None)
     librato_token = getattr(settings, "LIBRATO_TOKEN", None)
     if librato_user and librato_token:

--- a/temba/utils/analytics/base.py
+++ b/temba/utils/analytics/base.py
@@ -1,0 +1,17 @@
+import zope.interface
+
+
+class IMetricBackend(zope.interface.Interface):
+    """
+    A metric backend
+    """
+
+    def gauge(event, value=None):
+        """
+        Sets the value of a gauge
+        """
+
+    def increment(event, value=None):
+        """
+        Increments a counter
+        """

--- a/temba/utils/analytics/base.py
+++ b/temba/utils/analytics/base.py
@@ -1,7 +1,7 @@
-import zope.interface
+import abc
 
 
-class IMetricBackend(zope.interface.Interface):
+class IMetricBackend(metaclass=abc.ABCMeta):
     """
     A metric backend
     """

--- a/temba/utils/analytics/librato.py
+++ b/temba/utils/analytics/librato.py
@@ -1,4 +1,3 @@
-import zope.interface
 from librato_bg import Client as LibratoClient
 
 from django.conf import settings
@@ -6,8 +5,7 @@ from django.conf import settings
 from temba.utils.analytics.base import IMetricBackend
 
 
-@zope.interface.implementer(IMetricBackend)
-class LibratoBackend:
+class LibratoBackend(IMetricBackend):
     """
     A metrics backend for the librato service
     """

--- a/temba/utils/analytics/librato.py
+++ b/temba/utils/analytics/librato.py
@@ -1,0 +1,31 @@
+import zope.interface
+from librato_bg import Client as LibratoClient
+
+from django.conf import settings
+
+from temba.utils.analytics.base import IMetricBackend
+
+
+@zope.interface.implementer(IMetricBackend)
+class LibratoBackend:
+    """
+    A metrics backend for the librato service
+    """
+
+    def __init__(self, user, token):
+        self._librato = LibratoClient(user, token)
+
+    def _get_hostname(self):
+        # settings.HOSTNAME is actually service name (like textit.in), and settings.MACHINE_NAME is the name of the machine
+        # (virtual/physical) that is part of the service
+        return "%s.%s" % (settings.MACHINE_HOSTNAME, settings.HOSTNAME)
+
+    def gauge(self, event, value=None):
+        if value is None:
+            value = 1
+
+        self._librato.gauge(event, value, self._get_hostname())
+
+    def increment(self, event, value=None):
+        # In librato, gauges are used as counters
+        self.gauge(event, value)

--- a/temba/utils/analytics/prometheus.py
+++ b/temba/utils/analytics/prometheus.py
@@ -1,15 +1,19 @@
+import logging
+
 import zope.interface
 from prometheus_client import Counter, Gauge
+
 from django.conf import settings
-import logging
+
+from temba.utils.analytics.base import IMetricBackend
 
 logger = logging.getLogger(__name__)
 
-from temba.utils.analytics.base import IMetricBackend
 
 MESSAGE_COUNTS = Gauge("message_counts", "Current count of messages", ["hostname", "direction", "state"])
 RELAYER_SYNC = Gauge("relayer_sync_seconds_duration", "Duration of relayer sync view", ["hostname"])
 CONTACTS = Counter("contacts_total", "Number of contacts", ["hostname", "action"])
+
 
 @zope.interface.implementer(IMetricBackend)
 class PrometheusBackend:
@@ -27,9 +31,13 @@ class PrometheusBackend:
             value = 1
 
         if event.startswith("temba.current_outgoing"):
-            MESSAGE_COUNTS.labels(hostname=self._get_hostname(), direction="outbound", state=event.split("_")[-1]).set(value)
+            MESSAGE_COUNTS.labels(hostname=self._get_hostname(), direction="outbound", state=event.split("_")[-1]).set(
+                value
+            )
         elif event.startswith("temba.current_incoming"):
-            MESSAGE_COUNTS.labels(hostname=self._get_hostname(), direction="inbound", state=events.split("_")[1]).set(value)
+            MESSAGE_COUNTS.labels(hostname=self._get_hostname(), direction="inbound", state=event.split("_")[1]).set(
+                value
+            )
         elif event == "temba.relayer_sync":
             RELAYER_SYNC.labels(hostname=self._get_hostname()).set(value)
         else:

--- a/temba/utils/analytics/prometheus.py
+++ b/temba/utils/analytics/prometheus.py
@@ -10,9 +10,9 @@ from temba.utils.analytics.base import IMetricBackend
 logger = logging.getLogger(__name__)
 
 
-MESSAGE_COUNTS = Gauge("message_counts", "Current count of messages", ["hostname", "direction", "state"])
-RELAYER_SYNC = Gauge("relayer_sync_seconds_duration", "Duration of relayer sync view", ["hostname"])
-CONTACTS = Counter("contacts_total", "Number of contacts", ["hostname", "action"])
+MESSAGE_COUNTS = Gauge("temba_message_counts", "Current count of messages", ["hostname", "direction", "state"])
+RELAYER_SYNC = Gauge("temba_relayer_sync_seconds_duration", "Duration of relayer sync view", ["hostname"])
+CONTACTS = Counter("temba_contacts_total", "Number of contacts", ["hostname", "action"])
 
 
 @zope.interface.implementer(IMetricBackend)

--- a/temba/utils/analytics/prometheus.py
+++ b/temba/utils/analytics/prometheus.py
@@ -1,6 +1,5 @@
 import logging
 
-import zope.interface
 from prometheus_client import Counter, Gauge
 
 from django.conf import settings
@@ -15,8 +14,7 @@ RELAYER_SYNC = Gauge("temba_relayer_sync_seconds_duration", "Duration of relayer
 CONTACTS = Counter("temba_contacts_total", "Number of contacts", ["hostname", "action"])
 
 
-@zope.interface.implementer(IMetricBackend)
-class PrometheusBackend:
+class PrometheusBackend(IMetricBackend):
     """
     A metrics backend for Prometheus
     """

--- a/temba/utils/analytics/prometheus.py
+++ b/temba/utils/analytics/prometheus.py
@@ -1,0 +1,45 @@
+import zope.interface
+from prometheus_client import Counter, Gauge
+from django.conf import settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+from temba.utils.analytics.base import IMetricBackend
+
+MESSAGE_COUNTS = Gauge("message_counts", "Current count of messages", ["hostname", "direction", "state"])
+RELAYER_SYNC = Gauge("relayer_sync_seconds_duration", "Duration of relayer sync view", ["hostname"])
+CONTACTS = Counter("contacts_total", "Number of contacts", ["hostname", "action"])
+
+@zope.interface.implementer(IMetricBackend)
+class PrometheusBackend:
+    """
+    A metrics backend for Prometheus
+    """
+
+    def _get_hostname(self):
+        # settings.HOSTNAME is actually service name (like textit.in), and settings.MACHINE_NAME is the name of the machine
+        # (virtual/physical) that is part of the service
+        return "%s.%s" % (settings.MACHINE_HOSTNAME, settings.HOSTNAME)
+
+    def gauge(self, event, value=None):
+        if value is None:
+            value = 1
+
+        if event.startswith("temba.current_outgoing"):
+            MESSAGE_COUNTS.labels(hostname=self._get_hostname(), direction="outbound", state=event.split("_")[-1]).set(value)
+        elif event.startswith("temba.current_incoming"):
+            MESSAGE_COUNTS.labels(hostname=self._get_hostname(), direction="inbound", state=events.split("_")[1]).set(value)
+        elif event == "temba.relayer_sync":
+            RELAYER_SYNC.labels(hostname=self._get_hostname()).set(value)
+        else:
+            logger.warning(f"Unknown prometheus gauge metric {{event}} with value {{value}}")
+
+    def increment(self, event, value=None):
+        if value is None:
+            value = 1
+
+        if event == "temba.contact_created":
+            CONTACTS.labels(hostname=self._get_hostname(), action="created").inc(value)
+        else:
+            logger.warning(f"Unknown prometheus counter metric {{event}} with value {{value}}")


### PR DESCRIPTION
This abstracts the metrics portion of analytics.py into a generic metric provider, with provider implementations for Librato and Prometheus.

I've only added the concepts of a Gauge (something that goes up and down), and an Increment/counter (something that continually goes up), that is all that seems to be required at the moment.

I haven't abstracted out analytics part of analytics.py, since that's better suited for the current tools, rather than a metrics tool.