### PR TITLE
Fix: Increase otp_secret length to 64 in orgs_usersettings

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -304,7 +304,7 @@ class UserSettings(models.Model):
     user = models.ForeignKey(User, on_delete=models.PROTECT, related_name="usersettings")
     language = models.CharField(max_length=8, choices=settings.LANGUAGES, default=settings.DEFAULT_LANGUAGE)
     team = models.ForeignKey("tickets.Team", on_delete=models.PROTECT, null=True)
-    otp_secret = models.CharField(max_length=16, default=pyotp.random_base32)
+    otp_secret = models.CharField(max_length=64, default=pyotp.random_base32)
     two_factor_enabled = models.BooleanField(default=False)
     last_auth_on = models.DateTimeField(null=True)
     external_id = models.CharField(max_length=128, null=True)


### PR DESCRIPTION
The current length of otp_secret is 64. It throws an error while doing a new installation. Changing the length of otp_secret to 64 fixes the problem. 