### PR TITLE
Feat/add fba pages limit

### DIFF
--- a/temba/channels/types/facebookapp/views.py
+++ b/temba/channels/types/facebookapp/views.py
@@ -95,6 +95,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         context = super().get_context_data(**kwargs)
         context["claim_url"] = reverse("channels.types.facebookapp.claim")
         context["facebook_app_id"] = settings.FACEBOOK_APPLICATION_ID
+        context["fba_pages_limit"] = settings.FACEBOOK_PAGES_LIMIT
         return context
 
     def form_valid(self, form):

--- a/temba/context_processors.py
+++ b/temba/context_processors.py
@@ -20,3 +20,8 @@ def analytics(request):
         intercom_app_id=settings.INTERCOM_APP_ID,
         google_tracking_id=settings.GOOGLE_TRACKING_ID,
     )
+
+def fba_pages_limit(request):
+    return {
+            "fba_pages_limit": settings.FACEBOOK_PAGES_LIMIT,
+    }

--- a/temba/context_processors.py
+++ b/temba/context_processors.py
@@ -20,8 +20,3 @@ def analytics(request):
         intercom_app_id=settings.INTERCOM_APP_ID,
         google_tracking_id=settings.GOOGLE_TRACKING_ID,
     )
-
-def fba_pages_limit(request):
-    return {
-            "fba_pages_limit": settings.FACEBOOK_PAGES_LIMIT,
-    }

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -190,7 +190,6 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "temba.context_processors.branding",
                 "temba.context_processors.analytics",
-                "temba.context_processors.fba_pages_limit",
                 "temba.orgs.context_processors.user_group_perms_processor",
                 "temba.channels.views.channel_status_processor",
                 "temba.orgs.context_processors.settings_includer",

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -190,6 +190,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "temba.context_processors.branding",
                 "temba.context_processors.analytics",
+                "temba.context_processors.fba_pages_limit",
                 "temba.orgs.context_processors.user_group_perms_processor",
                 "temba.channels.views.channel_status_processor",
                 "temba.orgs.context_processors.settings_includer",

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1208,6 +1208,7 @@ ZENDESK_CLIENT_SECRET = os.environ.get("ZENDESK_CLIENT_SECRET", "")
 FACEBOOK_APPLICATION_ID = os.environ.get("FACEBOOK_APPLICATION_ID", "")
 FACEBOOK_APPLICATION_SECRET = os.environ.get("FACEBOOK_APPLICATION_SECRET", "")
 FACEBOOK_WEBHOOK_SECRET = os.environ.get("FACEBOOK_WEBHOOK_SECRET", "")
+FACEBOOK_PAGES_LIMIT = os.environ.get("FACEBOOK_PAGES_LIMIT", "25")
 
 
 # -----------------------------------------------------------------------------------

--- a/templates/channels/types/facebookapp/claim.haml
+++ b/templates/channels/types/facebookapp/claim.haml
@@ -113,7 +113,7 @@
     function getFBPages(token) {
       $.ajax({
         type: "GET",
-        url: "https://graph.facebook.com/me/accounts?access_token=" + token,
+        url: "https://graph.facebook.com/me/accounts?access_token=" + token + "&limit={{ fba_pages_limit }}",
         dataType: "json",
         success: function(response, status, xhr){
           data = response.data;


### PR DESCRIPTION
Related to #1481 

Differences:
- Add `FACEBOOK_PAGES_LIMIT` environment variable into `settings_common.py`
- Add context to retrieve `FACEBOOK_PAGES_LIMIT` value
- Implement context value into _templates/channels/types/facebookapp/claim.haml_