### PR TITLE
africa's talking channel allow long username

### DIFF
--- a/temba/channels/types/africastalking/tests.py
+++ b/temba/channels/types/africastalking/tests.py
@@ -30,7 +30,7 @@ class AfricastalkingTypeTest(TembaTest):
         post_data = response.context["form"].initial
 
         post_data["shortcode"] = "5259"
-        post_data["username"] = "temba"
+        post_data["username"] = "temba_temba_temba_temba_temba_temba"
         post_data["api_key"] = "asdf-asdf-asdf-asdf-asdf"
         post_data["country"] = "KE"
 
@@ -38,7 +38,7 @@ class AfricastalkingTypeTest(TembaTest):
 
         channel = Channel.objects.get()
 
-        self.assertEqual("temba", channel.config["username"])
+        self.assertEqual("temba_temba_temba_temba_temba_temba", channel.config["username"])
         self.assertEqual("asdf-asdf-asdf-asdf-asdf", channel.config["api_key"])
         self.assertEqual("5259", channel.address)
         self.assertEqual("KE", channel.country)

--- a/temba/channels/types/africastalking/views.py
+++ b/temba/channels/types/africastalking/views.py
@@ -41,7 +41,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         is_shared = forms.BooleanField(
             initial=False, required=False, help_text=_("Whether this short code is shared with others")
         )
-        username = forms.CharField(max_length=32, help_text=_("Your username on Africa's Talking"))
+        username = forms.CharField(max_length=320, help_text=_("Your username on Africa's Talking"))
         api_key = forms.CharField(max_length=64, help_text=_("Your api key, should be 64 characters"))
 
     form_class = Form


### PR DESCRIPTION
The username field in the Africa's Talking channel setup screen doesn't allow enough characters for an email addresses. It is currently restricted to 32 characters whereas an email address can be up to 320 characters long. This pull request fixes the username field length and adjusts the test.