### PR TITLE
Clarify that STORAGE_URL should be an absolute URL

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -46,7 +46,7 @@ FLOW_FROM_EMAIL = "no-reply@temba.io"
 # HTTP Headers using for outgoing requests to other services
 OUTGOING_REQUEST_HEADERS = {"User-agent": "RapidPro"}
 
-STORAGE_URL = None  # may be local /media or AWS S3
+STORAGE_URL = None  # may be an absolute URL to /media (like http://localhost:8000/media) or AWS S3
 STORAGE_ROOT_DIR = "test_orgs" if TESTING else "orgs"
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Based on the comments in settings_common.py, we've been using a relative STORAGE_URL value of `/media/` with many limited successes. However, the relative URL didn't work with the Twilio channel and we spent some time debugging this.

This change proposes a clarification to the comment in settings_common.py so it is clear that this should be an absolute URL when set