### PR TITLE
Set max fba pages limit to 200

### DIFF
--- a/templates/channels/types/facebookapp/claim.haml
+++ b/templates/channels/types/facebookapp/claim.haml
@@ -113,7 +113,7 @@
     function getFBPages(token) {
       $.ajax({
         type: "GET",
-        url: "https://graph.facebook.com/me/accounts?access_token=" + token,
+        url: "https://graph.facebook.com/me/accounts?access_token=" + token + "&limit=200",
         dataType: "json",
         success: function(response, status, xhr){
           data = response.data;


### PR DESCRIPTION
Just implemented the param `limit` set to 200. 

@rowanseymour 